### PR TITLE
[CUBRIDQA-20]reduce count of records.

### DIFF
--- a/isolation/_01_ReadCommitted/index_column/filter_index/basic_sql/answer/insert_insert_01.answer
+++ b/isolation/_01_ReadCommitted/index_column/filter_index/basic_sql/answer/insert_insert_01.answer
@@ -1,9 +1,9 @@
-| 100000 rows affected
-| 100000 rows affected
-| 100000 rows affected
-| 100000 rows affected
+| 1000 rows affected
+| 1000 rows affected
+| 1000 rows affected
+| 1000 rows affected
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
-|    10000200000  
+|    1002000  
 | 1 row selected

--- a/isolation/_01_ReadCommitted/index_column/filter_index/basic_sql/insert_insert_01.ctl
+++ b/isolation/_01_ReadCommitted/index_column/filter_index/basic_sql/insert_insert_01.ctl
@@ -10,10 +10,10 @@ No Lock for non unique index
 insert a lot of the same value
 
 NUM_CLIENTS = 4
-C1: insert 100000 rows, values(1);
-C2: insert 100000 rows, values(1);
-C3: insert 100000 rows, values(2);
-C4: insert 100000 rows, values(3);
+C1: insert 1000 rows, values(1);
+C2: insert 1000 rows, values(1);
+C3: insert 1000 rows, values(2);
+C4: insert 1000 rows, values(3);
 */
 
 MC: setup NUM_CLIENTS = 4;
@@ -39,19 +39,19 @@ MC: wait until C1 ready;
 
 /* test case */
 C1: set @newincr=0;
-C1: insert into t select (@newincr:=@newincr+1),'abc' from db_class a,db_class b,db_class c,db_class d limit 100000;
+C1: insert into t select (@newincr:=@newincr+1),'abc' from db_class a,db_class b,db_class c,db_class d limit 1000;
 MC: wait until C1 ready;
 
 C2: set @newincr=0;
-C2: insert into t select (@newincr:=@newincr+1),'abc' from db_class a,db_class b,db_class c,db_class d limit 100000;
+C2: insert into t select (@newincr:=@newincr+1),'abc' from db_class a,db_class b,db_class c,db_class d limit 1000;
 MC: wait until C2 ready;
 
 C3: set @newincr=0;
-C3: insert into t select (@newincr:=@newincr+1),'abc' from db_class a,db_class b,db_class c,db_class d limit 100000;
+C3: insert into t select (@newincr:=@newincr+1),'abc' from db_class a,db_class b,db_class c,db_class d limit 1000;
 MC: wait until C3 ready;
 
 C4: set @newincr=0;
-C4: insert into t select (@newincr:=@newincr+1),'abc' from db_class a,db_class b,db_class c,db_class d limit 100000;
+C4: insert into t select (@newincr:=@newincr+1),'abc' from db_class a,db_class b,db_class c,db_class d limit 1000;
 MC: wait until C4 ready;
 
 C1: commit;
@@ -66,7 +66,7 @@ MC: wait until C3 ready;
 C4: commit;
 MC: wait until C4 ready;
 
-/* expected (1,200000)(2,100000)(3,100000) */
+/* expected (1,2000)(2,1000)(3,1000) */
 C2: select sum(id) from t where id%2=0 using index idx(+);
 C2: commit;
 MC: wait until C2 ready;

--- a/isolation/_01_ReadCommitted/partition_table/range/with_index/unique_with_key/answer/insert_select_03.answer
+++ b/isolation/_01_ReadCommitted/partition_table/range/with_index/unique_with_key/answer/insert_select_03.answer
@@ -1,11 +1,11 @@
-| 40000 rows affected
-| 40000 rows affected
-| 40000 rows affected
-| 40000 rows affected
-| 40000 rows affected
-| 40000 rows affected
-| 40000 rows affected
-| 40000 rows affected
+| 4000 rows affected
+| 4000 rows affected
+| 4000 rows affected
+| 4000 rows affected
+| 4000 rows affected
+| 4000 rows affected
+| 4000 rows affected
+| 4000 rows affected
 | 1 row affected
 | =================   Q U E R Y   R E S U L T S   =================
 | 
@@ -20,7 +20,7 @@
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
-|    50004  
+|    5004  
 | 1 row selected
 | =================   Q U E R Y   R E S U L T S   =================
 | 

--- a/isolation/_01_ReadCommitted/partition_table/range/with_index/unique_with_key/insert_select_03.ctl
+++ b/isolation/_01_ReadCommitted/partition_table/range/with_index/unique_with_key/insert_select_03.ctl
@@ -21,30 +21,30 @@ C2: set transaction isolation level read committed;
 
 /* preparation */
 C1: drop table if exists t;
-C1: create table t(id int,col varchar(10),col1 varchar(10)) partition by range(id)(partition p1 values less than (50000),partition p2 values less than (100000));
+C1: create table t(id int,col varchar(10),col1 varchar(10)) partition by range(id)(partition p1 values less than (5000),partition p2 values less than (10000));
 C1: set @newincr=0;
-C1: insert into t select (@newincr:=@newincr+1),'a','b' from db_class a,db_class b,db_class c,db_class d limit 40000;
+C1: insert into t select (@newincr:=@newincr+1),'a','b' from db_class a,db_class b,db_class c,db_class d limit 4000;
 C1: set @newincr=0;
