### PR TITLE
[CBRD-24181] Revised isolation testcases for CBRD-24181 (additional)

### DIFF
--- a/isolation/_01_ReadCommitted/index_column/multi_index/basic_sql/insert_update_06_1.ctl
+++ b/isolation/_01_ReadCommitted/index_column/multi_index/basic_sql/insert_update_06_1.ctl
@@ -13,7 +13,7 @@ two index, unique index and non unique index
 NUM_CLIENTS = 2
 prepare (4,3a)(5,d)(6,e) --4,3a overlap
 C1: set @newincr=0;
-C1: insert into t select (@newincr:=@newincr+1),concat((@newincr),'a') from (select sleep(1)) x, t where id>0 limit 3;
+C1: insert into t select (@newincr:=@newincr+1),concat((@newincr),'a') from t where id>0 and (select sleep(1)=0)<>0 limit 3;
 C2: update t set id=concat(id,'a') where id>0 using index idx;
 */
 

--- a/isolation/_01_ReadCommitted/primary_key_column/aggregate/insert_select_06_3.ctl
+++ b/isolation/_01_ReadCommitted/primary_key_column/aggregate/insert_select_06_3.ctl
@@ -74,7 +74,7 @@ C1: commit;
 C2: insert into t values(1,'aa');
 
 /* expected 10 group */
-C6: select min(t.id) from t, (select sleep(3)) x where id between 1 and 900;
+C6: select min(t.id) from t where id between 1 and 900 and (select sleep(3)=0)<>0;
 MC: wait until C6 ready;
 C3: insert into t values(2,'cc');
 C2: commit;


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-24181
Fixed test cases where additional failure occurred due to (select sleep(x))