### PR TITLE
[CUBRIDQA-12] stabilize the timezone test cases.

### DIFF
--- a/sql/_27_banana_qa/issue_5765_timezone_support/_08_current_date_function/_02_functions/answers/_13_datediff.answer
+++ b/sql/_27_banana_qa/issue_5765_timezone_support/_08_current_date_function/_02_functions/answers/_13_datediff.answer
@@ -15,7 +15,7 @@ if( datediff(@x2, @x1) in multiset{0, 1}, 'ok', 'nok')
 ok     
 
 ===================================================
-if( month(@x3)- month(@x1) in multiset{2, -10}, 'ok', 'nok')    
+if( month(@x3)- month(@x1) in multiset{2, 3, -10}, 'ok', 'nok')    
 ok     
 
 ===================================================
@@ -81,7 +81,7 @@ if( datediff(@x2, @x1) in multiset{0, 1}, 'ok', 'nok')
 ok     
 
 ===================================================
-if( month(@x3)- month(@x1) in multiset{2, -10}, 'ok', 'nok')    
+if( month(@x3)- month(@x1) in multiset{2, 3, -10}, 'ok', 'nok')    
 ok     
 
 ===================================================

--- a/sql/_27_banana_qa/issue_5765_timezone_support/_08_current_date_function/_02_functions/cases/_13_datediff.sql
+++ b/sql/_27_banana_qa/issue_5765_timezone_support/_08_current_date_function/_02_functions/cases/_13_datediff.sql
@@ -6,7 +6,7 @@ set @x2=(select current_datetime);
 set @x3=(select adddate(current_datetime,interval 2 month));
 set @x4=(select adddate(current_datetime,interval 2 hour));
 select if (datediff(@x2,@x1) in(0,1), 'ok', 'nok');
-select if (month(@x3)-month(@x1) in (2,-10), 'ok', 'nok');
+select if (month(@x3)-month(@x1) in (2,3,-10), 'ok', 'nok');
 select if (hour(@x4)-hour(@x1) in (6, -18), 'ok', 'nok');
 drop variable @x1,@x2,@x3,@x4;
 
@@ -36,7 +36,7 @@ set @x2=(select current_date);
 set @x3=(select adddate(current_date,interval 2 month));
 set @x4=(select adddate(current_date,interval 2 hour));
 select if (datediff(@x2,@x1) in(0,1), 'ok', 'nok');
-select if (month(@x3)-month(@x1) in (2,-10), 'ok', 'nok');
+select if (month(@x3)-month(@x1) in (2,3,-10), 'ok', 'nok');
 select if (hour(@x4)-hour(@x1) in (6, -18), 'ok', 'nok');
 drop variable @x1,@x2,@x3,@x4;
 

--- a/sql/_27_banana_qa/issue_5765_timezone_support/_08_current_date_function/_02_functions/cases/_19_round.sql
+++ b/sql/_27_banana_qa/issue_5765_timezone_support/_08_current_date_function/_02_functions/cases/_19_round.sql
@@ -1,5 +1,5 @@
 --+ holdcas on;
-set timezone '-01:00';
+set timezone '+13:00';
 set @x1=(select round(current_date,'yy'));
 set timezone '+14:00';
 set @x2=(select round(current_date,'yy'));


### PR DESCRIPTION
**_08_current_date_function/_02_functions/cases/_13_datediff.sql**

- https://github.com/CUBRID/cubrid-testcases/commit/de26f09d2540c21c1d08be527f9c2ae309c9834c
When the datetime is '2016-07-01 02:37:00 KST', 'hour(@x4)-hour(@x1)' is '3'. So add '3' to expected answer.

**_08_current_date_function/_02_functions/cases/_19_round.sql**

- https://github.com/CUBRID/cubrid-testcases/commit/c39b67bce92b5c115b040178d410d2a9204f25ef
 set the adjacent timezone value, to reduce the probability of instability.