### PR TITLE
[CUBRIDQA-1136] Exclude synonym test cases from HA_repl test

### DIFF
--- a/sql/config/daily_regression_test_exclude_list_ha_repl.conf
+++ b/sql/config/daily_regression_test_exclude_list_ha_repl.conf
@@ -302,3 +302,6 @@ sql/_23_apricot_qa/_01_sql_extension3/_04_mutitable_update_delete/_01_multi_tabl
 sql/_23_apricot_qa/_01_sql_extension3/_04_mutitable_update_delete/_01_multi_table_update/_02_table_syntax/cases/multi_update_reuseoid_002.test
 sql/_23_apricot_qa/_03_i18n/ko_KR/_11_data_type/_08_clob/cases/clob001.test
 sql/_27_banana_qa/issue_8909_unquoted_keywords/cases/_004_update.test 
+
+#[PERMANENT] don't support 'call' on HA.
+sql/_33_elderberry/cbrd_23845/cases/_02_permission_check.test


### PR DESCRIPTION
don't support 'call' method on HA_repl test

"call login('...') on class db_user;" This method does not create a replication log.
In ha_repl test, the call method is deleted while parsing the test scenario.
So, ha_repl cannot test the scenario of creating tables for each user.