### PR TITLE
[CBRD-23878] Backporting Add new test case for copy STRING type precision.

### DIFF
--- a/sql/_13_issues/_21_1h/answers/cbrd_23878.answer
+++ b/sql/_13_issues/_21_1h/answers/cbrd_23878.answer
@@ -1,0 +1,68 @@
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+attr_name    data_type    prec    
+col1     STRING     1073741823     
+col2     STRING     1073741823     
+col3     STRING     10     
+
+===================================================
+Field    Type    Null    Key    Default    Extra    
+col1     VARCHAR(1073741823)     YES          null          
+col2     VARCHAR(1073741823)     YES          null          
+col3     VARCHAR(10)     YES          null          
+
+===================================================
+TABLE    CREATE TABLE    
+tbl1     CREATE TABLE [tbl1] ([col1] CHARACTER VARYING(1073741823), [col2] CHARACTER VARYING(1073741823), [col3] CHARACTER VARYING(10)) REUSE_OID, COLLATE iso88591_bin     
+
+===================================================
+Field    Type    Null    Key    Default    Extra    
+col1     VARCHAR(1073741823)     YES          null          
+col2     VARCHAR(1073741823)     YES          null          
+col3     VARCHAR(10)     YES          null          
+
+===================================================
+0
+===================================================
+0
+===================================================
+attr_name    data_type    prec    
+col1     CHAR     1     
+col2     CHAR     268435455     
+col3     CHAR     10     
+
+===================================================
+Field    Type    Null    Key    Default    Extra    
+col1     CHAR(1)     YES          null          
+col2     CHAR(268435455)     YES          null          
+col3     CHAR(10)     YES          null          
+
+===================================================
+TABLE    CREATE TABLE    
+tbl2     CREATE TABLE [tbl2] ([col1] CHARACTER(1), [col2] CHARACTER(268435455), [col3] CHARACTER(10)) REUSE_OID, COLLATE iso88591_bin     
+
+===================================================
+Field    Type    Null    Key    Default    Extra    
+col1     CHAR(1)     YES          null          
+col2     CHAR(268435455)     YES          null          
+col3     CHAR(10)     YES          null          
+
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0

--- a/sql/_13_issues/_21_1h/cases/cbrd_23878.sql
+++ b/sql/_13_issues/_21_1h/cases/cbrd_23878.sql
@@ -1,0 +1,23 @@
+drop table if exists t1;
+drop table if exists t2;
+drop table if exists tbl1;
+drop table if exists tbl2;
+
+create table t1 (col1 varchar, col2 varchar(1073741823), col3 varchar(10));
+create table tbl1 as select * from t1;
+select attr_name, data_type, prec from db_attribute where attr_name like '%col%' and class_name='tbl1' order by 1;
+show columns from tbl1;
+show create table tbl1;
+desc tbl1;
+
+create table t2 (col1 char, col2 char(268435455), col3 char(10));
+create table tbl2 as select * from t2;
+select attr_name, data_type, prec from db_attribute where attr_name like '%col%' and class_name='tbl2' order by 1;
+show columns from tbl2;
+show create table tbl2;
+desc tbl2;
+
+drop table t1;
+drop table t2;
+drop table tbl1;
+drop table tbl2;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23878, #958 

Backporting Test case for copy precision of the domain with the CREATE TABLE AS SELECT statement.