### PR TITLE
[CBRD-24502] Revised isolation answer for do not update statistical information when performing DDL (add) (10.2)

### DIFF
--- a/isolation/_02_RepeatableRead/foreign_key_column/answer/truncate_insert_01.answer
+++ b/isolation/_02_RepeatableRead/foreign_key_column/answer/truncate_insert_01.answer
@@ -40,7 +40,7 @@
 |    2    'test'  
 | 4 rows selected
 | ERROR RETURNED: Operation would have caused one or more unique constraint violations. INDEX pk_abc(B+tree: ?) ON CLASS t_foreign(CLASS_OID: ?). key: {1, 'do'}(OID: ?). 
-|    on statement number: 13
+|    on statement number: 14
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_02_RepeatableRead/foreign_key_column/truncate_insert_01.ctl
+++ b/isolation/_02_RepeatableRead/foreign_key_column/truncate_insert_01.ctl
@@ -27,6 +27,7 @@ C1: CREATE TABLE t_primary(id INT PRIMARY KEY,col VARCHAR(10));
 C1: CREATE TABLE t_foreign(id INT,col VARCHAR(10),FOREIGN KEY(id) REFERENCES t_primary(id) ON DELETE CASCADE);
 C1: INSERT INTO t_primary VALUES(1,'a'),(2,'b');
 C1: INSERT INTO t_foreign VALUES(1,'do'),(2,'test'),(1,'make'),(2,'spell');
+C1: update statistics on t_foreign;
 C1: commit work;
 
 /* test case */
@@ -39,6 +40,7 @@ MC: wait until C2 ready;
 C2: alter table t_foreign add CONSTRAINT pk_abc primary key(id,col);
 C2: SELECT * FROM t_primary ORDER BY id;
 C2: SELECT * FROM t_foreign ORDER BY id;
+C2: update statistics on t_foreign;
 C2: show index from t_foreign;
 C2: commit;
 C2: INSERT INTO t_primary VALUES(1,'a'),(2,'b');


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-24502
`_02_RepeatableRead/foreign_key_column/truncate_insert_01.ctl` is a test case that requires modification only on 10.2 because CBRD-23916 has been applied since 11.1

Refer to #984 for details