### PR TITLE
[CBRD-24798] Modifying test cases due to a specification change in the 'ALTER INDEX ~REBUILD' statement.

### DIFF
--- a/isolation/_01_ReadCommitted/catalog/db_index_03.ctl
+++ b/isolation/_01_ReadCommitted/catalog/db_index_03.ctl
@@ -33,7 +33,7 @@ C1: commit;
 /* test case */
 C1: rename table tb1 as tb1_rename;
 MC: wait until C1 ready;
-C2: alter index i_tb2_id_col on tb2(id, col DESC) REBUILD;
+C2: alter index i_tb2_id_col on tb2 REBUILD;
 MC: wait until C2 ready;
 
 C3: select * from db_index where class_name like 'tb%';
@@ -48,7 +48,7 @@ MC: wait until C3 ready;
 
 C1: alter table tb2 add constraint fk_id_col foreign key (id,col) references t1 (id,col);
 MC: wait until C1 ready;
-C2: alter index i_tb2_id_col on tb2(id, email) REBUILD;
+C2: alter index i_tb2_id_col on tb2 REBUILD;
 MC: wait until C2 blocked;
 
 C3: select * from db_index where class_name like 'tb%';

--- a/isolation/_01_ReadCommitted/catalog/db_index_05.ctl
+++ b/isolation/_01_ReadCommitted/catalog/db_index_05.ctl
@@ -32,7 +32,7 @@ C1: insert into tb2 values(1,'abcdefg',100,'sda');
 C1: commit;
 
 /* test case */
-C2: alter index i_tb2_id_col on tb2(id, col DESC) REBUILD;
+C2: alter index i_tb2_id_col on tb2 REBUILD;
 MC: wait until C1 ready;
 C3: alter table tb1 drop constraint pk_tb1_id_col;
 MC: wait until C2 ready;
@@ -47,7 +47,7 @@ C1: select * from db_index where class_name like 'tb%';
 C1: commit;
 MC: wait until C1 ready;
 
-C2: alter index i_tb2_id_col on tb2(id, email) REBUILD;
+C2: alter index i_tb2_id_col on tb2 REBUILD;
 MC: wait until C2 ready;
 C3: drop index i_tb2_id_col on tb2;
 MC: wait until C3 blocked;

--- a/isolation/_01_ReadCommitted/catalog/db_index_key_03.ctl
+++ b/isolation/_01_ReadCommitted/catalog/db_index_key_03.ctl
@@ -33,7 +33,7 @@ C1: commit;
 /* test case */
 C1: rename table tb1 as tb1_rename;
 MC: wait until C1 ready;
-C2: alter index i_tb2_id_col on tb2(id, col DESC) REBUILD;
+C2: alter index i_tb2_id_col on tb2 REBUILD;
 MC: wait until C2 ready;
 
 C3: select * from db_index_key where class_name like 'tb%';
@@ -48,7 +48,7 @@ MC: wait until C3 ready;
 
 C1: alter table tb2 add constraint fk_id_col foreign key (id,col) references t1 (id,col);
 MC: wait until C1 ready;
-C2: alter index i_tb2_id_col on tb2(id, email) REBUILD;
+C2: alter index i_tb2_id_col on tb2 REBUILD;
 MC: wait until C2 blocked;
 
 C3: select * from db_index_key where class_name like 'tb%';

--- a/isolation/_01_ReadCommitted/catalog/db_index_key_05.ctl
+++ b/isolation/_01_ReadCommitted/catalog/db_index_key_05.ctl
@@ -33,7 +33,7 @@ C1: commit;
 MC: wait until C1 ready;
 
 /* test case */
-C2: alter index i_tb2_id_col on tb2(id, col DESC) REBUILD;
+C2: alter index i_tb2_id_col on tb2 REBUILD;
 MC: wait until C1 ready;
 C3: alter table tb1 drop constraint pk_tb1_id_col;
 MC: wait until C2 ready;
@@ -48,7 +48,7 @@ C1: select * from db_index_key where class_name like 'tb%';
 C1: commit;
 MC: wait until C1 ready;
 
-C2: alter index i_tb2_id_col on tb2(id, email) REBUILD;
+C2: alter index i_tb2_id_col on tb2 REBUILD;
 MC: wait until C2 ready;
 C3: drop index i_tb2_id_col on tb2;
 MC: wait until C3 blocked;