-C1: insert into t select (@newincr:=@newincr+1)+50000,'a','b' from db_class a,db_class b,db_class c,db_class d limit 40000;
+C1: insert into t select (@newincr:=@newincr+1)+5000,'a','b' from db_class a,db_class b,db_class c,db_class d limit 4000;
 C1: create unique index idx on t(id,col);
 C1: commit work;
 MC: wait until C1 ready;
 
 /* prepare unvacuummed data */
-C1: update t set id=id+1 where id<50000;
-C2: update t set id=id+1 where id>=50000;
+C1: update t set id=id+1 where id<5000;
+C2: update t set id=id+1 where id>=5000;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
 C1: commit;
 C2: commit;
-C1: update t set id=id+1 where id<50000;
-C2: update t set id=id+1 where id>=50000;
+C1: update t set id=id+1 where id<5000;
+C2: update t set id=id+1 where id>=5000;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
 C1: commit;
 C2: commit;
-C1: update t set id=id+1 where id<50000;
-C2: update t set id=id+1 where id>=50000;
+C1: update t set id=id+1 where id<5000;
+C2: update t set id=id+1 where id>=5000;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
 C1: commit;
@@ -56,9 +56,9 @@ MC: wait until C1 ready;
 /* expected 4 */
 C2: select min(id) from t where id>0;
 /* expected 4 */
-C2: select min(id) from t where id<50000;
+C2: select min(id) from t where id<5000;
 /* expected 50004 */
-C2: select min(id) from t where id>50000;
+C2: select min(id) from t where id>5000;
 MC: wait until C2 ready;
 C1: commit;
 MC: wait until C1 ready;

--- a/isolation/_04_RepeatableRead_ReadCommitted/partition_table/range/with_index/unique_with_key/answer/insert_select_03.answer
+++ b/isolation/_04_RepeatableRead_ReadCommitted/partition_table/range/with_index/unique_with_key/answer/insert_select_03.answer
@@ -1,11 +1,11 @@
-| 40000 rows affected
-| 40000 rows affected
-| 40000 rows affected
-| 40000 rows affected
-| 40000 rows affected
-| 40000 rows affected
-| 40000 rows affected
-| 40000 rows affected
+| 4000 rows affected
+| 4000 rows affected
+| 4000 rows affected
+| 4000 rows affected
+| 4000 rows affected
+| 4000 rows affected
+| 4000 rows affected
+| 4000 rows affected
 | 1 row affected
 | =================   Q U E R Y   R E S U L T S   =================
 | 
@@ -20,7 +20,7 @@
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
-|    50004  
+|    5004  
 | 1 row selected
 | =================   Q U E R Y   R E S U L T S   =================
 | 

--- a/isolation/_04_RepeatableRead_ReadCommitted/partition_table/range/with_index/unique_with_key/insert_select_03.ctl
+++ b/isolation/_04_RepeatableRead_ReadCommitted/partition_table/range/with_index/unique_with_key/insert_select_03.ctl
@@ -21,28 +21,28 @@ C2: set transaction isolation level read committed;
 
 /* preparation */
 C1: drop table if exists t;
-C1: create table t(id int,col varchar(10),col1 varchar(10)) partition by range(id)(partition p1 values less than (50000),partition p2 values less than (100000));
-C1: insert into t select rownum,'a','b' from db_class a,db_class b,db_class c,db_class d where rownum <= 40000;
-C1: insert into t select rownum+50000,'a','b' from db_class a,db_class b,db_class c,db_class d where rownum <= 40000;
+C1: create table t(id int,col varchar(10),col1 varchar(10)) partition by range(id)(partition p1 values less than (5000),partition p2 values less than (10000));
+C1: insert into t select rownum,'a','b' from db_class a,db_class b,db_class c,db_class d where rownum <= 4000;
+C1: insert into t select rownum+5000,'a','b' from db_class a,db_class b,db_class c,db_class d where rownum <= 4000;
 C1: create unique index idx on t(id,col);
 C1: commit work;
 MC: wait until C1 ready;
 
 /* prepare unvacuummed data */
-C1: update t set id=id+1 where id<50000;
-C2: update t set id=id+1 where id>=50000;
+C1: update t set id=id+1 where id<5000;
+C2: update t set id=id+1 where id>=5000;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
 C1: commit;
 C2: commit;
-C1: update t set id=id+1 where id<50000;
-C2: update t set id=id+1 where id>=50000;
+C1: update t set id=id+1 where id<5000;
+C2: update t set id=id+1 where id>=5000;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
 C1: commit;
 C2: commit;
-C1: update t set id=id+1 where id<50000;
-C2: update t set id=id+1 where id>=50000;
+C1: update t set id=id+1 where id<5000;
+C2: update t set id=id+1 where id>=5000;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
 C1: commit;
@@ -54,9 +54,9 @@ MC: wait until C1 ready;
 /* expected 4 */
 C2: select min(id) from t where id>0;
 /* expected 4 */
-C2: select min(id) from t where id<50000;
+C2: select min(id) from t where id<5000;
 /* expected 50004 */
-C2: select min(id) from t where id>50000;
+C2: select min(id) from t where id>5000;
 MC: wait until C2 ready;
 C1: commit;
 MC: wait until C1 ready;


### PR DESCRIPTION
Reduce the count of records to stabilize test cases. Because sometimes they will be failed by exceeded of execution time.