### PR TITLE
[CBRD-25214] Remove join predicate already logically evaluated.

### DIFF
--- a/sql/_13_issues/_23_1h/answers/cbrd_24843_1.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24843_1.answer
@@ -137,7 +137,7 @@ trace
 Query Plan:
   NESTED LOOPS (inner join)
     TABLE SCAN (p)
-    INDEX SCAN (c.fk_t_child_p_a_p_b) (key range: c.p_a=p.a, key filter: c.p_a=p.a)
+    INDEX SCAN (c.fk_t_child_p_a_p_b) (key range: c.p_a=p.a)
 
   rewritten query: select c.a, c.b, c.p_a, c.p_b from [dba.t_parent] p, [dba.t_child] c where c.p_a=p.a and c.p_a=p.a
 
@@ -162,7 +162,7 @@ trace
 Query Plan:
   NESTED LOOPS (inner join)
     TABLE SCAN (p)
-    INDEX SCAN (c.fk_t_child_p_a_p_b) (key range: c.p_a=p.a, key filter: c.p_a=p.a)
+    INDEX SCAN (c.fk_t_child_p_a_p_b) (key range: c.p_a=p.a)
 
   rewritten query: select c.a, c.b, c.p_a, c.p_b from [dba.t_child] c, [dba.t_parent] p where c.p_a=p.a and c.p_a=p.a
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25214

Remove join predicate already logically evaluated.