### PR TITLE
[CBRD-25075] Fix unstable testcase caused by order by is omitted

### DIFF
--- a/medium/_01_fixed/cases/fview2.sql
+++ b/medium/_01_fixed/cases/fview2.sql
@@ -4,5 +4,6 @@ autocommit off;
    from all joe.inventory_v i, joe.shipment_v s
   where i.location = s.origin
     and i.product_code = s.product_code
-    and i.shipment_pending = 'yes';
+    and i.shipment_pending = 'yes'
+  order by i.product_code;
 rollback;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25075

The following unstable case is found at https://github.com/CUBRID/cubrid/pull/4927
```
** Testcase : medium/_01_fixed/cases/fview2.sql (has 2 queries) - https://github.com/CUBRID/cubrid-testcases/blob/6837fa3cd1dd21f04c92a5f5b3394dabaaaabf74/medium/_01_fixed/cases/fview2.sql
** Expected : medium/_01_fixed/answers/fview2.answer - https://github.com/CUBRID/cubrid-testcases/blob/6837fa3cd1dd21f04c92a5f5b3394dabaaaabf74/medium/_01_fixed/answers/fview2.answer
** Failed query #1 (in fview2.sql):
 select i.product_code, descr, location,
        ((i.quantity - s.quantity)*price)
   from all joe.inventory_v i, joe.shipment_v s
  where i.location = s.origin
    and i.product_code = s.product_code
    and i.shipment_pending = 'yes';
** Difference between Expected(-) and Actual(+) results:
@@ -1,5 +1,5 @@
 ===================================================
 product_code    descr    location    ((i.quantity-s.quantity)*price)    
-2     roue     marseilles     1875000.0     
 4     arriere aile     paris     50000.0     
+2     roue     marseilles     1875000.0     
```