### PR TITLE
[CBRD-24772] modified test case for not supported functions.

### DIFF
--- a/sql/_13_issues/_23_1h/cases/cbrd_24772.sql
+++ b/sql/_13_issues/_23_1h/cases/cbrd_24772.sql
@@ -1,10 +1,12 @@
 -- This test case verifies CBRD-24772 issue.
 -- A segfault occurs when using the connect by REGEXP_SUBSTR statement
+-- 10.2 does not support dual, REGEXP_SUBSTR function so change it to db_root, ELT function.
+-- The result should be same with using dual, REGEXP_SUBSTR on version over 11.0.
 
 select 1
-from dual
-connect by REGEXP_SUBSTR(1,'1', 1,level)=1;
+from db_root
+connect by ELT (2, 'string1', level, 'string3')=1;
 
 select 1
-from dual
-connect by REGEXP_SUBSTR(level,'1', 1,1)=1;
+from db_root
+connect by ELT (3, 'string1', 'string2', level)=1;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24772

dual, REGEXP_SUBSTR is not supported on 10.2 so modified test case as using db_root, ELT instead.
dual -> db_root
REGEXP_SUBSTR(1,'1', 1,level)=1; -> ELT (2, 'string1', level, 'string3')=1;