### PR TITLE
[CBRD-24502] Revised isolation answer for CBRD-24502 (add)

### DIFF
--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_03.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_03.ctl
@@ -14,7 +14,6 @@ C1: create table t1(stu_id int primary key, stu_name varchar(30));
 C1: insert into t1 values(1,'james'),(4,'mikey'),(8,'lucy'),(-8,'un'),(-9,'un');
 C1: create table t2(class_id bigint, class_name varchar(10),stu_id int, constraint foreign key(stu_id) references t1(stu_id));
 C1: insert into t2 values(1,'math',4),(1,'math',8),(2,'english',1),(2,'english',4),(3,'history',1),(3,'history',8),(4,'art',-8),(5,'aaaaa',-9);
-C1: update statistics on t2;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -27,6 +26,7 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
+C1: update statistics on t2;
 C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_03.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_03.ctl
@@ -26,7 +26,6 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
-C1: update statistics on t2;
 C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/update_insert_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/update_insert_01.ctl
@@ -67,6 +67,7 @@ MC: wait until C2 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/update_insert_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/update_insert_01.ctl
@@ -67,7 +67,6 @@ MC: wait until C2 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
-C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-24502
Fix missing tc and repair incorrectly modified tc

missing tc :
_06_features/cbrd_22705_online_index_parallel/unique_index/update_insert_01.ctl -> _06_features/cbrd_22705_online_index_parallel/normal_index/update_insert_01.ctl

incorrectly modified tc :
_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_03.ctl
Delete " update statistics on t2; " in C1.