### PR TITLE
[CBRD-25098] Add new test case for problem where inst_num() is inappropriately changed to order_by_num() when a subquery containing an ORDER BY is view merged (11.3)

### DIFF
--- a/sql/_13_issues/_24_1h/answers/cbrd_25098.answer
+++ b/sql/_13_issues/_24_1h/answers/cbrd_25098.answer
@@ -1,0 +1,177 @@
+===================================================
+0
+===================================================
+0
+===================================================
+3
+===================================================
+col_two    col_three    orderby_num()    scala col_one    
+1     1     1     1     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: tbl node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select ?, tbl.col_one from tbl tbl order by ? for orderby_num()<= ?:? )
+Query plan:
+sscan
+    class: d? node[?]
+    cost:  ? card ?
+Query stmt:
+(select d?.a_? from ((select ?, tbl.col_one from tbl tbl order by ? for orderby_num()<= ?:? ) as [scala col_one]) d? (a_?, col_one))
+Query plan:
+sscan
+    class: tbl node[?]
+    sargs: term[?] AND term[?]
+    cost:  ? card ?
+Query stmt:
+select tbl.col_two, tbl.col_three, (inst_num()), (select d?.a_? from ((select ?, tbl.col_one from tbl tbl order by ? for orderby_num()<= ?:? ) as [scala col_one]) d? (a_?, col_one)) from tbl tbl where tbl.col_two= ?:?  and (inst_num())<= ?:? 
+===================================================
+col_two    col_three    orderby_num()    scala col_one    
+1     1     1     1     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: tbl node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select tbl.col_two, tbl.col_one from tbl tbl order by ? for orderby_num()<= ?:? )
+Query plan:
+sscan
+    class: d? node[?]
+    cost:  ? card ?
+Query stmt:
+(select d?.col_two from ((select tbl.col_two, tbl.col_one from tbl tbl order by ? for orderby_num()<= ?:? ) as [scala col_one]) d? (col_two, col_one))
+Query plan:
+temp(group by)
+    subplan: sscan
+                 class: tbl node[?]
+                 sargs: term[?]
+                 cost:  ? card ?
+    sort:  
+    cost:  ? card ?
+Query stmt:
+select tbl.col_two, tbl.col_three, groupby_num(), (select d?.col_two from ((select tbl.col_two, tbl.col_one from tbl tbl order by ? for orderby_num()<= ?:? ) as [scala col_one]) d? (col_two, col_one)), tbl.col_one from tbl tbl where tbl.col_one= ?:?  group by tbl.col_one, tbl.col_two
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+3
+===================================================
+3
+===================================================
+rownum    test    
+1     1     
+2     2     
+3     3     
+
+Query plan:
+sscan
+    class: tbl_two node[?]
+    sargs: term[?] AND term[?]
+    cost:  ? card ?
+Query stmt:
+(select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=X.col_one and (rownum= ?:? ))
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: X node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), (select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=X.col_one and (rownum= ?:? )), X.col_one from tbl_one X order by ?
+===================================================
+rownum    test    
+1     1     
+
+Query plan:
+sscan
+    class: tbl_two node[?]
+    sargs: term[?] AND term[?]
+    cost:  ? card ?
+Query stmt:
+(select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=X.col_one and (rownum= ?:? ))
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: X node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), (select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=X.col_one and (rownum= ?:? )), X.col_one from tbl_one X order by ? for (orderby_num())<= ?:? 
+===================================================
+rownum    test    
+1     1     
+2     2     
+3     3     
+
+Query plan:
+sscan
+    class: tbl_two node[?]
+    sargs: term[?] AND term[?]
+    cost:  ? card ?
+Query stmt:
+(select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=a_? and (rownum= ?:? ))
+Query plan:
+temp(group by)
+    subplan: sscan
+                 class: t_one node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select t_one.col_one from tbl_one t_one group by t_one.col_one)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: X node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), (select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=a_? and (rownum= ?:? )), a_? from (select t_one.col_one from tbl_one t_one group by t_one.col_one) X (a_?) order by ?
+===================================================
+rownum    test    
+1     1     
+
+Query plan:
+sscan
+    class: tbl_two node[?]
+    sargs: term[?] AND term[?]
+    cost:  ? card ?
+Query stmt:
+(select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=a_? and (rownum= ?:? ))
+Query plan:
+temp(group by)
+    subplan: sscan
+                 class: t_one node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select t_one.col_one from tbl_one t_one group by t_one.col_one)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: X node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), (select tbl_two.col_three from tbl_two tbl_two where tbl_two.col_three=a_? and (rownum= ?:? )), a_? from (select t_one.col_one from tbl_one t_one group by t_one.col_one) X (a_?) order by ? for (orderby_num())<= ?:? 
+===================================================
+0

