### PR TITLE
[CBRD-22856] Support Row Value Constructor

### DIFF
--- a/sql/_14_mysql_compatibility_2/_15_host_variable/_12_common/answers/where_clause.answer_cci
+++ b/sql/_14_mysql_compatibility_2/_15_host_variable/_12_common/answers/where_clause.answer_cci
@@ -60,20 +60,14 @@ Query stmt:
 (select max( cast(t?.i? as numeric)+?.?) from t? t?)
 Query plan:
 temp(order by)
-    subplan: nl-join (inner join)
-                 edge:  term[?]
-                 outer: sscan
-                            class: t? node[?]
-                            cost:  ? card ?
-                 inner: sscan
-                            class: av? node[?]
-                            sargs: term[?]
-                            cost:  ? card ?
+    subplan: iscan
+                 class: t? node[?]
+                 index: i_t?_i? term[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select /*+ ORDERED */ t?.i?, t?.i? from t? t?, (select max( cast(t?.i? as numeric)+?.?) from t? t?) av? (av_?) where t?.i?=av?.av_? order by ?
+select /*+ ORDERED */ t?.i?, t?.i? from t? t? where t?.i?=(select max( cast(t?.i? as numeric)+?.?) from t? t?) order by ?
 ===================================================
 0
 i1    i2    
@@ -168,7 +162,7 @@ nl-join (inner join)
     sargs: term[?]
     cost:  ? card ?
 Query stmt:
-select ? from t? t?, table(set{t?.i?}) t (i) where (t?.i?=t.i+?)
+select ? from t? t?, table(set{t?.i?}) t (i) where t?.i?=t.i+?
 ===================================================
 0
 1    
@@ -187,7 +181,7 @@ nl-join (inner join)
     sargs: term[?]
     cost:  ? card ?
 Query stmt:
-select ? from t? t?, table(set{t?.i?}) t (i) where (t?.i?=t.i+ ?:? )
+select ? from t? t?, table(set{t?.i?}) t (i) where t?.i?=t.i+ ?:? 
 ===================================================
 0
 ===================================================
@@ -248,20 +242,14 @@ Query stmt:
 (select max( cast(t?.i? as numeric)+?.?) from t? t?)
 Query plan:
 temp(order by)
-    subplan: nl-join (inner join)
-                 edge:  term[?]
-                 outer: sscan
-                            class: t? node[?]
-                            cost:  ? card ?
-                 inner: sscan
-                            class: av? node[?]
-                            sargs: term[?]
-                            cost:  ? card ?
+    subplan: sscan
+                 class: t? node[?]
+                 sargs: term[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select /*+ ORDERED */ t?.i?, t?.i? from t? t?, (select max( cast(t?.i? as numeric)+?.?) from t? t?) av? (av_?) where t?.i?=av?.av_? order by ?
+select /*+ ORDERED */ t?.i?, t?.i? from t? t? where t?.i?=(select max( cast(t?.i? as numeric)+?.?) from t? t?) order by ?
 ===================================================
 0
 i1    i2    
@@ -358,7 +346,7 @@ nl-join (inner join)
     sargs: term[?]
     cost:  ? card ?
 Query stmt:
-select ? from t? t?, table(set{t?.i?}) t (i) where (t?.i?=t.i+?)
+select ? from t? t?, table(set{t?.i?}) t (i) where t?.i?=t.i+?
 ===================================================
 0
 1    
@@ -377,7 +365,7 @@ nl-join (inner join)
     sargs: term[?]
     cost:  ? card ?
 Query stmt:
-select ? from t? t?, table(set{t?.i?}) t (i) where (t?.i?=t.i+ ?:? )
+select ? from t? t?, table(set{t?.i?}) t (i) where t?.i?=t.i+ ?:? 
 ===================================================
 0
 ===================================================

--- a/sql/_32_damson/cbrd_22856_Row_Value_Constructor/cases/Row_Value_Constructor_queryPlan.sql
+++ b/sql/_32_damson/cbrd_22856_Row_Value_Constructor/cases/Row_Value_Constructor_queryPlan.sql
@@ -17,7 +17,7 @@ select /*+ recompile */ * from rvc_tmp2 where (col1,col2) IN ((2,4),(1,2)) and (
 select /*+ recompile */ * from rvc_tmp2 where (col1,col2) IN ((2,4),(1,2)) and (col1,col2) in ((3,4),(2,3));
 select /*+ recompile */ * from rvc_tmp2 where (col1,col4) IN ((1,2),(2,2)) and col2 > 1;
 select /*+ recompile */ * from rvc_tmp2 where (col1,col3) IN ((2,4),(1,3)) and (col4,col5) in ((4,5),(2,3));
-select /*+ recompile */ * from rvc_tmp2 where (col1,col2) in (select 1,2 from rvc_tmp2);
+select /*+ recompile ordered */ * from rvc_tmp2 where (col1,col2) in (select 1,2 from rvc_tmp2);
 select /*+ recompile */ * from rvc_tmp2 where (col1,col2) in (select 1,col2 from rvc_tmp2 WHERE col1 = 1);
 select /*+ recompile */ * from rvc_tmp2 where col1 = 1 and col2 =1 and (col3,col4,col5) in ((1,1,1),(2,2,2));
 select /*+ recompile ordered */ b.* from rvc_tmp2 a, rvc_tmp2 b where a.col1 = b.col1 and (a.col1,a.col2) IN ((1,2),(2,2)) and (b.col2,b.col3) in ((2,3),(1,1));


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22856

Test case 'sql/_14_mysql_compatibility_2/_15_host_variable/_12_common/cases/where_clause.sql' occurred an error from sql_by_cci test.
And modified the sql/_32_damson/cbrd_22856_Row_Value_Constructor/cases/Row_Value_Constructor_queryPlan.sql.
because This case sometimes occurs to an error by the query optimizer.

Modified list 
- where_clause.answer_cci
- Row_Value_Constructor_queryPlan.sql