### PR TITLE
[CUBRIDQA-1127] Backport develop to release/12.0 

### DIFF
--- a/sql/_13_issues/_15_1h/answers/bug_bts_13571.answer
+++ b/sql/_13_issues/_15_1h/answers/bug_bts_13571.answer
@@ -10,41 +10,39 @@
 i    k    i    k    i    k    i    k    i    k    
 
 Query plan:
-nl-join (left outer join)
+nl-join (inner join)
     edge:  term[?]
-    outer: sscan
+    outer: nl-join (inner join)
+               edge:  term[?]
+               outer: nl-join (inner join)
+                          edge:  term[?]
+                          outer: nl-join (inner join)
+                                     edge:  term[?]
+                                     outer: sscan
+                                                class: p node[?]
+                                                cost:  ? card ?
+                                     inner: sscan
+                                                class: q node[?]
+                                                sargs: term[?]
+                                                cost:  ? card ?
+                                     cost:  ? card ?
+                          inner: sscan
+                                     class: r node[?]
+                                     sargs: term[?] AND term[?]
+                                     cost:  ? card ?
+                          sargs: term[?]
+                          cost:  ? card ?
+               inner: sscan
+                          class: s node[?]
+                          sargs: term[?]
+                          cost:  ? card ?
+               cost:  ? card ?
+    inner: sscan
                class: t node[?]
+               sargs: term[?]
                cost:  ? card ?
-    inner: temp
-               order: UNORDERED
-               subplan: nl-join (inner join)
-                            edge:  term[?]
-                            outer: nl-join (inner join)
-                                       edge:  term[?]
-                                       outer: nl-join (inner join)
-                                                  edge:  term[?]
-                                                  outer: sscan
-                                                             class: p node[?]
-                                                             cost:  ? card ?
-                                                  inner: sscan
-                                                             class: q node[?]
-                                                             sargs: term[?]
-                                                             cost:  ? card ?
-                                                  cost:  ? card ?
-                                       inner: sscan
-                                                  class: r node[?]
-                                                  sargs: term[?]
-                                                  cost:  ? card ?
-                                       cost:  ? card ?
-                            inner: sscan
-                                       class: s node[?]
-                                       sargs: term[?]
-                                       cost:  ? card ?
-                            cost:  ? card ?
-               cost:  ? card ?
-    after: term[?]
     cost:  ? card ?
 Query stmt:
-select p.i, p.k, q.i, q.k, r.i, r.k, s.i, s.k, t.i, t.k from foo p inner join foo q on p.i=q.i inner join foo r on q.i=r.i inner join foo s on r.i=s.i right outer join foo t on s.i=t.i where r.k=p.k+q.k
+select p.i, p.k, q.i, q.k, r.i, r.k, s.i, s.k, t.i, t.k from foo p, foo q, foo r, foo s, foo t where r.k=p.k+q.k and p.i=q.i and q.i=r.i and r.i=s.i and s.i=t.i
 ===================================================
 0

--- a/sql/_13_issues/_15_1h/answers/bug_bts_7547_1.answer
+++ b/sql/_13_issues/_15_1h/answers/bug_bts_7547_1.answer
@@ -167,32 +167,30 @@ count(*)
 0     
 
 Query plan:
-nl-join (left outer join)
-    edge:  term[?]
-    outer: sscan
-               class: c node[?]
+idx-join (inner join)
+    outer: nl-join (inner join)
+               edge:  term[?]
+               outer: nl-join (inner join)
+                          edge:  term[?]
+                          outer: sscan
+                                     class: a node[?]
+                                     cost:  ? card ?
+                          inner: sscan
+                                     class: b node[?]
+                                     sargs: term[?]
+                                     cost:  ? card ?
+                          cost:  ? card ?
+               inner: sscan
+                          class: c node[?]
+                          sargs: term[?]
+                          cost:  ? card ?
                cost:  ? card ?
-    inner: temp
-               order: UNORDERED
-               subplan: idx-join (inner join)
-                            outer: nl-join (left outer join)
-                                       edge:  term[?]
-                                       outer: sscan
-                                                  class: a node[?]
-                                                  cost:  ? card ?
-                                       inner: sscan
-                                                  class: b node[?]
-                                                  sargs: term[?]
-                                                  cost:  ? card ?
-                                       cost:  ? card ?
-                            inner: iscan
-                                       class: d node[?]
-                                       index: idx? term[?] (covers)
-                                       cost:  ? card ?
-                            cost:  ? card ?
+    inner: iscan
+               class: d node[?]
+               index: idx? term[?] (covers)
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select count(*) from fjj a left outer join fjj b on a.i=b.i right outer join fjj c on b.i=c.i, fjj d where a.k=d.k
+select count(*) from fjj a, fjj b, fjj c, fjj d where a.k=d.k and a.i=b.i and b.i=c.i
 ===================================================
 0

--- a/sql/_13_issues/_20_2h/cases/cbrd_23708_1.sql
+++ b/sql/_13_issues/_20_2h/cases/cbrd_23708_1.sql
@@ -5,7 +5,7 @@ create table d(id int) reuse_oid reuseoid;
 create table d(id int) dont_reuse_oid dont_reuse_oid;
 create table d(id int) reuse_oid dont_reuse_oid;
 create table d(id int) dont_reuse_oid reuse_oid;
-select class_name, is_reuse_oid_class  from db_class where is_system_class = 'NO';
+select class_name, is_reuse_oid_class  from db_class where is_system_class = 'NO' order by class_name;
 show create table a;
 show create table b;
 show create table c;


### PR DESCRIPTION
https://jira.cubrid.org/browse/CUBRIDQA-1127
refer to https://github.com/CUBRID/cubrid-testcases/pull/986, https://github.com/CUBRID/cubrid-testcases/pull/983