### PR TITLE
[CBRD-24502] Backport from develop to 11.0 - Revised isolation answer

### DIFF
--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_01.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_01.ctl
@@ -16,6 +16,7 @@ C4: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS t1;
 C1: create table t1 (a int primary key auto_increment, b int, c char(300));
 C1: insert into t1(b,c) values (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f');
+C1: update statistics on t1;
 C1: COMMIT;
 MC: wait until C1 ready;
 
@@ -60,6 +61,7 @@ C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
 C1: describe t1;
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_02.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_02.ctl
@@ -16,6 +16,7 @@ C4: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS t1;
 C1: create table t1 (a int primary key auto_increment, b int, c char(10));
 C1: insert into t1(b,c) values (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f');
+C1: update statistics on t1;
 C1: COMMIT;
 MC: wait until C1 ready;
 
@@ -58,6 +59,7 @@ MC: wait until C4 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: describe t1;
 MC: wait until C1 ready;

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_03.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_03.ctl
@@ -57,6 +57,7 @@ MC: wait until C4 ready;
 C1: select sum(set{c}) into :s from t1 ignore index (i) where c > 'a' order by 1;
 C1: select sum(set{c}) into :i from t1 force index (i) where c > 'a' order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: describe t1;
 MC: wait until C1 ready;

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_04.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_04.ctl
@@ -16,6 +16,7 @@ C4: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS t1;
 C1: create table t1 (a int primary key auto_increment, b int, c char(10));
 C1: insert into t1(b,c) values (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f');
+C1: update statistics on t1;
 C1: COMMIT;
 MC: wait until C1 ready;
 
@@ -56,6 +57,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: describe t1;
 MC: wait until C1 ready;

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_06.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_06.ctl
@@ -16,6 +16,7 @@ C4: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS t1;
 C1: create table t1 (a int primary key auto_increment, b int, c char(10),d char(4) default 'zzz');
 C1: insert into t1(b,c) values (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f');
+C1: update statistics on t1;
 C1: COMMIT;
 MC: wait until C1 ready;
 
@@ -58,6 +59,7 @@ C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
 C1: describe t1;
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_07.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_07.ctl
@@ -16,6 +16,7 @@ C4: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS t1;
 C1: create table t1 (a int primary key auto_increment, b int, c char(10),d char(4) default 'zzz');
 C1: insert into t1(b,c) values (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f');
+C1: update statistics on t1;
 C1: COMMIT;
 MC: wait until C1 ready;
 
@@ -59,6 +60,7 @@ C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
 C1: describe t1;
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_08.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_08.ctl
@@ -16,6 +16,7 @@ C4: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS t1;
 C1: create table t1 (a int primary key auto_increment, b int, c char(10),d char(4) default 'zzz');
 C1: insert into t1(b,c) values (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f');
+C1: update statistics on t1;
 C1: COMMIT;
 MC: wait until C1 ready;
 
@@ -54,6 +55,7 @@ C4: commit;
 MC: wait until C4 ready;
 
 /* verification */
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_10.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_10.ctl
@@ -18,6 +18,7 @@ C1: create table t1 (a int primary key auto_increment, b int, c char(10),d char(
 C1: insert into t1(b,c) values (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f');
 C1: create index idx on t1(d);
 C1: COMMIT;
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 
@@ -59,6 +60,7 @@ MC: wait until C4 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_11.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_11.ctl
@@ -51,6 +51,7 @@ C1: select sum(set{k}) into :s from t ignore index (a) where k > 0 order by 1;
 C1: select sum(set{k}) into :i from t force index (a) where k > 0 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
 C1: describe t;
+C1: update statistics on t;
 C1: show index from t;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_14.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/create_14.ctl
@@ -51,6 +51,7 @@ C1: select sum(set{k}) into :s from t ignore index (a) where k > 0 order by 1;
 C1: select sum(set{k}) into :i from t force index (a) where k > 0 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
 C1: describe t;
+C1: update statistics on t;
 C1: show index from t;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/show_001.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/show_001.ctl
@@ -16,6 +16,7 @@ C4: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS t1;
 C1: create table t1 (a int primary key auto_increment, b int, c char(300));
 C1: insert into t1(b,c) values (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f');
+C1: update statistics on t1;
 C1: COMMIT;
 MC: wait until C1 ready;
 
@@ -55,6 +56,7 @@ MC: wait until C2 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C4: update statistics on t1;
 C4: show index from t1;
 C4: commit;
 MC: wait until C4 ready;

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/create_multiple_index_01.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/create_multiple_index_01.ctl
@@ -52,6 +52,7 @@ C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1
 C1: select sum(set{a}) into :i1 from t1 force index (i1) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
 C1: select if (:s = :i1, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/create_multiple_index_02.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/create_multiple_index_02.ctl
@@ -52,6 +52,7 @@ MC: wait until C3 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/delete_01.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/delete_01.ctl
@@ -19,6 +19,7 @@ C3: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS a_tbl;
 C1: CREATE TABLE a_tbl(id INT PRIMARY KEY, charge DOUBLE);
 C1: INSERT INTO a_tbl VALUES (1, 100.0), (2, 150.0), (3, 10000.0);
+C1: update statistics on a_tbl;
 C1: COMMIT;
 MC: wait until C1 ready;
 
@@ -56,6 +57,7 @@ MC: wait until C2 ready;
 C1: select sum(set{id}) into :s from a_tbl ignore index (i) where id > -999 order by 1;
 C1: select sum(set{id}) into :i from a_tbl force index (i) where id > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on a_tbl;
 C1: show index from a_tbl;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/delete_05_prepare.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/delete_05_prepare.ctl
@@ -60,6 +60,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/insert_01.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/insert_01.ctl
@@ -66,6 +66,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/insert_01_rollback.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/insert_01_rollback.ctl
@@ -66,6 +66,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/insert_02_rollback.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/insert_02_rollback.ctl
@@ -57,6 +57,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/insert_03.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/insert_03.ctl
@@ -57,6 +57,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/insert_04_rollback.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/insert_04_rollback.ctl
@@ -67,6 +67,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/insert_05.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/insert_05.ctl
@@ -56,6 +56,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/insert_delete_02.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/insert_delete_02.ctl
@@ -67,6 +67,7 @@ MC: wait until C2 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/insert_delete_03.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/insert_delete_03.ctl
@@ -67,6 +67,7 @@ MC: wait until C2 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/select_01.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/select_01.ctl
@@ -66,6 +66,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/update_01.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/update_01.ctl
@@ -59,6 +59,7 @@ C1: select if (:s = :i, 'OK', 'NOK');
 C1: select sum(set{charge}) into :s2 from a_tbl ignore index (i) where id > -999 order by 1;
 C1: select sum(set{charge}) into :i2 from a_tbl force index (i) where id > -999 order by 1;
 C1: select if (:s2 = :i2, 'OK', 'NOK');
+C1: update statistics on a_tbl;
 C1: show index from a_tbl;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/update_02.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/update_02.ctl
@@ -56,6 +56,7 @@ MC: wait until C2 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_22202_invisible_indexes/invisible_index_02.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_22202_invisible_indexes/invisible_index_02.ctl
@@ -27,9 +27,11 @@ MC: wait until C1 ready;
 C2: select * from t1 order by 1;
 MC: wait until C2 ready;
 
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 
+C2: update statistics on t1;
 C2: show index from t1;
 MC: wait until C2 ready;
 

--- a/isolation/_01_ReadCommitted/cbrd_22202_invisible_indexes/invisible_index_05.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_22202_invisible_indexes/invisible_index_05.ctl
@@ -33,6 +33,7 @@ MC: wait until C2 blocked;
 C1: ROLLBACK;
 MC: wait until C1 ready;
 
+C2: update statistics on t1;
 C2: show index from t1;
 MC: wait until C2 ready;
 

--- a/isolation/_01_ReadCommitted/dml_ddl/altertable_delete_04.ctl
+++ b/isolation/_01_ReadCommitted/dml_ddl/altertable_delete_04.ctl
@@ -43,6 +43,7 @@ C1: commit work;
 MC: wait until C2 ready;
 C2: commit work;
 C2: SELECT * FROM tb1 order by 1,2; 
+C2: update statistics on tb1;
 C2: show index from tb1;
 C2: commit work;
 

--- a/isolation/_01_ReadCommitted/dml_ddl/altertable_delete_05.ctl
+++ b/isolation/_01_ReadCommitted/dml_ddl/altertable_delete_05.ctl
@@ -43,6 +43,7 @@ C1: rollback;
 MC: wait until C2 ready;
 C2: commit work;
 C2: SELECT * FROM tb1 order by 1,2;
+C2: update statistics on tb1;
 C2: show index from tb1;
 C2: commit work;
 

--- a/isolation/_01_ReadCommitted/dml_ddl/altertable_insert_03.ctl
+++ b/isolation/_01_ReadCommitted/dml_ddl/altertable_insert_03.ctl
@@ -42,6 +42,7 @@ C1: commit work;
 MC: wait until C2 ready;
 C2: commit work;
 MC: wait until C2 ready;
+C2: update statistics on tb1;
 C2: show index from tb1;
 C2: commit work;
 MC: wait until C2 ready;

--- a/isolation/_01_ReadCommitted/dml_ddl/altertable_insert_05.ctl
+++ b/isolation/_01_ReadCommitted/dml_ddl/altertable_insert_05.ctl
@@ -40,6 +40,7 @@ C1: rollback;
 
 MC: wait until C2 ready;
 C2: commit work;
+C1: update statistics on tb1;
 C1: show index from tb1;
 C2: commit;
 

--- a/isolation/_01_ReadCommitted/issues/_15_1h/bug_bts_17140.ctl
+++ b/isolation/_01_ReadCommitted/issues/_15_1h/bug_bts_17140.ctl
@@ -39,7 +39,8 @@ C1: commit work;
 MC: wait until C1 ready;
 
 MC: wait until C2 ready;
-C2: SELECT * FROM tb1 order by 1,2; 
+C2: SELECT * FROM tb1 order by 1,2;
+C2: update statistics on tb1;
 C2: show index from tb1;
 C2: commit work;
 MC: wait until C2 ready;
@@ -75,6 +76,7 @@ C1: commit work;
 
 MC: wait until C2 ready;
 C2: SELECT * FROM tb1 order by 1,2; 
+C2: update statistics on tb1;
 C2: show index from tb1;
 C2: commit work;
 MC: wait until C2 ready;

--- a/isolation/_02_RepeatableRead/dml_ddl/altertable_delete_03.ctl
+++ b/isolation/_02_RepeatableRead/dml_ddl/altertable_delete_03.ctl
@@ -29,6 +29,7 @@ C1: INSERT INTO tb1 VALUES(1,'abc',10);
 C1: INSERT INTO tb1 VALUES(2,'efg',11);
 C1: INSERT INTO tb1 VALUES(3,'hijk',12);
 C1: create unique index idx on tb1(col,grade);
+C1: update statistics on tb1;
 C1: commit work;
 
 /* test case */

--- a/isolation/_02_RepeatableRead/dml_ddl/altertable_truncate_04.ctl
+++ b/isolation/_02_RepeatableRead/dml_ddl/altertable_truncate_04.ctl
@@ -41,6 +41,7 @@ MC: wait until C2 ready;
 C2: commit work;
 C2: select * from tb1 order by id;
 MC: wait until C2 ready;
+C1: update statistics on tb1;
 C1: show index from tb1;
 C1: commit work;
 C2: commit work;

--- a/isolation/_02_RepeatableRead/foreign_key_column/answer/truncate_insert_01.answer
+++ b/isolation/_02_RepeatableRead/foreign_key_column/answer/truncate_insert_01.answer
@@ -40,7 +40,7 @@
 |    2    'test'  
 | 4 rows selected
 | ERROR RETURNED: Operation would have caused one or more unique constraint violations. INDEX pk_abc(B+tree: ?) ON CLASS t_foreign(CLASS_OID: ?). key: {1, 'do'}(OID: ?). 
-|    on statement number: 13
+|    on statement number: 14
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_02_RepeatableRead/foreign_key_column/truncate_insert_01.ctl
+++ b/isolation/_02_RepeatableRead/foreign_key_column/truncate_insert_01.ctl
@@ -27,6 +27,7 @@ C1: CREATE TABLE t_primary(id INT PRIMARY KEY,col VARCHAR(10));
 C1: CREATE TABLE t_foreign(id INT,col VARCHAR(10),FOREIGN KEY(id) REFERENCES t_primary(id) ON DELETE CASCADE);
 C1: INSERT INTO t_primary VALUES(1,'a'),(2,'b');
 C1: INSERT INTO t_foreign VALUES(1,'do'),(2,'test'),(1,'make'),(2,'spell');
+C1: update statistics on t_foreign;
 C1: commit work;
 
 /* test case */
@@ -39,6 +40,7 @@ MC: wait until C2 ready;
 C2: alter table t_foreign add CONSTRAINT pk_abc primary key(id,col);
 C2: SELECT * FROM t_primary ORDER BY id;
 C2: SELECT * FROM t_foreign ORDER BY id;
+C2: update statistics on t_foreign;
 C2: show index from t_foreign;
 C2: commit;
 C2: INSERT INTO t_primary VALUES(1,'a'),(2,'b');

--- a/isolation/_02_RepeatableRead/index_column/common_index/basic_sql/delete_select_04.ctl
+++ b/isolation/_02_RepeatableRead/index_column/common_index/basic_sql/delete_select_04.ctl
@@ -39,6 +39,7 @@ C1: SELECT * FROM tb1 WHERE col in ('2','3') ORDER BY id;
 C1: commit work;
 
 MC: wait until C2 ready;
+C2: update statistics on tb1;
 C2: show index from tb1;
 C2: SELECT * FROM tb1 WHERE col in ('2','3') ORDER BY id;
 C2: commit work;
@@ -46,6 +47,7 @@ MC: wait until C1 ready;
 C2: SELECT COUNT(*) FROM tb1;
 C2: commit work;
 MC: wait until C2 ready;
+C1: update statistics on tb1;
 C1: show index from tb1;
 C1: CREATE INDEX idx_col on tb1(id);
 C1: select * from db_index where class_name='tb1';

--- a/isolation/_05_ReadCommitted_RepeatableRead/index_column/common_index/basic_sql/answer/delete_select_02_ext.answer
+++ b/isolation/_05_ReadCommitted_RepeatableRead/index_column/common_index/basic_sql/answer/delete_select_02_ext.answer
@@ -30,7 +30,7 @@
 |    'tb1'    1    'idx_id'    1    'id'    'A'    500    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 | 1 row selected
 | ERROR RETURNED: Serializable conflict due to concurrent updates 
-|    on statement number: 10
+|    on statement number: 11
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_05_ReadCommitted_RepeatableRead/index_column/common_index/basic_sql/delete_select_01_ext.ctl
+++ b/isolation/_05_ReadCommitted_RepeatableRead/index_column/common_index/basic_sql/delete_select_01_ext.ctl
@@ -20,6 +20,7 @@ C1: CREATE TABLE tb1( id INT, col VARCHAR(10) );
 C1: INSERT INTO tb1 SELECT rownum,mod(rownum,100) FROM db_class a,db_class b where rownum<=500;
 C1: CREATE INDEX idx_id on tb1(id);
 C1: CREATE INDEX idx_col on tb1(col);
+C1: update statistics on tb1;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -34,6 +35,7 @@ C1: commit;
 MC: wait until C2 ready;
 C2: SELECT COUNT(*) FROM tb1;
 C2: CREATE INDEX idx_col on tb1(col);
+C2: update statistics on tb1;
 C2: show index from tb1;
 C2: commit;
 MC: wait until C2 ready;

--- a/isolation/_05_ReadCommitted_RepeatableRead/index_column/common_index/basic_sql/delete_select_02_ext.ctl
+++ b/isolation/_05_ReadCommitted_RepeatableRead/index_column/common_index/basic_sql/delete_select_02_ext.ctl
@@ -40,6 +40,7 @@ C2: drop INDEX idx_col on tb1;
 MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C2 ready;
+C2: update statistics on tb1;
 C2: show index from tb1;
 C2: update tb1 set id=id+500,col='updated' where id in ('2','9','10');
 C2: commit;

--- a/isolation/_05_ReadCommitted_RepeatableRead/index_column/common_index/basic_sql/delete_select_04.ctl
+++ b/isolation/_05_ReadCommitted_RepeatableRead/index_column/common_index/basic_sql/delete_select_04.ctl
@@ -26,6 +26,7 @@ C1: CREATE TABLE tb1( id INT, col VARCHAR(10) );
 C1: INSERT INTO tb1 SELECT rownum,mod(rownum,100) FROM db_class a,db_class b where rownum<=500;
 C1: CREATE INDEX idx_id on tb1(col);
 C1: CREATE INDEX idx_col on tb1(id);
+C1: update statistics on tb1;
 C1: commit work;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/_04_RepeatableRead_ReadCommitted/basic_sql/delete_update_07_3.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/_04_RepeatableRead_ReadCommitted/basic_sql/delete_update_07_3.ctl
@@ -46,6 +46,7 @@ MC: wait until C3 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C3: update statistics on t1;
 C3: show index from t1;
 C3: SELECT /*+ recompile */ * FROM t1 where id>0 and col>'A' using index idx1(+);
 C3: SELECT /*+ recompile */ * FROM t1 where id>0 and col>'A' using index none order by id ;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_01.ctl
@@ -16,6 +16,7 @@ C4: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS t1;
 C1: create table t1 (a int primary key auto_increment, b int, c char(300));
 C1: insert into t1(b,c) values (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f');
+C1: update statistics on t1;
 C1: COMMIT;
 MC: wait until C1 ready;
 
@@ -60,6 +61,7 @@ C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
 C1: describe t1;
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_02.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_02.ctl
@@ -16,6 +16,7 @@ C4: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS t1;
 C1: create table t1 (a int primary key auto_increment, b int, c char(10));
 C1: insert into t1(b,c) values (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f');
+C1: update statistics on t1;
 C1: COMMIT;
 MC: wait until C1 ready;
 
@@ -58,6 +59,7 @@ MC: wait until C4 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: describe t1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_03.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_03.ctl
@@ -16,6 +16,7 @@ C4: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS t1;
 C1: create table t1 (a int , b int auto_increment, c char(10));
 C1: insert into t1(b,c) values (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f');
+C1: update statistics on t1;
 C1: COMMIT;
 MC: wait until C1 ready;
 
@@ -57,6 +58,7 @@ MC: wait until C4 ready;
 C1: select sum(set{c}) into :s from t1 ignore index (i) where c > 'a' order by 1;
 C1: select sum(set{c}) into :i from t1 force index (i) where c > 'a' order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: describe t1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_04.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_04.ctl
@@ -16,6 +16,7 @@ C4: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS t1;
 C1: create table t1 (a int primary key auto_increment, b int, c char(10));
 C1: insert into t1(b,c) values (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f');
+C1: update statistics on t1;
 C1: COMMIT;
 MC: wait until C1 ready;
 
@@ -56,6 +57,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: describe t1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_06.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_06.ctl
@@ -16,6 +16,7 @@ C4: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS t1;
 C1: create table t1 (a int primary key auto_increment, b int, c char(10),d char(4) default 'zzz');
 C1: insert into t1(b,c) values (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f');
+C1: update statistics on t1;
 C1: COMMIT;
 MC: wait until C1 ready;
 
@@ -58,6 +59,7 @@ C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
 C1: describe t1;
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_07.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_07.ctl
@@ -16,6 +16,7 @@ C4: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS t1;
 C1: create table t1 (a int primary key auto_increment, b int, c char(10),d char(4) default 'zzz');
 C1: insert into t1(b,c) values (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f');
+C1: update statistics on t1;
 C1: COMMIT;
 MC: wait until C1 ready;
 
@@ -59,6 +60,7 @@ C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
 C1: describe t1;
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_08.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_08.ctl
@@ -16,6 +16,7 @@ C4: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS t1;
 C1: create table t1 (a int primary key auto_increment, b int, c char(10),d char(4) default 'zzz');
 C1: insert into t1(b,c) values (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f');
+C1: update statistics on t1;
 C1: COMMIT;
 MC: wait until C1 ready;
 
@@ -54,6 +55,7 @@ C4: commit;
 MC: wait until C4 ready;
 
 /* verification */
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_10.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_10.ctl
@@ -17,6 +17,7 @@ C1: DROP TABLE IF EXISTS t1;
 C1: create table t1 (a int primary key auto_increment, b int, c char(10),d char(4) default 'zzz');
 C1: insert into t1(b,c) values (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f');
 C1: create index idx on t1(d) with online parallel 2;
+C1: update statistics on t1;
 C1: COMMIT;
 C1: show index from t1;
 MC: wait until C1 ready;
@@ -59,6 +60,7 @@ MC: wait until C4 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_11.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_11.ctl
@@ -51,6 +51,7 @@ C1: select sum(set{k}) into :s from t ignore index (a) where k > 0 order by 1;
 C1: select sum(set{k}) into :i from t force index (a) where k > 0 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
 C1: describe t;
+C1: update statistics on t;
 C1: show index from t;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_14.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/create_14.ctl
@@ -51,6 +51,7 @@ C1: select sum(set{k}) into :s from t ignore index (a) where k > 0 order by 1;
 C1: select sum(set{k}) into :i from t force index (a) where k > 0 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
 C1: describe t;
+C1: update statistics on t;
 C1: show index from t;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/show_001.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/show_001.ctl
@@ -16,6 +16,7 @@ C4: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS t1;
 C1: create table t1 (a int primary key auto_increment, b int, c char(300));
 C1: insert into t1(b,c) values (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f');
+C1: update statistics on t1;
 C1: COMMIT;
 MC: wait until C1 ready;
 
@@ -55,6 +56,7 @@ MC: wait until C2 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C4: update statistics on t1;
 C4: show index from t1;
 C4: commit;
 MC: wait until C4 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_04.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_04.answer
@@ -69,22 +69,22 @@
 | 7 rows selected
 | ERROR RETURNED: Semantic: before ' (+) ;'
 | Cannot find the index 'idx1(+)'. (select t2.class_id, t2.class_name, t2.stu_id, t2.birty_date... 
-|    on statement number: 14
+|    on statement number: 15
 | ERROR RETURNED: Syntax: In line 1, column 1 before ' from t2 where ADDTIME(birty_date, time'1:1:2')='2000-01-01 01...'
 | Syntax error: unexpected '*', expecting SELECT or VALUE or VALUES or '('  
-|    on statement number: 15
+|    on statement number: 16
 | ERROR RETURNED: Syntax: In line 1, column 1 before '/ C1: select * from t2 where DAYOFWEEK(birty_date)=7 using ind...'
 | Syntax error: unexpected '*', expecting SELECT or VALUE or VALUES or '('  
-|    on statement number: 16
+|    on statement number: 17
 | ERROR RETURNED: Semantic: before '  using index idx3(+) ;'
 | Cannot coerce 2 to type date. select t2.class_id, t2.class_name, t2.stu_id, t2.birty_date ... 
-|    on statement number: 17
+|    on statement number: 18
 | ERROR RETURNED: Semantic: before ' (+) ;'
 | Cannot find the index 'idx4(+)'. (select t2.class_id, t2.class_name, t2.stu_id, t2.birty_date... 
-|    on statement number: 18
+|    on statement number: 19
 | ERROR RETURNED: Semantic: before ' ,'1999-12-31 00:00:00')=1 using index idx5(+) ;'
 | Attribute "birth_date" was not found. select t2.class_id, t2.class_name, t2.stu_id, t2.birty_date ... 
-|    on statement number: 19
+|    on statement number: 20
 | ERROR RETURNED: Semantic: before ' (+) ;'
 | Cannot find the index 'idx6(+)'. (select t2.class_id, t2.class_name, t2.stu_id, t2.birty_date... 
-|    on statement number: 20
+|    on statement number: 21

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/delete_online_index_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/delete_online_index_01.ctl
@@ -13,6 +13,7 @@ C3: set transaction isolation level read committed;
 C1: drop table if exists t;
 C1: create table t(id bigint primary key,col varchar(100));
 C1: insert into t select rownum,rownum from db_root connect by level<=100;
+C1: update statistics on t;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -38,6 +39,7 @@ MC: wait until C3 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t;
 C1: show indexes from t;
 C1: select * from t where id >85 and col!='a' order by 1 desc,2 desc;
 C1: drop table t;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/delete_online_index_02.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/delete_online_index_02.ctl
@@ -13,6 +13,7 @@ C3: set transaction isolation level read committed;
 C1: drop table if exists t;
 C1: create table t(id bigint primary key,col char(5000));
 C1: insert into t select rownum,rownum from db_root connect by level<=100;
+C1: update statistics on t;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -38,6 +39,7 @@ MC: wait until C3 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t;
 C1: show indexes from t;
 C1: select id,trim(col) from t where id >20 and col!='a' order by 1 desc,2 desc limit 20;
 C1: drop table t;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/insert_odku_online_index_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/insert_odku_online_index_01.ctl
@@ -17,6 +17,7 @@ C4: set transaction isolation level read committed;
 C1: drop table if exists t;
 C1: create table t(id bigint primary key,col varchar(10));
 C1: insert into t select rownum,rownum||'a' from db_root connect by level<=10;
+C1: update statistics on t;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -55,6 +56,7 @@ MC: wait until C4 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t;
 C1: show indexes from t;
 C1: select * from t where id>5 and col >'5' order by 1 desc,2 desc;
 C1: commit work;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/insert_odku_online_index_04.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/insert_odku_online_index_04.ctl
@@ -16,6 +16,7 @@ C4: set transaction isolation level read committed;
 C1: drop table if exists t;
 C1: create table t(id bigint unique, a char(10) unique, b varchar(10) unique, c timestamp default current_timestamp, d datetime default current_datetime);
 C1: insert into t(id,a,b) select rownum,rownum||'a',rownum||'b' from db_root connect by level<=100;
+C1: update statistics on t;
 C1: commit;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/insert_online_index_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/insert_online_index_01.ctl
@@ -22,6 +22,8 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
+C1: update statistics on t;
+C2: update statistics on t;
 C2: show indexes from t;
 C2: commit;
 MC: wait until C2 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/p_delete_online_index_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/p_delete_online_index_01.ctl
@@ -13,6 +13,7 @@ C3: set transaction isolation level read committed;
 C1: drop table if exists t;
 C1: create table t(id bigint primary key,col varchar(100)) PARTITION BY HASH (id) PARTITIONS 4;
 C1: insert into t select rownum,rownum from db_root connect by level<=100;
+C1: update statistics on t;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -38,6 +39,7 @@ MC: wait until C3 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t;
 C1: show indexes from t;
 C1: select * from t where id >85 and col!='a' order by 1 desc,2 desc;
 C1: drop table t;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/p_delete_online_index_03.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/p_delete_online_index_03.ctl
@@ -13,6 +13,7 @@ C3: set transaction isolation level read committed;
 C1: drop table if exists t;
 C1: create table t(id bigint primary key,col char(5000)) PARTITION BY RANGE (id) (PARTITION before_600 VALUES LESS THAN (600),PARTITION before_1200 VALUES LESS THAN (1200));
 C1: insert into t select rownum,rownum from db_root connect by level<=1000;
+C1: update statistics on t;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -38,6 +39,7 @@ MC: wait until C3 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t;
 C1: show indexes from t;
 C1: select id,trim(col) from t where col>'4' order by 1 desc limit 10;
 C1: drop table t;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/p_delete_online_index_04.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/p_delete_online_index_04.ctl
@@ -13,6 +13,7 @@ C3: set transaction isolation level read committed;
 C1: drop table if exists t;
 C1: create table t(id bigint primary key,col char(5000)) PARTITION BY RANGE (id) (PARTITION before_600 VALUES LESS THAN (600),PARTITION before_1200 VALUES LESS THAN (1200));
 C1: insert into t select rownum,rownum from db_root connect by level<=1000;
+C1: update statistics on t;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -38,6 +39,7 @@ MC: wait until C3 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t;
 C1: show indexes from t;
 C1: select id,trim(col) from t where col>'4' order by 1 desc limit 10;
 C1: drop table t;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/p_select_online_index_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/p_select_online_index_01.ctl
@@ -16,6 +16,7 @@ C1: insert into t(id,col) select rownum,rownum||'1' from db_root connect by leve
 C1: insert into t(id,col) select rownum,rownum||'9' from db_root connect by level<=10;
 C1: insert into t(id,col) select rownum,rownum||'6' from db_root connect by level<=10;
 C1: insert into t(id,col) select rownum,rownum||'3' from db_root connect by level<=10;
+C1: update statistics on t;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -41,6 +42,7 @@ MC: wait until C3 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t;
 C1: show indexes from t;
 C1: select /*+ recompile */id,trim(col),col1,col2,col3,col4,col5,col6,col7 from t where id >0 and col!='a' and col1 is not null using index idx1(+) ;
 C1: select /*+ recompile */ id,trim(col),col1,col2,col3,col4,col5,col6,col7 from t where id >0 and col!='a' and col1 is not null using index none order by 1 ;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/p_select_online_index_02.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/p_select_online_index_02.ctl
@@ -17,6 +17,7 @@ C1: insert into t select rownum,rownum||'9' from db_root connect by level<=10;
 C1: insert into t select rownum,rownum||'6' from db_root connect by level<=10;
 C1: insert into t select rownum,rownum||'3' from db_root connect by level<=10;
 C1: insert into t values(20,null);
+C1: update statistics on t;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -42,6 +43,7 @@ MC: wait until C3 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t;
 C1: show indexes from t;
 C1: select id,trim(col) from t where id >0 and col!='a' using index idx1(+);
 C1: drop table t;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/p_update_online_function_index_02.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/p_update_online_function_index_02.ctl
@@ -26,6 +26,8 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
+C1: update statistics on t2;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 MC: wait until C2 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/p_update_online_function_index_03.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/p_update_online_function_index_03.ctl
@@ -26,6 +26,8 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
+C1: update statistics on t2;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 MC: wait until C2 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/p_update_online_function_index_09.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/p_update_online_function_index_09.ctl
@@ -14,6 +14,7 @@ C1: create table t1(stu_id int primary key, stu_name varchar(30));
 C1: insert into t1 values(1,'james'),(4,'mikey'),(8,'lucy'),(-8,'un');
 C1: create table t2(class_id bigint, class_name varchar(10),stu_id int, col1 date default '1999-01-01', col2 datetime default '1999-01-01 13:00:00',col3 timestamp default '1999-01-01 13:00:00', col4 time default '08:00:00', col5 char(1000) ) partition by range(class_id)(partition p1 values less than (2),partition p2 values less than MAXVALUE);
 C1: insert into t2(class_id,class_name,stu_id) values(1,'math',4),(1,'math',8),(2,'english',1),(2,'english',4),(3,'history',1),(3,'history',8),(4,'art',-8);
+C1: update statistics on t2;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -26,6 +27,7 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 MC: wait until C2 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/p_update_online_function_index_11.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/p_update_online_function_index_11.ctl
@@ -14,6 +14,7 @@ C1: create table t1(stu_id int primary key, stu_name varchar(30));
 C1: insert into t1 values(1,'james'),(4,'mikey'),(8,'lucy'),(-8,'un');
 C1: create table t2(class_id bigint, class_name varchar(10),stu_id int, col1 date default '1999-01-01', col2 datetime default '1999-01-01 13:00:00',col3 timestamp default '1999-01-01 13:00:00', col4 time default '08:00:00', col5 char(1000) ) partition by range(class_id)(partition p1 values less than (2),partition p2 values less than (100));
 C1: insert into t2(class_id,class_name,stu_id) values(1,'math',4),(1,'math',8),(2,'english',1),(2,'english',4),(3,'history',1),(3,'history',8),(4,'art',-8);
+C1: update statistics on t2;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -26,6 +27,7 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 MC: wait until C2 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/select_online_index_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/select_online_index_01.ctl
@@ -16,6 +16,7 @@ C1: insert into t select rownum,rownum||'1' from db_root connect by level<=10;
 C1: insert into t select rownum,rownum||'9' from db_root connect by level<=10;
 C1: insert into t select rownum,rownum||'6' from db_root connect by level<=10;
 C1: insert into t select rownum,rownum||'3' from db_root connect by level<=10;
+C1: update statistics on t;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -41,6 +42,7 @@ MC: wait until C3 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t;
 C1: show indexes from t;
 C1: select id,trim(col) from t where id >5 and col!='a' using index idx1(+) order by 1 desc,2 desc;
 C1: drop table t;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/select_online_index_02.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/select_online_index_02.ctl
@@ -17,6 +17,7 @@ C1: insert into t select rownum,rownum||'9' from db_root connect by level<=10;
 C1: insert into t select rownum,rownum||'6' from db_root connect by level<=10;
 C1: insert into t select rownum,rownum||'3' from db_root connect by level<=10;
 C1: insert into t values(20,null);
+C1: update statistics on t;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -61,6 +62,7 @@ MC: wait until C3 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t;
 C1: show indexes from t;
 C1: select id,trim(col) from t where id >5 and col!='a' using index idx1(+) order by 1 desc,2 desc;
 C1: drop table t;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/select_online_index_03.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/select_online_index_03.ctl
@@ -16,6 +16,7 @@ C1: insert into t select rownum,'2008-12-25 10:30:20' from db_root connect by le
 C1: insert into t select rownum+10,'10:30:20' from db_root connect by level<=10;
 C1: insert into t select rownum+20,'09:00:01 AM 01/01/1970' from db_root connect by level<=10;
 C1: insert into t select rownum+30,'1234.567890' from db_root connect by level<=10;
+C1: update statistics on t;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -41,6 +42,7 @@ MC: wait until C3 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t;
 C1: show indexes from t;
 C1: select id,trim(col) from t where id >5 and col!='a' using index idx1(+) order by 1 desc,2 desc;
 C1: drop table t;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/select_online_index_04.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/select_online_index_04.ctl
@@ -13,6 +13,7 @@ C3: set transaction isolation level read committed;
 C1: drop table if exists t;
 C1: create table t(id bigint primary key,col varchar(100));
 C1: insert into t select rownum,rownum from db_root connect by level<=100;
+C1: update statistics on t;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -38,6 +39,7 @@ MC: wait until C3 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t;
 C1: show indexes from t;
 C1: select * from t where id >85 and col!='a' using index idx1(+);
 C1: drop table t;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/select_online_index_05.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/select_online_index_05.ctl
@@ -16,6 +16,7 @@ C1: insert into t select rownum,rownum||'1' from db_root connect by level<=10;
 C1: insert into t select rownum,rownum||'9' from db_root connect by level<=10;
 C1: insert into t select rownum,rownum||'6' from db_root connect by level<=10;
 C1: insert into t select rownum,rownum||'3' from db_root connect by level<=10;
+C1: update statistics on t;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -41,6 +42,7 @@ MC: wait until C3 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t;
 C1: show indexes from t;
 C1: select id,trim(col) from t where id >5 and col!='a' order by 1 desc,2 desc;
 C1: drop table t;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/select_online_index_06.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/select_online_index_06.ctl
@@ -16,6 +16,7 @@ C1: insert into t select rownum,rownum||'1' from db_root connect by level<=10;
 C1: insert into t select rownum,rownum||'9' from db_root connect by level<=10;
 C1: insert into t select rownum,rownum||'6' from db_root connect by level<=10;
 C1: insert into t select rownum,rownum||'3' from db_root connect by level<=10;
+C1: update statistics on t;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -41,6 +42,7 @@ MC: wait until C3 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t;
 C1: show indexes from t;
 C1: select id,trim(col) from t where id >5 and col!='a' order by 1 desc,2 desc;
 C1: drop table t;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/select_online_index_07.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/select_online_index_07.ctl
@@ -16,6 +16,7 @@ C1: insert into t select rownum,rownum||'1' from db_root connect by level<=10;
 C1: insert into t select rownum,rownum||'9' from db_root connect by level<=10;
 C1: insert into t select rownum,rownum||'6' from db_root connect by level<=10;
 C1: insert into t select rownum,rownum||'3' from db_root connect by level<=10;
+C1: update statistics on t;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -41,6 +42,7 @@ MC: wait until C3 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t;
 C1: show indexes from t;
 C1: select id,trim(col) from t where id >5 and col!='a' order by 1 desc,2 desc;
 C1: drop table t;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/select_online_index_08.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/select_online_index_08.ctl
@@ -16,6 +16,7 @@ C1: insert into t select rownum,rownum||'1' from db_root connect by level<=5;
 C1: insert into t select rownum,rownum||'9' from db_root connect by level<=5;
 C1: insert into t select rownum,rownum||'6' from db_root connect by level<=5;
 C1: insert into t select rownum,rownum||'3' from db_root connect by level<=5;
+C1: update statistics on t;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -41,6 +42,7 @@ MC: wait until C3 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t;
 C1: show indexes from t;
 C1: select id,trim(col) from t where id >0 and col!='a' using index idx1(+);
 C1: drop table t;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/select_online_index_09.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/select_online_index_09.ctl
@@ -16,6 +16,7 @@ C1: insert into t select rownum,rownum||'1' from db_root connect by level<=5;
 C1: insert into t select rownum,rownum||'9' from db_root connect by level<=5;
 C1: insert into t select rownum,rownum||'6' from db_root connect by level<=5;
 C1: insert into t select rownum,rownum||'3' from db_root connect by level<=5;
+C1: update statistics on t;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -41,6 +42,7 @@ MC: wait until C3 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t;
 C1: show indexes from t;
 C1: select id,trim(col) from t where TO_BASE64(col)!='a' using index idx1(+) order by 1,2;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_01.ctl
@@ -26,6 +26,8 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
+C1: update statistics on t2;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 MC: wait until C2 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_02.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_02.ctl
@@ -11,6 +11,7 @@ C2: set transaction isolation level read committed;
 C1: drop table if exists t2;
 C1: create table t2(class_id bigint, class_name varchar(10),stu_id int);
 C1: insert into t2 values(1,'math',4),(1,'math',8),(2,'english',1),(2,'english',4),(3,'history',1),(3,'history',8),(4,'art',-8),(5,'aaaaa',-9);
+C1: update statistics on t2;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -22,6 +23,7 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 MC: wait until C2 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_03.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_03.ctl
@@ -26,6 +26,7 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 MC: wait until C2 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_04.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_04.ctl
@@ -26,6 +26,8 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
+C1: update statistics on t2;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 MC: wait until C2 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_05.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_05.ctl
@@ -26,6 +26,8 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
+C1: update statistics on t2;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 MC: wait until C2 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_06.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_06.ctl
@@ -34,10 +34,13 @@ C1: commit;
 MC: wait until C1 ready;
 
 MC: wait until C2 ready;
+C1: update statistics on t2;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 
 MC: wait until C3 ready;
+C3: update statistics on t2;
 C3: show indexes from t2;
 C3: commit;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_07.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_07.ctl
@@ -34,10 +34,13 @@ C1: commit;
 MC: wait until C1 ready;
 
 MC: wait until C2 ready;
+C1: update statistics on t2;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 
 MC: wait until C3 ready;
+C3: update statistics on t2;
 C3: show indexes from t2;
 C3: commit;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_08.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_filter_index_08.ctl
@@ -34,10 +34,13 @@ C1: commit;
 MC: wait until C1 ready;
 
 MC: wait until C2 ready;
+C1: update statistics on t2;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 
 MC: wait until C3 ready;
+C3: update statistics on t2;
 C3: show indexes from t2;
 C3: commit;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_01.ctl
@@ -27,6 +27,8 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
+C1: update statistics on t2;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 MC: wait until C2 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_02.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_02.ctl
@@ -26,6 +26,8 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
+C1: update statistics on t1;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 MC: wait until C2 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_03.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_03.ctl
@@ -26,6 +26,8 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
+C1: update statistics on t2;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 MC: wait until C2 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_04.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_04.ctl
@@ -72,31 +72,39 @@ C1: commit;
 MC: wait until C1 ready;
 
 MC: wait until C2 ready;
+C1: update statistics on t2;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 
 MC: wait until C3 ready;
+C3: update statistics on t2;
 C3: show indexes from t2;
 C3: commit;
 
 MC: wait until C4 ready;
+C4: update statistics on t2;
 C4: show indexes from t2;
 C4: commit;
 
 MC: wait until C5 ready;
+C5: update statistics on t2;
 C5: show indexes from t2;
 C5: commit;
 
 MC: wait until C6 ready;
+C6: update statistics on t2;
 C6: show indexes from t2;
 C6: commit;
 
 MC: wait until C7 ready;
+C7: update statistics on t2;
 C7: show indexes from t2;
 C7: commit;
 
 
 MC: wait until C8 ready;
+C8: update statistics on t2;
 C8: show indexes from t2;
 C8: commit;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_05.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_05.ctl
@@ -31,6 +31,8 @@ C1: commit;
 MC: wait until C1 ready;
 
 MC: wait until C2 ready;
+C1: update statistics on t2;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_06.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_06.ctl
@@ -31,6 +31,8 @@ C1: commit;
 MC: wait until C1 ready;
 
 MC: wait until C2 ready;
+C1: update statistics on t2;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_07.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_07.ctl
@@ -15,6 +15,7 @@ C1: insert into t1 values(1,'james'),(4,'mikey'),(8,'lucy'),(-8,'un');
 C1: create table t2(class_id bigint, class_name varchar(10),stu_id int, constraint foreign key(stu_id) references t1(stu_id));
 C1: insert into t2 values(1,'math',4),(1,'math',8),(2,'english',1),(2,'english',4),(3,'history',1),(3,'history',8),(4,'art',-8);
 C1: alter table t2 add column birty_date datetime default '2000-01-01 00:00:00';
+C1: update statistics on t2;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -27,6 +28,7 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 MC: wait until C2 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_10.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_10.ctl
@@ -27,6 +27,8 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
+C1: update statistics on t2;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 MC: wait until C2 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_index_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_index_01.ctl
@@ -22,6 +22,7 @@ C1: create table t2(id bigint primary key ,col1 varchar(10),col2 int, constraint
 C1: insert into t2 select rownum,'a'||rownum,1 from db_root connect by level<=10;
 C1: insert into t2 select rownum+10,'b'||rownum,2 from db_root connect by level<=10;
 C1: insert into t2 select rownum+20,'c'||rownum,3 from db_root connect by level<=10;
+C1: update statistics on t2;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -56,6 +57,7 @@ MC: wait until C4 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t2;
 C1: show indexes from t2;
 C1: select /*+ recompile */ * from t2 where col1>40 and col2 >3 using index idx_t2_col1_col2(+) order by 2 asc,3 desc,1 desc;
 C1: select /*+ recompile */ * from t2 where col1>40 and col2 >3 using index none order by 2 asc,3 desc,1 desc;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_index_02.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_index_02.ctl
@@ -18,6 +18,7 @@ C1: create table t2(id bigint primary key ,col1 varchar(10),col2 int, constraint
 C1: insert into t2 select rownum,rownum,1 from db_root connect by level<=10;
 C1: insert into t2 select rownum+20,rownum+20,2 from db_root connect by level<=10;
 C1: insert into t2 select rownum+40,rownum+40,3 from db_root connect by level<=10;
+C1: update statistics on t1;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -30,10 +31,12 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 MC: wait until C2 ready;
 C3: create index idx_t1_col1 on t1(col1) with online parallel 2;
+C3: update statistics on t1;
 C3: show indexes from t1;
 C3: commit;
 MC: wait until C3 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_index_03.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_index_03.ctl
@@ -22,6 +22,7 @@ C1: create table t2(id bigint primary key ,col1 varchar(10),col2 int, constraint
 C1: insert into t2 select rownum,'a'||rownum,1 from db_root connect by level<=10;
 C1: insert into t2 select rownum+10,'b'||rownum,2 from db_root connect by level<=10;
 C1: insert into t2 select rownum+20,'c'||rownum,3 from db_root connect by level<=10;
+C1: update statistics on t2;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -56,6 +57,7 @@ MC: wait until C4 ready;
 C2: commit;
 MC: wait until C2 ready;
 
+C1: update statistics on t2;
 C1: show indexes from t2;
 C1: select /*+ recompile */ * from t2 where col1>40 and col2 >3 using index idx_t2_col1_col2(+) order by 2 asc,3 desc,1;
 C1: select /*+ recompile */ * from t2 where col1>40 and col2 >3 using index none order by 2 asc,3 desc,1;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_view_online_index_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_view_online_index_01.ctl
@@ -18,6 +18,7 @@ C1: create table t2(id bigint primary key ,col1 varchar(10),col2 int, constraint
 C1: insert into t2 select rownum,rownum,1 from db_root connect by level<=10;
 C1: insert into t2 select rownum+20,rownum+20,2 from db_root connect by level<=10;
 C1: insert into t2 select rownum+40,rownum+40,3 from db_root connect by level<=10;
+C1: update statistics on t1;
 C1: commit;
 MC: wait until C1 ready;
 
@@ -31,10 +32,12 @@ MC: wait until C2 blocked;
 C1: commit;
 MC: wait until C1 ready;
 MC: wait until C2 ready;
+C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
 MC: wait until C2 ready;
 C3: create index idx_t1_col1 on t1(col1) with online parallel 2;
+C3: update statistics on t1;
 C3: show indexes from t1;
 C3: commit;
 MC: wait until C3 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/create_multiple_index_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/create_multiple_index_01.ctl
@@ -52,6 +52,7 @@ C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1
 C1: select sum(set{a}) into :i1 from t1 force index (i1) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
 C1: select if (:s = :i1, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/create_multiple_index_02.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/create_multiple_index_02.ctl
@@ -52,6 +52,7 @@ MC: wait until C3 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/delete_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/delete_01.ctl
@@ -19,6 +19,7 @@ C3: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS a_tbl;
 C1: CREATE TABLE a_tbl(id INT PRIMARY KEY, charge DOUBLE);
 C1: INSERT INTO a_tbl VALUES (1, 100.0), (2, 150.0), (3, 10000.0);
+C1: update statistics on a_tbl;
 C1: COMMIT;
 MC: wait until C1 ready;
 
@@ -56,6 +57,7 @@ MC: wait until C2 ready;
 C1: select sum(set{id}) into :s from a_tbl ignore index (i) where id > -999 order by 1;
 C1: select sum(set{id}) into :i from a_tbl force index (i) where id > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on a_tbl;
 C1: show index from a_tbl;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/delete_02.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/delete_02.ctl
@@ -61,6 +61,7 @@ MC: wait until C2 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/delete_05_prepare.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/delete_05_prepare.ctl
@@ -64,6 +64,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/delete_05_prepare_rollback.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/delete_05_prepare_rollback.ctl
@@ -64,6 +64,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_01.ctl
@@ -66,6 +66,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_01_rollback.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_01_rollback.ctl
@@ -66,6 +66,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_02.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_02.ctl
@@ -57,6 +57,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_02_rollback.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_02_rollback.ctl
@@ -57,6 +57,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_03.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_03.ctl
@@ -57,6 +57,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_04.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_04.ctl
@@ -67,6 +67,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_04_rollback.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_04_rollback.ctl
@@ -67,6 +67,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_05.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_05.ctl
@@ -56,6 +56,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_delete_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_delete_01.ctl
@@ -67,6 +67,7 @@ MC: wait until C2 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_delete_02.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_delete_02.ctl
@@ -67,6 +67,7 @@ MC: wait until C2 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_delete_03.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_delete_03.ctl
@@ -67,6 +67,7 @@ MC: wait until C2 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_delete_04.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_delete_04.ctl
@@ -74,6 +74,7 @@ MC: wait until C2 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_update_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_update_01.ctl
@@ -67,6 +67,7 @@ MC: wait until C2 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_update_04.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/insert_update_04.ctl
@@ -68,6 +68,7 @@ MC: wait until C2 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/select_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/select_01.ctl
@@ -66,6 +66,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/update_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/update_01.ctl
@@ -59,6 +59,7 @@ C1: select if (:s = :i, 'OK', 'NOK');
 C1: select sum(set{charge}) into :s2 from a_tbl ignore index (i) where id > -999 order by 1;
 C1: select sum(set{charge}) into :i2 from a_tbl force index (i) where id > -999 order by 1;
 C1: select if (:s2 = :i2, 'OK', 'NOK');
+C1: update statistics on a_tbl;
 C1: show index from a_tbl;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/update_02.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/update_02.ctl
@@ -56,6 +56,7 @@ MC: wait until C2 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/update_03.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/update_03.ctl
@@ -56,6 +56,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/update_delete_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/update_delete_01.ctl
@@ -67,6 +67,7 @@ MC: wait until C2 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/update_insert_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/update_insert_01.ctl
@@ -67,6 +67,7 @@ MC: wait until C2 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/create_multiple_index_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/create_multiple_index_01.ctl
@@ -52,6 +52,7 @@ C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1
 C1: select sum(set{a}) into :i1 from t1 force index (i1) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
 C1: select if (:s = :i1, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/create_multiple_index_02.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/create_multiple_index_02.ctl
@@ -52,6 +52,7 @@ MC: wait until C3 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/delete_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/delete_01.ctl
@@ -19,6 +19,7 @@ C3: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS a_tbl;
 C1: CREATE TABLE a_tbl(id INT PRIMARY KEY, charge DOUBLE);
 C1: INSERT INTO a_tbl VALUES (1, 100.0), (2, 150.0), (3, 10000.0);
+C1: update statistics on a_tbl;
 C1: COMMIT;
 MC: wait until C1 ready;
 
@@ -56,6 +57,7 @@ MC: wait until C2 ready;
 C1: select sum(set{id}) into :s from a_tbl ignore index (i) where id > -999 order by 1;
 C1: select sum(set{id}) into :i from a_tbl force index (i) where id > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on a_tbl;
 C1: show index from a_tbl;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/delete_05_prepare.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/delete_05_prepare.ctl
@@ -60,6 +60,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/insert_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/insert_01.ctl
@@ -66,6 +66,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/insert_01_rollback.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/insert_01_rollback.ctl
@@ -66,6 +66,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/insert_02_rollback.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/insert_02_rollback.ctl
@@ -57,6 +57,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/insert_03.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/insert_03.ctl
@@ -57,6 +57,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/insert_04_rollback.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/insert_04_rollback.ctl
@@ -67,6 +67,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/insert_05.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/insert_05.ctl
@@ -56,6 +56,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 C1: select * from t1 order by 1;
 MC: wait until C1 ready;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/insert_delete_02.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/insert_delete_02.ctl
@@ -67,6 +67,7 @@ MC: wait until C2 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/insert_delete_03.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/insert_delete_03.ctl
@@ -67,6 +67,7 @@ MC: wait until C2 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/select_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/select_01.ctl
@@ -66,6 +66,7 @@ MC: wait until C2 ready;
 C1: select sum(set{b}) into :s from t1 ignore index (i) where b > -999 order by 1;
 C1: select sum(set{b}) into :i from t1 force index (i) where b > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/update_01.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/update_01.ctl
@@ -59,6 +59,7 @@ C1: select if (:s = :i, 'OK', 'NOK');
 C1: select sum(set{charge}) into :s2 from a_tbl ignore index (i) where id > -999 order by 1;
 C1: select sum(set{charge}) into :i2 from a_tbl force index (i) where id > -999 order by 1;
 C1: select if (:s2 = :i2, 'OK', 'NOK');
+C1: update statistics on a_tbl;
 C1: show index from a_tbl;
 MC: wait until C1 ready;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/update_02.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/update_02.ctl
@@ -56,6 +56,7 @@ MC: wait until C2 ready;
 C1: select sum(set{a}) into :s from t1 ignore index (i) where a > -999 order by 1;
 C1: select sum(set{a}) into :i from t1 force index (i) where a > -999 order by 1;
 C1: select if (:s = :i, 'OK', 'NOK');
+C1: update statistics on t1;
 C1: show index from t1;
 MC: wait until C1 ready;
 


### PR DESCRIPTION
Backport #1338, #1402

isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_04.answer
Conflict occurred due to #1249 in the above answer sheet, and it has been resolved.

Backport #1495
_02_RepeatableRead/foreign_key_column/truncate_insert_01.ctl is a test case that requires modification only on 11.0 because CBRD-23916 has been applied since 11.1