--- a/isolation/_02_RepeatableRead/catalog/db_index_03.ctl
+++ b/isolation/_02_RepeatableRead/catalog/db_index_03.ctl
@@ -33,7 +33,7 @@ C1: commit;
 /* test case */
 C1: rename table tb1 as tb1_rename;
 MC: wait until C1 ready;
-C2: alter index i_tb2_id_col on tb2(id, col DESC) REBUILD;
+C2: alter index i_tb2_id_col on tb2 REBUILD;
 MC: wait until C2 ready;
 
 C3: select * from db_index where class_name like 'tb%' order by 1,2,3,4;
@@ -50,7 +50,7 @@ MC: wait until C3 ready;
 
 C1: alter table tb2 add constraint fk_id_col foreign key (id,col) references t1 (id,col);
 MC: wait until C1 ready;
-C2: alter index i_tb2_id_col on tb2(id, email) REBUILD;
+C2: alter index i_tb2_id_col on tb2 REBUILD;
 MC: wait until C2 blocked;
 
 C3: select * from db_index where class_name like 'tb%' order by 1,2,3,4;

--- a/isolation/_02_RepeatableRead/catalog/db_index_05.ctl
+++ b/isolation/_02_RepeatableRead/catalog/db_index_05.ctl
@@ -32,7 +32,7 @@ C1: insert into tb2 values(1,'abcdefg',100,'sda');
 C1: commit;
 
 /* test case */
-C2: alter index i_tb2_id_col on tb2(id, col DESC) REBUILD;
+C2: alter index i_tb2_id_col on tb2 REBUILD;
 MC: wait until C1 ready;
 C3: alter table tb1 drop constraint pk_tb1_id_col;
 MC: wait until C2 ready;
@@ -49,7 +49,7 @@ C1: select * from db_index where class_name like 'tb%' order by 1,2,3,4;
 C1: commit;
 MC: wait until C1 ready;
 
-C2: alter index i_tb2_id_col on tb2(id, email) REBUILD;
+C2: alter index i_tb2_id_col on tb2 REBUILD;
 MC: wait until C2 ready;
 C3: drop index i_tb2_id_col on tb2;
 MC: wait until C3 blocked;

--- a/isolation/_02_RepeatableRead/catalog/db_index_key_03.ctl
+++ b/isolation/_02_RepeatableRead/catalog/db_index_key_03.ctl
@@ -33,7 +33,7 @@ C1: commit;
 /* test case */
 C1: rename table tb1 as tb1_rename;
 MC: wait until C1 ready;
-C2: alter index i_tb2_id_col on tb2(id, col DESC) REBUILD;
+C2: alter index i_tb2_id_col on tb2 REBUILD;
 MC: wait until C2 ready;
 
 C3: select * from db_index_key where class_name like 'tb%';
@@ -50,7 +50,7 @@ MC: wait until C3 ready;
 
 C1: alter table tb2 add constraint fk_id_col foreign key (id,col) references t1 (id,col);
 MC: wait until C1 ready;
-C2: alter index i_tb2_id_col on tb2(id, email) REBUILD;
+C2: alter index i_tb2_id_col on tb2 REBUILD;
 MC: wait until C2 blocked;
 
 C3: select * from db_index_key where class_name like 'tb%';

--- a/isolation/_02_RepeatableRead/catalog/db_index_key_05.ctl
+++ b/isolation/_02_RepeatableRead/catalog/db_index_key_05.ctl
@@ -32,7 +32,7 @@ C1: insert into tb2 values(1,'abcdefg',100,'sda');
 C1: commit;
 
 /* test case */
-C2: alter index i_tb2_id_col on tb2(id, col DESC) REBUILD;
+C2: alter index i_tb2_id_col on tb2 REBUILD;
 MC: wait until C1 ready;
 C3: alter table tb1 drop constraint pk_tb1_id_col;
 MC: wait until C2 ready;
@@ -49,7 +49,7 @@ C1: select * from db_index_key where class_name like 'tb%';
 C1: commit;
 MC: wait until C1 ready;
 
-C2: alter index i_tb2_id_col on tb2(id, email) REBUILD;
+C2: alter index i_tb2_id_col on tb2 REBUILD;
 MC: wait until C2 ready;
 C3: drop index i_tb2_id_col on tb2;
 MC: wait until C3 blocked;


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-24798

Only the following two forms are supported when using REBUILD:
```
ALTER INDEX <index-name> ON <table-name> REBUID;
ALTER INDEX <index-name> ON <table-name> COMMENT 'new comment' REBUID;
```
Therefore, the column list following ON <table-name> in the test cases is removed