### PR TITLE
[CBRD-25135] allow duplicate column names in a select list

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/answers/03_02_01-08_normal_dup_column_name.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/answers/03_02_01-08_normal_dup_column_name.answer
@@ -1,13 +1,13 @@
 ===================================================
-Error:-1360
-In line 5, column 1
-Stored procedure compile error: more than one columns have the same name 'X' in the SELECT list
+0
 
 ===================================================
 sp_name    sp_type    return_type    arg_count    lang    target    owner    comment    
+t     PROCEDURE     void     1     JAVA     Proc_T.T(java.lang.Integer)     DBA     null     
 
 
 ===================================================
 sp_name    index_of    arg_name    data_type    mode    comment    
+t     0     k     INTEGER     IN     null     
 
 

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-08_normal_dup_column_name.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-08_normal_dup_column_name.sql
@@ -1,7 +1,5 @@
 --+ server-message on
 
--- error: column name duplicates in the select list
-
 create or replace procedure t(k int) as
     i int;
     s string;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25135

. dumplicate column names in PL/CSQL Static SQL SELECT were error, but now they are not.