### PR TITLE
[CBRD-22000]add 'id=1' condition to make C3 resume when C1 commits.

### DIFF
--- a/isolation/_02_RepeatableRead/no_index_column/basic_sql/update_update_05.ctl
+++ b/isolation/_02_RepeatableRead/no_index_column/basic_sql/update_update_05.ctl
@@ -45,7 +45,7 @@ MC: wait until C1 ready;
 C1: update t1 set col='aa' where id<4;
 C1: select * from t1 order by 1,2;
 MC: wait until C1 ready;
-C2: update t1 set col='bb' where col='abc';
+C2: update t1 set col='bb' where col='abc' and id=1;
 MC: wait until C2 blocked;
 C3: update t1 set id=6 where id>2; 
 MC: wait until C3 blocked;


### PR DESCRIPTION
The behavior depends on the order of records.
It can be reproduced when the records are inserted with a different order.

When C2 accesses (5, abc) first, it locks the object and then may be blocked on (1, abc) or (3, abc) which is locked by C1.

Then, C2 resumes and gets serializable conflict error. Since C2 does not rollback, it holds the lock on (5, abc). C3 is blocked on the object and it cannot be resumed.

To make C3 resume when C1 commits, C2 should not hold a lock on which C3 wants.

ref: http://jira.cubrid.org/browse/CBRD-22000?focusedCommentId=4749863&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4749863