### PR TITLE
[CBRD-25098] Add new test case for problem where inst_num() is inappropriately changed to order_by_num() when a subquery containing an ORDER BY is view merged

### DIFF
--- a/sql/_13_issues/_24_1h/answers/cbrd_25098.answer
+++ b/sql/_13_issues/_24_1h/answers/cbrd_25098.answer
@@ -5,7 +5,7 @@
 ===================================================
 3
 ===================================================
-col2    col3    orderby_num()    scala col1    
+col_two    col_three    orderby_num()    scala col_one    
 1     1     1     1     
 
 Query plan:
@@ -16,22 +16,22 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-(select ?, tbl.col? from tbl tbl order by ? for orderby_num()<= ?:? )
+(select ?, tbl.col_one from tbl tbl order by ? for orderby_num()<= ?:? )
 Query plan:
 sscan
     class: d? node[?]
     cost:  ? card ?
 Query stmt:
-(select d?.a_? from ((select ?, tbl.col? from tbl tbl order by ? for orderby_num()<= ?:? ) as [scala col?]) d? (a_?, col?))
+(select d?.a_? from ((select ?, tbl.col_one from tbl tbl order by ? for orderby_num()<= ?:? ) as [scala col_one]) d? (a_?, col_one))
 Query plan:
 sscan
     class: tbl node[?]
     sargs: term[?] AND term[?]
     cost:  ? card ?
 Query stmt:
-select tbl.col?, tbl.col?, (inst_num()), (select d?.a_? from ((select ?, tbl.col? from tbl tbl order by ? for orderby_num()<= ?:? ) as [scala col?]) d? (a_?, col?)) from tbl tbl where tbl.col?= ?:?  and (inst_num())<= ?:? 
+select tbl.col_two, tbl.col_three, (inst_num()), (select d?.a_? from ((select ?, tbl.col_one from tbl tbl order by ? for orderby_num()<= ?:? ) as [scala col_one]) d? (a_?, col_one)) from tbl tbl where tbl.col_two= ?:?  and (inst_num())<= ?:? 
 ===================================================
-col2    col3    orderby_num()    scala col1    
+col_two    col_three    orderby_num()    scala col_one    
 1     1     1     1     
 
 Query plan:
@@ -42,13 +42,13 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-(select tbl.col?, tbl.col? from tbl tbl order by ? for orderby_num()<= ?:? )
+(select tbl.col_two, tbl.col_one from tbl tbl order by ? for orderby_num()<= ?:? )
 Query plan:
 sscan
     class: d? node[?]
     cost:  ? card ?
 Query stmt:
-(select d?.col? from ((select tbl.col?, tbl.col? from tbl tbl order by ? for orderby_num()<= ?:? ) as [scala col?]) d? (col?, col?))
+(select d?.col_two from ((select tbl.col_two, tbl.col_one from tbl tbl order by ? for orderby_num()<= ?:? ) as [scala col_one]) d? (col_two, col_one))
 Query plan:
 temp(group by)
     subplan: sscan
@@ -58,7 +58,7 @@ temp(group by)
     sort:  
     cost:  ? card ?
 Query stmt:
-select tbl.col?, tbl.col?, groupby_num(), (select d?.col? from ((select tbl.col?, tbl.col? from tbl tbl order by ? for orderby_num()<= ?:? ) as [scala col?]) d? (col?, col?)), tbl.col? from tbl tbl where tbl.col?= ?:?  group by tbl.col?, tbl.col?
+select tbl.col_two, tbl.col_three, groupby_num(), (select d?.col_two from ((select tbl.col_two, tbl.col_one from tbl tbl order by ? for orderby_num()<= ?:? ) as [scala col_one]) d? (col_two, col_one)), tbl.col_one from tbl tbl where tbl.col_one= ?:?  group by tbl.col_one, tbl.col_two
 ===================================================
 0
 ===================================================
@@ -79,11 +79,11 @@ rownum    test
 
 Query plan:
 sscan
-    class: tbl? node[?]
+    class: tbl_two node[?]
     sargs: term[?] AND term[?]
     cost:  ? card ?
 Query stmt:
