### PR TITLE
[CUBRIDQA-807]fix a bug in test case and add candidate answer.

### DIFF
--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_update_04.answer1
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_update_04.answer1
@@ -1,0 +1,39 @@
+| 11 rows affected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    'a'    'INTEGER'    'YES'    ''    NULL    ''  
+| 1 row selected
+| 1 row affected
+| 2 rows affected
+| ERROR RETURNED: Operation would have caused one or more unique constraint violations. INDEX i(B+tree: ?) ON CLASS t1(CLASS_OID: ?). key: *UNKNOWN-KEY*. 
+|    on statement number: 3
+| ERROR RETURNED: Semantic: before ' ) where a > -999 order by 1;'
+| Cannot find the index 't1.i(-)'. (select sum(set{t1.a}) into :s from t1 t1 where t1.a>-999 us... 
+|    on statement number: 9
+| ERROR RETURNED: Semantic: before ' ) where a > -999 order by 1;'
+| Cannot find the index 't1.i(+)'. (select sum(set{t1.a}) into :i from t1 t1 where t1.a>-999 us... 
+|    on statement number: 10
+| ERROR RETURNED: Semantic: before '  = :i, 'OK', 'NOK');'
+| Query yields no result, so variable 's' is not set. select  if(:s=:i, 'OK', 'NOK') 
+|    on statement number: 11
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+| 0 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    0  
+|    1  
+|    1  
+|    2  
+|    3  
+|    4  
+|    5  
+|    6  
+|    7  
+|    8  
+|    9  
+|    10  
+| 12 rows selected

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/create_multiple_index_01.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/create_multiple_index_01.ctl
@@ -40,18 +40,10 @@ MC: wait until C3 unblocked;
 
 /* C2 C3 starts scan and will demote to IX. */
 
-/* C2 should be blocked to promote to SCH_M */
-MC: wait until C2 blocked;
-MC: wait until C3 blocked;
-
-MC: wait until C2 ready;
 C2: commit;
-
 MC: wait until C2 ready;
 
-MC: wait until C3 ready;
 C3: commit;
-
 MC: wait until C3 ready;
 
 /* verification */


### PR DESCRIPTION
- isolation/_01_ReadCommitted/cbrd_21506/unique_index/create_multiple_index_01.ctl
After C1 commitn, C2 ready and C3 will fail, so will not blocked to promote to SCH_M. Remove the useless lines.

- isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_update_04.answer1
for https://github.com/CUBRID/cubrid-testcases/blob/develop/isolation/_01_ReadCommitted/cbrd_21506/unique_index/insert_update_04.ctl
After C1 commit, the C3 and C4 sequences are uncertain, so add a candidate answer for it.