### PR TITLE
[CUBRIDQA-732] add patch for no pk table on ha mode

### DIFF
--- a/sql/_23_apricot_qa/_01_sql_extension3/_05_analytic_functions/_04_max/cases/max_group_by.master.slave1.diff_1
+++ b/sql/_23_apricot_qa/_01_sql_extension3/_05_analytic_functions/_04_max/cases/max_group_by.master.slave1.diff_1
@@ -1,0 +1,66 @@
+1893d1892
+<   'db_attribute'        'col1'                'max_groupby_order'   'INSTANCE'                      0  NULL                  NULL                  'INTEGER'                      10            0  'Not applicable'      'Not applicable'      NULL                  NULL                  'NO'                  NULL                
+1895d1893
+<   'db_attribute'        'col2'                'max_groupby_order'   'INSTANCE'                      1  NULL                  NULL                  'SHORT'                         5            0  'Not applicable'      'Not applicable'      NULL                  NULL                  'YES'                 NULL                
+1897d1894
+<   'db_attribute'        'col3'                'max_groupby_order'   'INSTANCE'                      2  NULL                  NULL                  'CHAR'                         30            0  'iso88591'            'iso88591_bin'        NULL                  'abc                           '  'YES'                 NULL                
+1899d1895
+<   'db_attribute'        'col4'                'max_groupby_order'   'INSTANCE'                      3  NULL                  NULL                  'DATE'                         10            0  'Not applicable'      'Not applicable'      NULL                  'SYS_DATE'            'YES'                 NULL                
+1901d1896
+<   'db_attribute'        'col5'                'max_groupby_order'   'INSTANCE'                      4  NULL                  NULL                  'CLOB'                          0            0  'Not applicable'      'Not applicable'      NULL                  NULL                  'YES'                 NULL                
+1903d1897
+<   'db_attribute'        'col6'                'max_groupby_order'   'INSTANCE'                      5  NULL                  NULL                  'MONETARY'                     15            0  'Not applicable'      'Not applicable'      NULL                  NULL                  'YES'                 NULL                
+2147c2141
+< 326 rows selected.Committed.
+---
+> 320 rows selected.Committed.
+2227d2220
+<   'db_class'            'max_groupby_order'   'DBA'                 'CLASS'               'NO'                  'NO'                  'NO'                  'iso88591_bin'        NULL                
+2230c2223
+< 46 rows selected.Committed.
+---
+> 45 rows selected.Committed.
+2711d2703
+<   'db_attribute'        'col1'                'max_groupby_order'   'INSTANCE'                      0  NULL                  NULL                  'INTEGER'                      10            0  'Not applicable'      'Not applicable'      NULL                  NULL                  'NO'                  NULL                
+2713d2704
+<   'db_attribute'        'col2'                'max_groupby_order'   'INSTANCE'                      1  NULL                  NULL                  'SHORT'                         5            0  'Not applicable'      'Not applicable'      NULL                  NULL                  'YES'                 NULL                
+2715d2705
+<   'db_attribute'        'col3'                'max_groupby_order'   'INSTANCE'                      2  NULL                  NULL                  'CHAR'                         30            0  'iso88591'            'iso88591_bin'        NULL                  'abc                           '  'YES'                 NULL                
+2717d2706
+<   'db_attribute'        'col4'                'max_groupby_order'   'INSTANCE'                      3  NULL                  NULL                  'DATE'                         10            0  'Not applicable'      'Not applicable'      NULL                  'SYS_DATE'            'YES'                 NULL                
+2719d2707
+<   'db_attribute'        'col5'                'max_groupby_order'   'INSTANCE'                      4  NULL                  NULL                  'CLOB'                          0            0  'Not applicable'      'Not applicable'      NULL                  NULL                  'YES'                 NULL                
+2721d2708
+<   'db_attribute'        'col6'                'max_groupby_order'   'INSTANCE'                      5  NULL                  NULL                  'MONETARY'                     15            0  'Not applicable'      'Not applicable'      NULL                  NULL                  'YES'                 NULL                
+2965c2952
+< 326 rows selected.Committed.
+---
+> 320 rows selected.Committed.
+3045d3031
+<   'db_class'            'max_groupby_order'   'DBA'                 'CLASS'               'NO'                  'NO'                  'NO'                  'iso88591_bin'        NULL                
+3048c3034
+< 46 rows selected.Committed.
+---
+> 45 rows selected.Committed.
+3528d3513
+<   'db_attribute'        'col1'                'max_groupby'         'INSTANCE'                      0  NULL                  NULL                  'INTEGER'                      10            0  'Not applicable'      'Not applicable'      NULL                  NULL                  'NO'                  NULL                
+3530d3514
+<   'db_attribute'        'col2'                'max_groupby'         'INSTANCE'                      1  NULL                  NULL                  'SHORT'                         5            0  'Not applicable'      'Not applicable'      NULL                  NULL                  'YES'                 NULL                
+3532d3515
+<   'db_attribute'        'col3'                'max_groupby'         'INSTANCE'                      2  NULL                  NULL                  'CHAR'                         30            0  'iso88591'            'iso88591_bin'        NULL                  'abc                           '  'YES'                 NULL                
+3534d3516
+<   'db_attribute'        'col4'                'max_groupby'         'INSTANCE'                      3  NULL                  NULL                  'DATE'                         10            0  'Not applicable'      'Not applicable'      NULL                  'SYS_DATE'            'YES'                 NULL                
+3536d3517
+<   'db_attribute'        'col5'                'max_groupby'         'INSTANCE'                      4  NULL                  NULL                  'CLOB'                          0            0  'Not applicable'      'Not applicable'      NULL                  NULL                  'YES'                 NULL                
+3538d3518
+<   'db_attribute'        'col6'                'max_groupby'         'INSTANCE'                      5  NULL                  NULL                  'MONETARY'                     15            0  'Not applicable'      'Not applicable'      NULL                  NULL                  'YES'                 NULL                
+3783c3763
+< 326 rows selected.Committed.
+---
+> 320 rows selected.Committed.
+3862d3841
+<   'db_class'            'max_groupby'         'DBA'                 'CLASS'               'NO'                  'NO'                  'NO'                  'iso88591_bin'        NULL                
+3866c3845
+< 46 rows selected.Committed.
+---
+> 45 rows selected.Committed.


### PR DESCRIPTION
Since https://github.com/CUBRID/cubrid-testcases/pull/435 add some new queries, and they don't have pk on table, it will not be sync on ha mode. so we need patch for them