-(select tbl?.col? from tbl? tbl? where tbl?.col?=X.col? and (rownum= ?:? ))
+(select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=X.col_one and (rownum= ?:? ))
 Query plan:
 temp(order by)
     subplan: sscan
@@ -92,7 +92,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select (orderby_num()), (select tbl?.col? from tbl? tbl? where tbl?.col?=X.col? and (rownum= ?:? )), X.col? from tbl? X order by ?
+select (orderby_num()), (select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=X.col_one and (rownum= ?:? )), X.col_one from tbl_one X order by ?
 ===================================================
 rownum    test    
 1     1     
@@ -101,20 +101,20 @@ rownum    test
 
 Query plan:
 sscan
-    class: tbl? node[?]
+    class: tbl_two node[?]
     sargs: term[?] AND term[?]
     cost:  ? card ?
 Query stmt:
-(select tbl?.col? from tbl? tbl? where tbl?.col?=a_? and (rownum= ?:? ))
+(select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=a_? and (rownum= ?:? ))
 Query plan:
 temp(group by)
     subplan: sscan
-                 class: t? node[?]
+                 class: t_one node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-(select t?.col? from tbl? t? group by t?.col?)
+(select t_one.col_one from tbl_one t_one group by t_one.col_one)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -123,6 +123,6 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select (orderby_num()), (select tbl?.col? from tbl? tbl? where tbl?.col?=a_? and (rownum= ?:? )), a_? from (select t?.col? from tbl? t? group by t?.col?) X (a_?) order by ?
+select (orderby_num()), (select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=a_? and (rownum= ?:? )), a_? from (select t_one.col_one from tbl_one t_one group by t_one.col_one) X (a_?) order by ?
 ===================================================
 0

--- a/sql/_13_issues/_24_1h/answers/cbrd_25098.answer
+++ b/sql/_13_issues/_24_1h/answers/cbrd_25098.answer
@@ -74,6 +74,28 @@ select tbl.col_two, tbl.col_three, groupby_num(), (select d?.col_two from ((sele
 ===================================================
 rownum    test    
 1     1     
+2     2     
+3     3     
+
+Query plan:
+sscan
+    class: tbl_two node[?]
+    sargs: term[?] AND term[?]
+    cost:  ? card ?
+Query stmt:
+(select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=X.col_one and (rownum= ?:? ))
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: X node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), (select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=X.col_one and (rownum= ?:? )), X.col_one from tbl_one X order by ?
+===================================================
+rownum    test    
+1     1     
 
 Query plan:
 sscan
@@ -91,6 +113,37 @@ temp(order by)
     cost:  ? card ?
 Query stmt:
 select (orderby_num()), (select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=X.col_one and (rownum= ?:? )), X.col_one from tbl_one X order by ? for (orderby_num())<= ?:? 
+===================================================
+rownum    test    
+1     1     
+2     2     
+3     3     
+
+Query plan:
+sscan
+    class: tbl_two node[?]
+    sargs: term[?] AND term[?]
+    cost:  ? card ?
+Query stmt:
+(select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=a_? and (rownum= ?:? ))
+Query plan:
+temp(group by)
+    subplan: sscan
+                 class: t_one node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select t_one.col_one from tbl_one t_one group by t_one.col_one)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: X node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), (select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=a_? and (rownum= ?:? )), a_? from (select t_one.col_one from tbl_one t_one group by t_one.col_one) X (a_?) order by ?
 ===================================================
 rownum    test    
 1     1     

