### PR TITLE
[CBRD-25077] Revise testcases not to select pkg_name

### DIFF
--- a/sql/_13_issues/_23_1h/cases/cbrd_24419.sql
+++ b/sql/_13_issues/_23_1h/cases/cbrd_24419.sql
@@ -508,8 +508,8 @@ select * from db_auth where class_name in (select class_name from db_class where
 select * from db_index where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
-select * from db_stored_procedure order by sp_name;
-select * from db_stored_procedure_args order by sp_name;
+select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg_setdomain_elm order by owner_name, class_name, meth_name;
@@ -531,8 +531,8 @@ select * from db_auth where class_name in (select class_name from db_class where
 select * from db_index where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
-select * from db_stored_procedure order by sp_name;
-select * from db_stored_procedure_args order by sp_name;
+select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg_setdomain_elm order by owner_name, class_name, meth_name;
@@ -554,8 +554,8 @@ select * from db_auth where class_name in (select class_name from db_class where
 select * from db_index where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
-select * from db_stored_procedure order by sp_name;
-select * from db_stored_procedure_args order by sp_name;
+select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg_setdomain_elm order by owner_name, class_name, meth_name;
@@ -577,8 +577,8 @@ select * from db_auth where class_name in (select class_name from db_class where
 select * from db_index where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
-select * from db_stored_procedure order by sp_name;
-select * from db_stored_procedure_args order by sp_name;
+select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg_setdomain_elm order by owner_name, class_name, meth_name;
@@ -600,8 +600,8 @@ select * from db_auth where class_name in (select class_name from db_class where
 select * from db_index where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
-select * from db_stored_procedure order by sp_name;
-select * from db_stored_procedure_args order by sp_name;
+select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg_setdomain_elm order by owner_name, class_name, meth_name;
@@ -623,8 +623,8 @@ select * from db_auth where class_name in (select class_name from db_class where
 select * from db_index where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
-select * from db_stored_procedure order by sp_name;
-select * from db_stored_procedure_args order by sp_name;
+select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg_setdomain_elm order by owner_name, class_name, meth_name;
@@ -646,8 +646,8 @@ select * from db_auth where class_name in (select class_name from db_class where
 select * from db_index where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
-select * from db_stored_procedure order by sp_name;
-select * from db_stored_procedure_args order by sp_name;
+select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg_setdomain_elm order by owner_name, class_name, meth_name;
@@ -669,8 +669,9 @@ select * from db_auth where class_name in (select class_name from db_class where
 select * from db_index where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
-select * from db_stored_procedure order by sp_name;
-select * from db_stored_procedure_args order by sp_name;
+select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
+
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg_setdomain_elm order by owner_name, class_name, meth_name;
@@ -692,8 +693,9 @@ select * from db_auth where class_name in (select class_name from db_class where
 select * from db_index where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
-select * from db_stored_procedure order by sp_name;
-select * from db_stored_procedure_args order by sp_name;
+select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
+
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg_setdomain_elm order by owner_name, class_name, meth_name;
@@ -715,8 +717,9 @@ select * from db_auth where class_name in (select class_name from db_class where
 select * from db_index where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
-select * from db_stored_procedure order by sp_name;
-select * from db_stored_procedure_args order by sp_name;
+select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
+
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg_setdomain_elm order by owner_name, class_name, meth_name;

--- a/sql/_13_issues/_23_1h/cases/cbrd_24419.sql
+++ b/sql/_13_issues/_23_1h/cases/cbrd_24419.sql
@@ -509,7 +509,7 @@ select * from db_index where class_name in (select class_name from db_class wher
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
 select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
-select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name, index_of;
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg_setdomain_elm order by owner_name, class_name, meth_name;
@@ -532,7 +532,7 @@ select * from db_index where class_name in (select class_name from db_class wher
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
 select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
-select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name, index_of;
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg_setdomain_elm order by owner_name, class_name, meth_name;
@@ -555,7 +555,7 @@ select * from db_index where class_name in (select class_name from db_class wher
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
 select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
-select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name, index_of;
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg_setdomain_elm order by owner_name, class_name, meth_name;
@@ -578,7 +578,7 @@ select * from db_index where class_name in (select class_name from db_class wher
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
 select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
-select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name, index_of;
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg_setdomain_elm order by owner_name, class_name, meth_name;
@@ -601,7 +601,7 @@ select * from db_index where class_name in (select class_name from db_class wher
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
 select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
-select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name, index_of;
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg_setdomain_elm order by owner_name, class_name, meth_name;
@@ -624,7 +624,7 @@ select * from db_index where class_name in (select class_name from db_class wher
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
 select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
-select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name, index_of;
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg_setdomain_elm order by owner_name, class_name, meth_name;
@@ -647,7 +647,7 @@ select * from db_index where class_name in (select class_name from db_class wher
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
 select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
-select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name, index_of;
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg_setdomain_elm order by owner_name, class_name, meth_name;
@@ -670,7 +670,7 @@ select * from db_index where class_name in (select class_name from db_class wher
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
 select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
-select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name, index_of;
 
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
@@ -694,7 +694,7 @@ select * from db_index where class_name in (select class_name from db_class wher
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
 select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
-select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name, index_of;
 
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
@@ -718,7 +718,7 @@ select * from db_index where class_name in (select class_name from db_class wher
 select * from db_index_key where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, index_name;
 select * from db_trig order by owner_name, trigger_name;
 select sp_name, sp_type, return_type, arg_count, lang, target, owner, comment from db_stored_procedure order by sp_name;
-select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name;
+select sp_name, index_of, arg_name, data_type, mode, comment from db_stored_procedure_args order by sp_name, index_of;
 
 select * from db_method where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;
 select * from db_meth_arg where class_name in (select class_name from db_class where is_system_class = 'NO') order by owner_name, class_name, meth_name;


### PR DESCRIPTION
http://jira.cubrid.org//browse/CBRD-25077

`pkg_name` is added in db_stored_procedure catalog by CBRD-25077, an error occurs. By specifying the columns in the testcase, I'd like to resove the regression.

Refer to the https://app.circleci.com/pipelines/github/CUBRID/cubrid/12393/workflows/4b363482-bf49-4c2c-9ea8-7d5332030a50/jobs/65810/parallel-runs/3?filterBy=FAILED