--- a/sql/_13_issues/_24_1h/cases/cbrd_25098.sql
+++ b/sql/_13_issues/_24_1h/cases/cbrd_25098.sql
@@ -1,0 +1,140 @@
+-- Verified the CBRD-25098
+-- Problem where inst_num() is inappropriately changed to order_by_num() when a subquery containing an ORDER BY is view merged
+
+-- orderby_num()
+-- create table & insert data
+drop table if exists tbl;
+create table tbl(col_one int, col_two int, col_three int);
+insert into tbl values(1,1,1),(2,2,2),(3,3,3);
+
+-- const order by
+select
+	/*+ RECOMPILE */
+	col_two,col_three,orderby_num()
+	,(select 1 from tbl order by col_one limit 1) as "scala col_one"
+from tbl 
+where col_two = 1 
+order by col_two for orderby_num() <= 1;
+
+-- const order by with group by
+select
+	/*+ RECOMPILE */
+	col_two,col_three,orderby_num()
+	,(select col_two from tbl order by col_one limit 1) as "scala col_one"
+from tbl 
+where col_one = 1 
+group by col_one,col_two 
+order by col_one;
+
+
+-- view merge
+-- create table & insert data
+drop table if exists tbl_one;
+drop table if exists tbl_two;
+
+create table tbl_one (col_one int, col_two int);
+create table tbl_two (col_three int, col_four int);
+
+insert into tbl_one values (1,1),(2,2),(3,3);
+insert into tbl_two values (1,1),(2,2),(3,3);
+
+
+-- view merge 1
+SELECT
+        /*+ RECOMPILE */
+        rownum,
+        (
+                SELECT
+                        col_three
+                FROM tbl_two
+                WHERE
+                        col_three = X.col_one
+                        AND ROWNUM =1
+        ) AS test
+FROM
+(
+        SELECT
+                t_one.col_one
+        FROM tbl_one t_one
+        ORDER BY t_one.col_one
+) X;
+
+-- view merge 1 + limit
+SELECT
+	/*+ RECOMPILE */
+	rownum,
+	(
+		SELECT
+			col_three
+		FROM tbl_two
+		WHERE
+			col_three = X.col_one
+			AND ROWNUM =1
+	) AS test
+FROM
+(
+	SELECT
+		t_one.col_one
+	FROM tbl_one t_one
+	ORDER BY t_one.col_one
+) X
+limit 1;
+
+-- view merge 2
+SELECT
+        /*+ RECOMPILE */
+        rownum,
+        (
+                SELECT
+                        col_three
+                FROM tbl_two
+                WHERE
+                        col_three = X.col_one
+                        AND ROWNUM =1
+         ) AS test
+FROM
+(
+        SELECT
+        t_one.col_one
+        ,(
+                select
+                        1
+                from tbl_one
+                where col_one = t_one.col_one
+        ) as col_one_another
+        FROM tbl_one t_one
+        GROUP BY t_one.col_one
+        ORDER BY t_one.col_one
+) X;
+
+-- view merge 2 + limit
+SELECT
+	/*+ RECOMPILE */
+	rownum,
+	(
+		SELECT
+			col_three
+		FROM tbl_two
+		WHERE
+			col_three = X.col_one
+			AND ROWNUM =1
+	 ) AS test
+FROM
+(
+	SELECT
+	t_one.col_one
+	,(
+		select
+			1
+		from tbl_one
+		where col_one = t_one.col_one
+	) as col_one_another
+	FROM tbl_one t_one
+	GROUP BY t_one.col_one
+	ORDER BY t_one.col_one
+) X
+limit 1;
+
+
+
+drop table tbl, tbl_one, tbl_two;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25098, #1635