### PR TITLE
[CUBRIDQA-1127] Backport develop to release/12.0

### DIFF
--- a/sql/_13_issues/_14_1h/answers/bug_bts_12230_iso_bin_coll.answer
+++ b/sql/_13_issues/_14_1h/answers/bug_bts_12230_iso_bin_coll.answer
@@ -102,7 +102,7 @@ index_prefix( cast(_euckr'1037' as char(10) collate euckr_bin),  cast(_euckr'103
 
 ===================================================
 index_prefix(_euckr'1037        ',  cast(_euckr'10369' as char(10) collate euckr_bin), _euckr'd')    
-10369     
+1037     
 
 ===================================================
 0


### PR DESCRIPTION
https://jira.cubrid.org/browse/CUBRIDQA-1127
refer to #1004