--- a/sql/_13_issues/_24_1h/answers/cbrd_25098.answer
+++ b/sql/_13_issues/_24_1h/answers/cbrd_25098.answer
@@ -1,0 +1,128 @@
+===================================================
+0
+===================================================
+0
+===================================================
+3
+===================================================
+col2    col3    orderby_num()    scala col1    
+1     1     1     1     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: tbl node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select ?, tbl.col? from tbl tbl order by ? for orderby_num()<= ?:? )
+Query plan:
+sscan
+    class: d? node[?]
+    cost:  ? card ?
+Query stmt:
+(select d?.a_? from ((select ?, tbl.col? from tbl tbl order by ? for orderby_num()<= ?:? ) as [scala col?]) d? (a_?, col?))
+Query plan:
+sscan
+    class: tbl node[?]
+    sargs: term[?] AND term[?]
+    cost:  ? card ?
+Query stmt:
+select tbl.col?, tbl.col?, (inst_num()), (select d?.a_? from ((select ?, tbl.col? from tbl tbl order by ? for orderby_num()<= ?:? ) as [scala col?]) d? (a_?, col?)) from tbl tbl where tbl.col?= ?:?  and (inst_num())<= ?:? 
+===================================================
+col2    col3    orderby_num()    scala col1    
+1     1     1     1     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: tbl node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select tbl.col?, tbl.col? from tbl tbl order by ? for orderby_num()<= ?:? )
+Query plan:
+sscan
+    class: d? node[?]
+    cost:  ? card ?
+Query stmt:
+(select d?.col? from ((select tbl.col?, tbl.col? from tbl tbl order by ? for orderby_num()<= ?:? ) as [scala col?]) d? (col?, col?))
+Query plan:
+temp(group by)
+    subplan: sscan
+                 class: tbl node[?]
+                 sargs: term[?]
+                 cost:  ? card ?
+    sort:  
+    cost:  ? card ?
+Query stmt:
+select tbl.col?, tbl.col?, groupby_num(), (select d?.col? from ((select tbl.col?, tbl.col? from tbl tbl order by ? for orderby_num()<= ?:? ) as [scala col?]) d? (col?, col?)), tbl.col? from tbl tbl where tbl.col?= ?:?  group by tbl.col?, tbl.col?
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+3
+===================================================
+3
+===================================================
+rownum    test    
+1     1     
+2     2     
+3     3     
+
+Query plan:
+sscan
+    class: tbl? node[?]
+    sargs: term[?] AND term[?]
+    cost:  ? card ?
+Query stmt:
+(select tbl?.col? from tbl? tbl? where tbl?.col?=X.col? and (rownum= ?:? ))
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: X node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), (select tbl?.col? from tbl? tbl? where tbl?.col?=X.col? and (rownum= ?:? )), X.col? from tbl? X order by ?
+===================================================
+rownum    test    
+1     1     
+2     2     
+3     3     
+
+Query plan:
+sscan
+    class: tbl? node[?]
+    sargs: term[?] AND term[?]
+    cost:  ? card ?
+Query stmt:
+(select tbl?.col? from tbl? tbl? where tbl?.col?=a_? and (rownum= ?:? ))
+Query plan:
+temp(group by)
+    subplan: sscan
+                 class: t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select t?.col? from tbl? t? group by t?.col?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: X node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), (select tbl?.col? from tbl? tbl? where tbl?.col?=a_? and (rownum= ?:? )), a_? from (select t?.col? from tbl? t? group by t?.col?) X (a_?) order by ?
+===================================================
+0

--- a/sql/_13_issues/_24_1h/answers/cbrd_25098.answer
+++ b/sql/_13_issues/_24_1h/answers/cbrd_25098.answer
@@ -74,8 +74,6 @@ select tbl.col_two, tbl.col_three, groupby_num(), (select d?.col_two from ((sele
 ===================================================
 rownum    test    
 1     1     
-2     2     
-3     3     
 
 Query plan:
 sscan
@@ -92,12 +90,10 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select (orderby_num()), (select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=X.col_one and (rownum= ?:? )), X.col_one from tbl_one X order by ?
+select (orderby_num()), (select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=X.col_one and (rownum= ?:? )), X.col_one from tbl_one X order by ? for (orderby_num())<= ?:? 
 ===================================================
 rownum    test    
 1     1     
-2     2     
-3     3     
 
 Query plan:
 sscan
@@ -123,6 +119,6 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select (orderby_num()), (select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=a_? and (rownum= ?:? )), a_? from (select t_one.col_one from tbl_one t_one group by t_one.col_one) X (a_?) order by ?
+select (orderby_num()), (select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=a_? and (rownum= ?:? )), a_? from (select t_one.col_one from tbl_one t_one group by t_one.col_one) X (a_?) order by ? for (orderby_num())<= ?:? 
 ===================================================
 0

--- a/sql/_13_issues/_24_1h/cases/cbrd_25098.sql
+++ b/sql/_13_issues/_24_1h/cases/cbrd_25098.sql
@@ -57,7 +57,8 @@ FROM
 		t_one.col_one
 	FROM tbl_one t_one
 	ORDER BY t_one.col_one
-) X;
+) X
+limit 1;
 
 -- view merge 2
 SELECT
@@ -84,6 +85,7 @@ FROM
 	FROM tbl_one t_one
 	GROUP BY t_one.col_one
 	ORDER BY t_one.col_one
-) X;
+) X
+limit 1;
 
 drop table tbl, tbl_one, tbl_two;

