### PR TITLE
[CBRD-23768] Unnecessary row X-LOCK is set depending on the plan

### DIFF
--- a/isolation/_01_ReadCommitted/function/counter_function/delete_delete_rownum_01.ctl
+++ b/isolation/_01_ReadCommitted/function/counter_function/delete_delete_rownum_01.ctl
@@ -49,7 +49,7 @@ MC: wait until C1 ready;
 
 C2: DELETE FROM t1 WHERE ROWNUM < 3; 
 /* expect: no transactions need to wait */
-MC: wait until C2 blocked;
+MC: wait until C1 ready;
 
 /* expect: C1 2 rows are deleted */
 C1: SELECT count(*) FROM t1;


### PR DESCRIPTION
change from MC: wait until C2 blocked; to MC: wait until C1 ready;

Refer to: http://jira.cubrid.org/browse/CBRD-23768
