### PR TITLE
Revert "[CBRD-24304] Revised answer for the first node isn't selected"

### DIFF
--- a/sql/_13_issues/_12_2h/answers/bug_bts_9935_03.answer
+++ b/sql/_13_issues/_12_2h/answers/bug_bts_9935_03.answer
@@ -596,13 +596,13 @@ a    b    c
 Query plan:
 temp(group by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: t? node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: i_t_d term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: i_t_a term[?]
-                            filtr: term[?]
+                            class: t? node[?]
+                            index: i_t?_a term[?]
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc
@@ -615,13 +615,13 @@ a    b    c
 Query plan:
 temp(group by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: t? node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: i_t_d term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: i_t_a term[?]
-                            filtr: term[?]
+                            class: t? node[?]
+                            index: i_t?_a term[?]
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  
@@ -637,13 +637,13 @@ a    b    c
 Query plan:
 temp(group by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: t? node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: i_t_d term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: i_t_a term[?]
-                            filtr: term[?]
+                            class: t? node[?]
+                            index: i_t?_a term[?]
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc
@@ -659,13 +659,13 @@ a    b    c    count(*)
 Query plan:
 temp(group by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: t? node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: i_t_d term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: i_t_a term[?]
-                            filtr: term[?]
+                            class: t? node[?]
+                            index: i_t?_a term[?]
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  
@@ -678,13 +678,13 @@ a    b    c    count(*)
 Query plan:
 temp(group by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: t? node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: i_t_d term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: i_t_a term[?]
-                            filtr: term[?]
+                            class: t? node[?]
+                            index: i_t?_a term[?]
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  
@@ -697,13 +697,13 @@ a    b    c    count(*)
 Query plan:
 temp(group by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: t? node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: i_t_d term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: i_t_a term[?]
-                            filtr: term[?]
+                            class: t? node[?]
+                            index: i_t?_a term[?]
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  
@@ -717,13 +717,13 @@ Query plan:
 temp(distinct)
     subplan: temp(group by)
                  subplan: idx-join (inner join)
-                              outer: sscan
-                                         class: t? node[?]
+                              outer: iscan
+                                         class: t node[?]
+                                         index: i_t_d term[?] (covers)
                                          cost:  ? card ?
                               inner: iscan
-                                         class: t node[?]
-                                         index: i_t_a term[?]
-                                         filtr: term[?]
+                                         class: t? node[?]
+                                         index: i_t?_a term[?]
                                          cost:  ? card ?
                               cost:  ? card ?
                  sort:  
@@ -740,13 +740,13 @@ a    b    c    count(*)
 Query plan:
 temp(group by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: t? node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: i_t_d term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: i_t_a term[?]
-                            filtr: term[?]
+                            class: t? node[?]
+                            index: i_t?_a term[?]
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  
@@ -785,13 +785,13 @@ Query plan:
 temp(order by)
     subplan: temp(group by)
                  subplan: idx-join (inner join)
-                              outer: sscan
-                                         class: t? node[?]
+                              outer: iscan
+                                         class: t node[?]
+                                         index: i_t_d term[?] (covers)
                                          cost:  ? card ?
                               inner: iscan
-                                         class: t node[?]
-                                         index: i_t_a term[?]
-                                         filtr: term[?]
+                                         class: t? node[?]
+                                         index: i_t?_a term[?]
                                          cost:  ? card ?
                               cost:  ? card ?
                  sort:  
@@ -810,13 +810,13 @@ a    b    c    count(*)
 Query plan:
 temp(group by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: t? node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: i_t_d term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: i_t_a term[?]
-                            filtr: term[?]
+                            class: t? node[?]
+                            index: i_t?_a term[?]
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  
@@ -834,13 +834,13 @@ Query plan:
 temp(order by)
     subplan: temp(group by)
                  subplan: idx-join (inner join)
-                              outer: sscan
-                                         class: t? node[?]
+                              outer: iscan
+                                         class: t node[?]
+                                         index: i_t_d term[?] (covers)
                                          cost:  ? card ?
                               inner: iscan
-                                         class: t node[?]
-                                         index: i_t_a term[?]
-                                         filtr: term[?]
+                                         class: t? node[?]
+                                         index: i_t?_a term[?]
                                          cost:  ? card ?
                               cost:  ? card ?
                  sort:  

--- a/sql/_24_aprium_qa/_03_other/issue_6091_orderbynum/answers/_06_mro_partition_orderbynum.answer
+++ b/sql/_24_aprium_qa/_03_other/issue_6091_orderbynum/answers/_06_mro_partition_orderbynum.answer
@@ -44,12 +44,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? desc, ? desc, ? asc
@@ -72,12 +73,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? desc, ? desc, ? asc
@@ -108,12 +110,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? asc, ? asc
@@ -144,12 +147,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? desc, ? asc

--- a/sql/_24_aprium_qa/_03_other/issue_6091_orderbynum/answers/_06_mro_partition_orderbynum.answer_cci
+++ b/sql/_24_aprium_qa/_03_other/issue_6091_orderbynum/answers/_06_mro_partition_orderbynum.answer_cci
@@ -44,12 +44,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? desc, ? desc, ? asc
@@ -72,12 +73,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? desc, ? desc, ? asc
@@ -108,12 +110,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? asc, ? asc
@@ -144,12 +147,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? desc, ? asc
@@ -168,12 +172,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? desc, ? desc, ? asc

--- a/sql/_24_aprium_qa/_03_other/issue_6091_orderbynum/answers/_07_mro_limit_orderbynum.answer
+++ b/sql/_24_aprium_qa/_03_other/issue_6091_orderbynum/answers/_07_mro_limit_orderbynum.answer
@@ -44,12 +44,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? desc, ? asc
@@ -68,12 +69,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? asc
@@ -92,12 +94,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? asc, ? asc
@@ -116,12 +119,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? desc, ? asc

--- a/sql/_24_aprium_qa/_03_other/issue_6091_orderbynum/answers/_07_mro_limit_orderbynum.answer_cci
+++ b/sql/_24_aprium_qa/_03_other/issue_6091_orderbynum/answers/_07_mro_limit_orderbynum.answer_cci
@@ -44,12 +44,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? desc, ? asc
@@ -68,12 +69,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? asc
@@ -92,12 +94,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? asc, ? asc
@@ -116,12 +119,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? desc, ? asc
@@ -140,12 +144,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? desc, ? desc, ? asc

--- a/sql/_24_aprium_qa/_03_other/issue_7441_MRO/answers/_01_mro_joins.answer
+++ b/sql/_24_aprium_qa/_03_other/issue_7441_MRO/answers/_01_mro_joins.answer
@@ -250,30 +250,28 @@ Query stmt:
 select t.a, t.b, t.c, t.d, t.e, s.a, s.b from t t, s s where ((t.a= ?:? ) or (t.a= ?:? )) and s.a=t.a and t.b= ?:?  order by ? desc , ? for orderby_num()<= ?:? 
 ===================================================
 a    b    c    d    e    a    b    
-3     1     2     1     2     3     1     
-1     1     2     1     1     1     1     
 3     1     2     1     1     3     1     
-3     1     2     1     1     3     2     
+3     1     2     1     3     3     1     
 1     1     2     1     3     1     2     
-1     1     2     1     2     1     1     
 1     1     2     1     2     1     2     
-1     1     2     1     1     1     2     
 1     1     2     1     3     1     1     
-3     1     2     1     2     3     2     
+3     1     2     1     2     3     1     
+1     1     2     1     2     1     1     
+1     1     2     1     1     1     2     
+1     1     2     1     1     1     1     
+3     1     2     1     1     3     2     
 
 Query plan:
 temp(order by)
-    subplan: nl-join (inner join)
-                 edge:  term[?]
-                 outer: iscan
+    subplan: idx-join (inner join)
+                 outer: sscan
+                            class: s node[?]
+                            cost:  ? card ?
+                 inner: iscan
                             class: t node[?]
                             index: idx_a_b_cd_d term[?] AND term[?]
+                            filtr: term[?]
                             cost:  ? card ?
-                 inner: sscan
-                            class: s node[?]
-                            sargs: term[?]
-                            cost:  ? card ?
-                 sort:  ? asc, ? desc, ? asc
                  cost:  ? card ?
     sort:  ? desc, ? asc
     cost:  ? card ?

--- a/sql/_24_aprium_qa/_03_other/issue_7441_MRO/answers/_06_mro_partition.answer
+++ b/sql/_24_aprium_qa/_03_other/issue_7441_MRO/answers/_06_mro_partition.answer
@@ -37,12 +37,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? desc, ? desc, ? asc
@@ -73,12 +74,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? desc, ? desc, ? asc
@@ -109,12 +111,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? asc, ? asc
@@ -132,12 +135,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? desc, ? asc

--- a/sql/_24_aprium_qa/_03_other/issue_7441_MRO/answers/_06_mro_partition.answer_cci
+++ b/sql/_24_aprium_qa/_03_other/issue_7441_MRO/answers/_06_mro_partition.answer_cci
@@ -37,12 +37,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? desc, ? desc, ? asc
@@ -73,12 +74,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? desc, ? desc, ? asc
@@ -109,12 +111,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? asc, ? asc
@@ -132,12 +135,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? desc, ? asc
@@ -156,12 +160,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? desc, ? desc, ? asc

--- a/sql/_24_aprium_qa/_03_other/issue_7441_MRO/answers/_07_mro_limit.answer
+++ b/sql/_24_aprium_qa/_03_other/issue_7441_MRO/answers/_07_mro_limit.answer
@@ -47,12 +47,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? desc, ? asc
@@ -71,12 +72,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? asc
@@ -95,12 +97,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? asc, ? asc
@@ -118,12 +121,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? desc, ? asc

--- a/sql/_24_aprium_qa/_03_other/issue_7441_MRO/answers/_07_mro_limit.answer_cci
+++ b/sql/_24_aprium_qa/_03_other/issue_7441_MRO/answers/_07_mro_limit.answer_cci
@@ -47,12 +47,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? desc, ? asc
@@ -71,12 +72,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? asc
@@ -95,12 +97,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? asc, ? asc
@@ -118,12 +121,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? asc, ? desc, ? asc
@@ -142,12 +146,13 @@ i2    i3    i
 Query plan:
 temp(order by)
     subplan: idx-join (inner join)
-                 outer: sscan
-                            class: u node[?]
+                 outer: iscan
+                            class: t node[?]
+                            index: idx? term[?] (covers)
                             cost:  ? card ?
                  inner: iscan
-                            class: t node[?]
-                            index: idx? term[?] AND term[?]
+                            class: u node[?]
+                            index: i_u_i_j term[?] (covers)
                             cost:  ? card ?
                  cost:  ? card ?
     sort:  ? desc, ? desc, ? asc


### PR DESCRIPTION
Reverts CUBRID/cubrid-testcases#1237
There is an error due to the revised answer sheet in circleCI.
It has to be proceed after developer's PR for CBRD-24285, CBRD-24304 merge.