--- a/sql/_13_issues/_24_1h/cases/cbrd_25098.sql
+++ b/sql/_13_issues/_24_1h/cases/cbrd_25098.sql
@@ -1,0 +1,89 @@
+-- Verified the CBRD-25098
+-- Problem where inst_num() is inappropriately changed to order_by_num() when a subquery containing an ORDER BY is view merged
+
+-- orderby_num()
+-- create table & insert data
+drop table if exists tbl;
+create table tbl(col1 int, col2 int, col3 int);
+insert into tbl values(1,1,1),(2,2,2),(3,3,3);
+
+-- const order by
+select
+	/*+ RECOMPILE */
+	col2,col3,orderby_num()
+	,(select 1 from tbl order by col1 limit 1) as "scala col1"
+from tbl 
+where col2 = 1 
+order by col2 for orderby_num() <= 1;
+
+-- const order by with group by
+select
+	/*+ RECOMPILE */
+	col2,col3,orderby_num()
+	,(select col2 from tbl order by col1 limit 1) as "scala col1"
+from tbl 
+where col1 = 1 
+group by col1,col2 
+order by col1;
+
+
+-- view merge
+-- create table & insert data
+drop table if exists tbl1;
+drop table if exists tbl2;
+
+create table tbl1 (col1 int, col2 int);
+create table tbl2 (col3 int, col4 int);
+
+insert into tbl1 values (1,1),(2,2),(3,3);
+insert into tbl2 values (1,1),(2,2),(3,3);
+
+
+-- view merge 1
+SELECT
+	/*+ RECOMPILE */
+	rownum,
+	(
+		SELECT
+			col3
+		FROM tbl2
+		WHERE
+			col3 = X.col1
+			AND ROWNUM =1
+	) AS test
+FROM
+(
+	SELECT
+		t1.col1
+	FROM tbl1 t1
+	ORDER BY t1.col1
+) X;
+
+-- view merge 2
+SELECT
+	/*+ RECOMPILE */
+	rownum,
+	(
+		SELECT
+			col3
+		FROM tbl2
+		WHERE
+			col3 = X.col1
+			AND ROWNUM =1
+	 ) AS test
+FROM
+(
+	SELECT
+	t1.col1
+	,(
+		select
+			1
+		from tbl1
+		where col1 = t1.col1
+	) as col10
+	FROM tbl1 t1
+	GROUP BY t1.col1
+	ORDER BY t1.col1
+) X;
+
+drop table tbl, tbl1, tbl2;

--- a/sql/_13_issues/_24_1h/cases/cbrd_25098.sql
+++ b/sql/_13_issues/_24_1h/cases/cbrd_25098.sql
@@ -41,6 +41,26 @@ insert into tbl_two values (1,1),(2,2),(3,3);
 
 -- view merge 1
 SELECT
+        /*+ RECOMPILE */
+        rownum,
+        (
+                SELECT
+                        col_three
+                FROM tbl_two
+                WHERE
+                        col_three = X.col_one
+                        AND ROWNUM =1
+        ) AS test
+FROM
+(
+        SELECT
+                t_one.col_one
+        FROM tbl_one t_one
+        ORDER BY t_one.col_one
+) X;
+
+-- view merge 1 + limit
+SELECT
 	/*+ RECOMPILE */
 	rownum,
 	(
@@ -61,6 +81,33 @@ FROM
 limit 1;
 
 -- view merge 2
+SELECT
+        /*+ RECOMPILE */
+        rownum,
+        (
+                SELECT
+                        col_three
+                FROM tbl_two
+                WHERE
+                        col_three = X.col_one
+                        AND ROWNUM =1
+         ) AS test
+FROM
+(
+        SELECT
+        t_one.col_one
+        ,(
+                select
+                        1
+                from tbl_one
+                where col_one = t_one.col_one
+        ) as col_one_another
+        FROM tbl_one t_one
+        GROUP BY t_one.col_one
+        ORDER BY t_one.col_one
+) X;
+
+-- view merge 2 + limit
 SELECT
 	/*+ RECOMPILE */
 	rownum,
@@ -87,5 +134,7 @@ FROM
 	ORDER BY t_one.col_one
 ) X
 limit 1;
