### PR TITLE
[CBRD-24832] specifying appropriate precision and scale of NUMERIC types in 6 TCs

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_02_using_clause/answers/03_04_02-04_error_arg_type_mismatch.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_02_using_clause/answers/03_04_02-04_error_arg_type_mismatch.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1359
 In line 4, column 85
-Stored procedure compile error: expressions in a USING clause cannot be of either BOOLEAN or SYS_REFCURSOR type
+Stored procedure compile error: expressions in a USING clause cannot be of either BOOLEAN, CURSOR or SYS_REFCURSOR type
 
 ===================================================
 sp_name    sp_type    return_type    arg_count    lang    target    owner    comment    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-04_error_incompatible_used_val.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-04_error_incompatible_used_val.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1359
 In line 3, column 82
-Stored procedure compile error: expressions in a USING clause cannot be of either BOOLEAN or SYS_REFCURSOR type
+Stored procedure compile error: expressions in a USING clause cannot be of either BOOLEAN, CURSOR or SYS_REFCURSOR type
 
 ===================================================
 sp_name    sp_type    return_type    arg_count    lang    target    owner    comment    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_01_literal/_05_unsigned_int/cases/04_01_05-01_normal_basic.sql
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_01_literal/_05_unsigned_int/cases/04_01_05-01_normal_basic.sql
@@ -4,7 +4,7 @@
 
 
 create or replace procedure t(j int) as
-    bbi numeric := 99999999999999999999999999999999999999;
+    bbi numeric(38) := 99999999999999999999999999999999999999;
     bi bigint := 9223372036854775807;
     bi2 bigint := -9223372036854775808;
     i int := 2147483647;

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_15_arithmetic_binary_op/_01_mult/cases/04_15_01-01_normal_basic_numeric.sql
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_15_arithmetic_binary_op/_01_mult/cases/04_15_01-01_normal_basic_numeric.sql
@@ -4,8 +4,8 @@
 
 
 create or replace procedure t(i int) as
-    a numeric := 3.5;
-    b numeric := 5.7;
+    a numeric(2, 1) := 3.5;
+    b numeric(2, 1) := 5.7;
 begin
     dbms_output.put_line(a * b);
     dbms_output.put_line(null * b);

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_15_arithmetic_binary_op/_05_add/cases/04_15_05-01_normal_basic_numeric.sql
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_15_arithmetic_binary_op/_05_add/cases/04_15_05-01_normal_basic_numeric.sql
@@ -4,8 +4,8 @@
 
 
 create or replace procedure t(i int) as
-    a numeric := 3.5;
-    b numeric := 5.7;
+    a numeric(2, 1) := 3.5;
+    b numeric(2, 1) := 5.7;
 begin
     dbms_output.put_line(a + b);
     dbms_output.put_line(null + b);

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_15_arithmetic_binary_op/_06_subtract/cases/04_15_06-01_normal_basic_numeric.sql
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_15_arithmetic_binary_op/_06_subtract/cases/04_15_06-01_normal_basic_numeric.sql
@@ -4,8 +4,8 @@
 
 
 create or replace procedure t(i int) as
-    a numeric := 3.5;
-    b numeric := 5.7;
+    a numeric(2, 1) := 3.5;
+    b numeric(2, 1) := 5.7;
 begin
     dbms_output.put_line(a - b);
     dbms_output.put_line(null - b);

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_16_arithmetic_unary_op/_01_plus/cases/04_16_01-01_normal_basic_numeric.sql
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_16_arithmetic_unary_op/_01_plus/cases/04_16_01-01_normal_basic_numeric.sql
@@ -4,8 +4,8 @@
 
 
 create or replace procedure t(i int) as
-    a numeric := 3.5;
-    b numeric := +a;
+    a numeric(2, 1) := 3.5;
+    b numeric(2, 1) := +a;
 begin
     dbms_output.put_line(a);
     dbms_output.put_line(b);

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_16_arithmetic_unary_op/_02_minus/cases/04_16_02-01_normal_basic_numeric.sql
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_16_arithmetic_unary_op/_02_minus/cases/04_16_02-01_normal_basic_numeric.sql
@@ -4,8 +4,8 @@
 
 
 create or replace procedure t(i int) as
-    a numeric := 3.5;
-    b numeric := -a;
+    a numeric(2, 1) := 3.5;
+    b numeric(2, 1) := -a;
 begin
     dbms_output.put_line(a);
     dbms_output.put_line(b);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24832

- CUBRID feature/plcsql branch has been updated to take precision and scale of NUMERIC type into account. 
  - Before the last commit, it ignored the precision and scale specifications and took NUMERIC types as if they have arbitrary precison and scale