### PR TITLE
[CUBRIDQA-1136] Reviesed sql answer file for CBRD-24467 (10.2)

### DIFF
--- a/sql/_13_issues/_22_2h/answers/cbrd_24467.answer
+++ b/sql/_13_issues/_22_2h/answers/cbrd_24467.answer
@@ -35,17 +35,17 @@ Query Plan:
         INDEX SCAN (b.idx) (key range: a.cola=b.cola, covered: true)
       INDEX SCAN (c.idx) (key range: a.cola=c.cola, covered: true)
 
-  rewritten query: select a.cola, a.colb from [dba.tbl] a left outer join [dba.tbl] b on a.cola=b.cola left outer join [dba.tbl] c on a.cola=c.cola order by ?, ? for orderby_num()> ?:?  and orderby_num()<= ?:? + ?:? 
+  rewritten query: select a.cola, a.colb from tbl a left outer join tbl b on a.cola=b.cola left outer join tbl c on a.cola=c.cola order by ?, ? for orderby_num()> ?:?  and orderby_num()<= ?:? + ?:? 
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (index: dba.tbl.idx), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-        SCAN (index: dba.tbl.idx), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+      SCAN (index: tbl.idx), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+        SCAN (index: tbl.idx), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ORDERBY (time: ?, topnsort: true)
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
-        SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SCAN (table: tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
      
 


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CUBRIDQA-1136, #1311, #1324
User schema has been added since version 11.2 or later. 
Therefore, the user schema part of the 10.2 answer of this TC is removed.