### PR TITLE
[CBRD-24658] Add temporary exclusion case to Ha_repl test

### DIFF
--- a/sql/config/daily_regression_test_exclude_list_ha_repl.conf
+++ b/sql/config/daily_regression_test_exclude_list_ha_repl.conf
@@ -305,3 +305,6 @@ sql/_27_banana_qa/issue_8909_unquoted_keywords/cases/_004_update.test
 
 #[PERMANENT] don't support 'call' on HA.
 sql/_33_elderberry/cbrd_23845/cases/_02_permission_check.test
+
+#[temporary] CBRD-24658 , If the problem is resolved, this case should be removed from this exclude file.
+sql/_08_javasp/cases/case_cte_01.test


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-24658
Planned Version is the fig-cake version, so temporarily excluding this tc.