+
+
 
 drop table tbl, tbl_one, tbl_two;

--- a/sql/_13_issues/_24_1h/cases/cbrd_25098.sql
+++ b/sql/_13_issues/_24_1h/cases/cbrd_25098.sql
@@ -4,39 +4,39 @@
 -- orderby_num()
 -- create table & insert data
 drop table if exists tbl;
-create table tbl(col1 int, col2 int, col3 int);
+create table tbl(col_one int, col_two int, col_three int);
 insert into tbl values(1,1,1),(2,2,2),(3,3,3);
 
 -- const order by
 select
 	/*+ RECOMPILE */
-	col2,col3,orderby_num()
-	,(select 1 from tbl order by col1 limit 1) as "scala col1"
+	col_two,col_three,orderby_num()
+	,(select 1 from tbl order by col_one limit 1) as "scala col_one"
 from tbl 
-where col2 = 1 
-order by col2 for orderby_num() <= 1;
+where col_two = 1 
+order by col_two for orderby_num() <= 1;
 
 -- const order by with group by
 select
 	/*+ RECOMPILE */
-	col2,col3,orderby_num()
-	,(select col2 from tbl order by col1 limit 1) as "scala col1"
+	col_two,col_three,orderby_num()
+	,(select col_two from tbl order by col_one limit 1) as "scala col_one"
 from tbl 
-where col1 = 1 
-group by col1,col2 
-order by col1;
+where col_one = 1 
+group by col_one,col_two 
+order by col_one;
 
 
 -- view merge
 -- create table & insert data
-drop table if exists tbl1;
-drop table if exists tbl2;
+drop table if exists tbl_one;
+drop table if exists tbl_two;
 
-create table tbl1 (col1 int, col2 int);
-create table tbl2 (col3 int, col4 int);
+create table tbl_one (col_one int, col_two int);
+create table tbl_two (col_three int, col_four int);
 
-insert into tbl1 values (1,1),(2,2),(3,3);
-insert into tbl2 values (1,1),(2,2),(3,3);
+insert into tbl_one values (1,1),(2,2),(3,3);
+insert into tbl_two values (1,1),(2,2),(3,3);
 
 
 -- view merge 1
@@ -45,18 +45,18 @@ SELECT
 	rownum,
 	(
 		SELECT
-			col3
-		FROM tbl2
+			col_three
+		FROM tbl_two
 		WHERE
-			col3 = X.col1
+			col_three = X.col_one
 			AND ROWNUM =1
 	) AS test
 FROM
 (
 	SELECT
-		t1.col1
-	FROM tbl1 t1
-	ORDER BY t1.col1
+		t_one.col_one
+	FROM tbl_one t_one
+	ORDER BY t_one.col_one
 ) X;
 
 -- view merge 2
@@ -65,25 +65,25 @@ SELECT
 	rownum,
 	(
 		SELECT
-			col3
-		FROM tbl2
+			col_three
+		FROM tbl_two
 		WHERE
-			col3 = X.col1
+			col_three = X.col_one
 			AND ROWNUM =1
 	 ) AS test
 FROM
 (
 	SELECT
-	t1.col1
+	t_one.col_one
 	,(
 		select
 			1
-		from tbl1
-		where col1 = t1.col1
-	) as col10
-	FROM tbl1 t1
-	GROUP BY t1.col1
-	ORDER BY t1.col1
+		from tbl_one
+		where col_one = t_one.col_one
+	) as col_one_another
+	FROM tbl_one t_one
+	GROUP BY t_one.col_one
+	ORDER BY t_one.col_one
 ) X;
 
-drop table tbl, tbl1, tbl2;
+drop table tbl, tbl_one, tbl_two;


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-25098

It needs to backport release/11.3, release/11.2