### PR TITLE
[CBRD-24213] Revised the test case for CBRD-24213 (11.2)

### DIFF
--- a/sql/_01_object/_10_system_table/_011_db_index_key/cases/1013.sql
+++ b/sql/_01_object/_10_system_table/_011_db_index_key/cases/1013.sql
@@ -6,6 +6,7 @@ create reverse index ddl_0001_index on ddl_0001(col1);
 
 select index_name, class_name, key_attr_name, key_order
 from   db_index_key
-where  class_name = 'ddl_0001';
+where  class_name = 'ddl_0001'
+order by index_name desc;
 
 drop class ddl_0001;


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-24213

The test result was unstable. (in CI test was failed)
because had not to 'order by' clause.