### PR TITLE
[CBRD-24502] Backport for the problem of updating statistical information when performing DDL (11.2)

### DIFF
--- a/sql/_08_javasp/answers/case_index_scan_01.answer
+++ b/sql/_08_javasp/answers/case_index_scan_01.answer
@@ -1,0 +1,234 @@
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+1
+===================================================
+1
+===================================================
+1
+===================================================
+1
+===================================================
+1
+===================================================
+1
+===================================================
+1
+===================================================
+1
+===================================================
+1
+===================================================
+1
+===================================================
+0
+===================================================
+equal    
+1     
+
+Query plan:
+sscan
+    class: dual node[?]
+    cost:  ? card ?
+Query stmt:
+(select inttest(?) from dual dual)
+Query plan:
+iscan
+    class: tbl node[?]
+    index: i_tbl term[?] (covers)
+    cost:  ? card ?
+Query stmt:
+select count(*) from tbl tbl where tbl.ord=(select inttest(?) from dual dual)
+===================================================
+equal    
+1     
+
+Query plan:
+sscan
+    class: t_? node[?]
+    cost:  ? card ?
+Query stmt:
+(select tbl.ord from table({?}) t_? (c_?))
+Query plan:
+nl-join (cselect join)
+    edge:  table(?) -> t_? node[?]
+    outer: sscan
+               class: t_? node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: t_? node[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+(select t_?.c_?, t_?.c_? from (select tbl.ord from table({?}) t_? (c_?)) t_? (c_?), (inttest(t_?.c_?)) t_? (c_?))
+Query plan:
+nl-join (inner join)
+    edge:  table(?) -> t_? node[?]
+    outer: iscan
+               class: tbl node[?]
+               index: i_tbl term[?] (covers)
+               cost:  ? card ?
+    inner: sscan
+               class: t_? node[?]
+               sargs: table(?) -> t_? node[?]
+               cost:  ? card ?
+    subqs: ?
+    cost:  ? card ?
+Query stmt:
+(select t_?.c_? from tbl tbl, (select t_?.c_?, t_?.c_? from (select tbl.ord from table({?}) t_? (c_?)) t_? (c_?), (inttest(t_?.c_?)) t_? (c_?)) t_? (c_?, c_?) where tbl.ord=?)
+Query plan:
+iscan
+    class: tbl node[?]
+    index: i_tbl term[?] (covers)
+    cost:  ? card ?
+Query stmt:
+select count(*) from tbl tbl where tbl.ord=(select t_?.c_? from tbl tbl, (select t_?.c_?, t_?.c_? from (select tbl.ord from table({?}) t_? (c_?)) t_? (c_?), (inttest(t_?.c_?)) t_? (c_?)) t_? (c_?, c_?) where tbl.ord=?)
+===================================================
+in    
+1     
+
+Query plan:
+temp(distinct)
+    subplan: sscan
+                 class: dual node[?]
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+(select distinct inttest(?) from dual dual)
+Query plan:
+idx-join (inner join)
+    outer: sscan
+               class: av? node[?]
+               cost:  ? card ?
+    inner: iscan
+               class: tbl node[?]
+               index: i_tbl term[?] (covers)
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select count(*) from tbl tbl, (select distinct inttest(?) from dual dual) av? (av_?) where tbl.ord=av?.av_?
+===================================================
+in    
+10     
+
+Query plan:
+sscan
+    class: t_? node[?]
+    cost:  ? card ?
+Query stmt:
+(select tbl.ord from table({?}) t_? (c_?))
+Query plan:
+nl-join (cselect join)
+    edge:  table(?) -> t_? node[?]
+    outer: sscan
+               class: t_? node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: t_? node[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+(select t_?.c_?, t_?.c_? from (select tbl.ord from table({?}) t_? (c_?)) t_? (c_?), (inttest(t_?.c_?)) t_? (c_?))
+Query plan:
+temp(distinct)
+    subplan: nl-join (inner join)
+                 edge:  table(?) -> t_? node[?]
+                 outer: sscan
+                            class: tbl node[?]
+                            cost:  ? card ?
+                 inner: sscan
+                            class: t_? node[?]
+                            sargs: table(?) -> t_? node[?]
+                            cost:  ? card ?
+                 subqs: ?
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+(select distinct t_?.c_? from tbl tbl, (select t_?.c_?, t_?.c_? from (select tbl.ord from table({?}) t_? (c_?)) t_? (c_?), (inttest(t_?.c_?)) t_? (c_?)) t_? (c_?, c_?))
+Query plan:
+idx-join (inner join)
+    outer: sscan
+               class: av? node[?]
+               cost:  ? card ?
+    inner: iscan
+               class: tbl node[?]
+               index: i_tbl term[?] (covers)
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select count(*) from tbl tbl, (select distinct t_?.c_? from tbl tbl, (select t_?.c_?, t_?.c_? from (select tbl.ord from table({?}) t_? (c_?)) t_? (c_?), (inttest(t_?.c_?)) t_? (c_?)) t_? (c_?, c_?)) av? (av_?) where tbl.ord=av?.av_?
+===================================================
+like    
+1     
+
+Query plan:
+sscan
+    class: dual node[?]
+    cost:  ? card ?
+Query stmt:
+(select stringTest('a') from dual dual)
+Query plan:
+sscan
+    class: tbl node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+select count(*) from tbl tbl where tbl.col_char like (select stringTest('a') from dual dual)
+===================================================
+like    
+1     
+
+Query plan:
+sscan
+    class: t_? node[?]
+    cost:  ? card ?
+Query stmt:
+(select tbl.col_char, tbl.ord from table({?}) t_? (c_?))
+Query plan:
+nl-join (cselect join)
+    edge:  table(?) -> t_? node[?]
+    outer: sscan
+               class: t_? node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: t_? node[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+(select t_?.c_?, t_?.c_?, t_?.c_? from (select tbl.col_char, tbl.ord from table({?}) t_? (c_?)) t_? (c_?, c_?), (stringTest(t_?.c_?)) t_? (c_?))
+Query plan:
+nl-join (inner join)
+    edge:  table(?) -> t_? node[?]
+    outer: iscan
+               class: tbl node[?]
+               index: i_tbl term[?]
+               cost:  ? card ?
+    inner: sscan
+               class: t_? node[?]
+               sargs: table(?) -> t_? node[?]
+               cost:  ? card ?
+    subqs: ?
+    cost:  ? card ?
+Query stmt:
+(select t_?.c_? from tbl tbl, (select t_?.c_?, t_?.c_?, t_?.c_? from (select tbl.col_char, tbl.ord from table({?}) t_? (c_?)) t_? (c_?, c_?), (stringTest(t_?.c_?)) t_? (c_?)) t_? (c_?, c_?, c_?) where tbl.ord=?)
+Query plan:
+sscan
+    class: tbl node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+select count(*) from tbl tbl where tbl.col_char like (select t_?.c_? from tbl tbl, (select t_?.c_?, t_?.c_?, t_?.c_? from (select tbl.col_char, tbl.ord from table({?}) t_? (c_?)) t_? (c_?, c_?), (stringTest(t_?.c_?)) t_? (c_?)) t_? (c_?, c_?, c_?) where tbl.ord=?)
+===================================================
+0
+===================================================
+0

--- a/sql/_08_javasp/cases/case_index_scan_01.sql
+++ b/sql/_08_javasp/cases/case_index_scan_01.sql
@@ -1,0 +1,39 @@
+CREATE OR REPLACE FUNCTION intTest(x int) RETURN int AS LANGUAGE JAVA NAME 'SpTest7.typetestint(int) return int';
+CREATE OR REPLACE FUNCTION stringTest(x String) RETURN String AS LANGUAGE JAVA NAME 'SpTest7.typeteststring(java.lang.String) return java.lang.String';
+
+DROP IF EXISTS tbl;
+
+CREATE TABLE tbl (ord INT, col_int INT, col_char char(1));
+CREATE INDEX i_tbl ON tbl (ord);
+CREATE INDEX i_tbl_char ON tbl (col_char);
+
+INSERT INTO tbl VALUES (1,10,'a');
+INSERT INTO tbl VALUES (2,10,'b');
+INSERT INTO tbl VALUES (3,10,'c');
+INSERT INTO tbl VALUES (4,10,'d');
+INSERT INTO tbl VALUES (5,10,'e');
+INSERT INTO tbl VALUES (6,10,'f');
+INSERT INTO tbl VALUES (7,10,'g');
+INSERT INTO tbl VALUES (8,10,'h');
+INSERT INTO tbl VALUES (9,10,'i');
+INSERT INTO tbl VALUES (10,10,'j');
+
+update statistics on tbl;
+
+-- equal
+SELECT count(*) AS "equal" FROM tbl WHERE ord = (SELECT inttest(5) FROM dual);
+SELECT count(*) AS "equal" FROM tbl WHERE ord = (SELECT inttest(ord) FROM tbl where ord=5);
+
+-- in
+SELECT count(*) AS "in" FROM tbl WHERE ord IN (SELECT inttest(5) FROM dual);
+SELECT count(*) AS "in" FROM tbl WHERE ord IN (SELECT inttest(ord) FROM tbl);
+
+-- LIKE
+SELECT count(*) AS "like" FROM tbl WHERE col_char LIKE (SELECT stringTest('a') FROM dual);
+-- (Related CBRD-24686) can not index-scan the 'JAVASP' function on 'LIKE' clause.
+SELECT count(*) AS "like" FROM tbl WHERE col_char LIKE (SELECT stringTest(col_char) FROM tbl where ord=5);
+
+DROP FUNCTION inttest, stringTest;
+
+DROP tbl;
+


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-24502, http://jira.cubrid.org/browse/CBRD-24715, #1485 

This test case reported a bug in the CBRD-24715.
but it is not a bug & won't fix it.
It is CUBRID's design, related to the CBRD-24502.
- (http://jira.cubrid.org/browse/CBRD-24715?focusedCommentId=4764235&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4764235)