### PR TITLE
[CBRD-23768] Unnecessary row X-LOCK is set depending on the plan 

### DIFF
--- a/isolation/_01_ReadCommitted/function/counter_function/delete_delete_rownum_01.ctl
+++ b/isolation/_01_ReadCommitted/function/counter_function/delete_delete_rownum_01.ctl
@@ -49,7 +49,7 @@ MC: wait until C1 ready;
 
 C2: DELETE FROM t1 WHERE ROWNUM < 3; 
 /* expect: no transactions need to wait */
-MC: wait until C2 blocked;
+MC: wait until C1 ready;
 
 /* expect: C1 2 rows are deleted */
 C1: SELECT count(*) FROM t1;

--- a/isolation/_01_ReadCommitted/partition_table/join/insert_update_09.ctl
+++ b/isolation/_01_ReadCommitted/partition_table/join/insert_update_09.ctl
@@ -52,7 +52,7 @@ MC: wait until C1 ready;
 C2: update (t1 left join t2 on t1.id = t2.id) RIGHT join t3 on t1.numid = t3.valueid set t1.col=t1.col+' a', t3.valueid=t1.numid where t1.id=2 and t1.numid=0 and t1.col is not null;
 MC: wait until C2 ready;
 C1: insert into t3(valueid, str) SELECT a.id, a.col+'xx' FROM t1 a LEFT JOIN t2 b ON a.id = b.id WHERE b.id >1 and b.id <7;
-MC: wait until C1 blocked;
+MC: wait until C1 ready;
 C2: COMMIT;
 MC: wait until C1 ready;
 C2: SELECT * FROM t1 order by 1,2;

--- a/isolation/_01_ReadCommitted/partition_table/join/insert_update_10.ctl
+++ b/isolation/_01_ReadCommitted/partition_table/join/insert_update_10.ctl
@@ -49,7 +49,7 @@ MC: wait until C1 ready;
 C2: update (t1 left join t2 on t1.id = t2.id) RIGHT join t3 on t1.numid = t3.valueid set t1.col=t1.col+' a', t3.valueid=t1.numid where t1.id=2 and t1.numid=0 and t1.col is not null;
 MC: wait until C2 ready;
 C1: insert into t3(valueid, str) SELECT a.id, a.col+'xx' FROM t1 a INNER JOIN t2 b ON a.id = b.id WHERE b.id >1 and b.id <7;
-MC: wait until C1 blocked;
+MC: wait until C1 ready;
 C2: COMMIT;
 MC: wait until C1 ready;
 C2: SELECT * FROM t1 order by 1,2;


### PR DESCRIPTION
Change MC: wait until C1 blocked; to MC: wait until C1 ready; 

Refer to: http://jira.cubrid.org/browse/CBRD-23768
