### PR TITLE
[CBRD-25077] Remove answers that DBMS_OUTPUT procedures from db_stored_procedure's rows

### DIFF
--- a/sql/_13_issues/_23_1h/answers/cbrd_24419.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24419.answer
@@ -1278,10 +1278,6 @@ r_u     U4     t5     U4     c2     INSTANCE     1     2     u4 > r_u (update)
 
 ===================================================
 sp_name    sp_type    return_type    arg_count    lang    target    owner    comment    
-disable     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.disable()     DBA     null     
-enable     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.enable(int)     DBA     null     
-get_line     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLine(java.lang.String[], int[])     DBA     null     
-get_lines     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLines(java.lang.String[], int[])     DBA     null     
 j0     FUNCTION     INTEGER     2     JAVA     test.j0(int) return int     U0     u0 {dba} > j0 (function)     
 j1     FUNCTION     INTEGER     2     JAVA     Test.j1(int) return int     U1     u1 > j1 (function)     
 j1_1     FUNCTION     INTEGER     2     JAVA     Test.j1_1(int) return int     U1_1     u1_1 {u1} > j1_1 (function)     
@@ -1290,17 +1286,9 @@ j2_1     FUNCTION     INTEGER     2     JAVA     Test.j2_1(int) return int     U
 j3     FUNCTION     INTEGER     2     JAVA     Test.j3(int) return int     U3     u3 {u1_1, u2_1} > j3 (function)     
 j3_1     FUNCTION     INTEGER     2     JAVA     Test.j3_1(int) return int     U3_1     u3_1 {u3} > j3_1 (function)     
 j4     FUNCTION     INTEGER     2     JAVA     Test.j4(int) return int     U4     u4 > j4 (function)     
-new_line     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.newLine()     DBA     null     
-put     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.put(java.lang.String)     DBA     null     
-put_line     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.putLine(java.lang.String)     DBA     null     
 
 ===================================================
 sp_name    index_of    arg_name    data_type    mode    comment    
-enable     0     s     INTEGER     IN     null     
-get_line     0     line     STRING     OUT     null     
-get_line     1     status     INTEGER     OUT     null     
-get_lines     0     lines     STRING     OUT     null     
-get_lines     1     cnt     INTEGER     OUT     null     
 j0     0     arg1     INTEGER     IN     u0 {dba} > j0 > arg1 (in)     
 j0     1     arg2     INTEGER     OUT     u0 {dba} > j0 > arg2 (out)     
 j1     0     arg1     INTEGER     IN     u1 > j1 > arg1 (in)     
@@ -1317,8 +1305,6 @@ j3_1     0     arg1     INTEGER     IN     u3_1 {u3} > j3_1 > arg1 (in)
 j3_1     1     arg2     INTEGER     OUT     u3_1 {u3} > j3_1 > arg2 (out)     
 j4     0     arg1     INTEGER     IN     u4 > j4 > arg1 (in)     
 j4     1     arg2     INTEGER     OUT     u4 > j4 > arg2 (out)     
-put     0     str     STRING     IN     null     
-put_line     0     str     STRING     IN     null     
 
 ===================================================
 meth_name    class_name    owner_name    meth_type    from_class_name    from_owner_name    from_meth_name    func_name    
@@ -1703,10 +1689,6 @@ r_u     U4     t5     U4     c2     INSTANCE     1     2     u4 > r_u (update)
 
 ===================================================
 sp_name    sp_type    return_type    arg_count    lang    target    owner    comment    
-disable     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.disable()     DBA     null     
-enable     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.enable(int)     DBA     null     
-get_line     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLine(java.lang.String[], int[])     DBA     null     
-get_lines     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLines(java.lang.String[], int[])     DBA     null     
 j0     FUNCTION     INTEGER     2     JAVA     test.j0(int) return int     U0     u0 {dba} > j0 (function)     
 j1     FUNCTION     INTEGER     2     JAVA     Test.j1(int) return int     U1     u1 > j1 (function)     
 j1_1     FUNCTION     INTEGER     2     JAVA     Test.j1_1(int) return int     U1_1     u1_1 {u1} > j1_1 (function)     
@@ -1715,17 +1697,9 @@ j2_1     FUNCTION     INTEGER     2     JAVA     Test.j2_1(int) return int     U
 j3     FUNCTION     INTEGER     2     JAVA     Test.j3(int) return int     U3     u3 {u1_1, u2_1} > j3 (function)     
 j3_1     FUNCTION     INTEGER     2     JAVA     Test.j3_1(int) return int     U3_1     u3_1 {u3} > j3_1 (function)     
 j4     FUNCTION     INTEGER     2     JAVA     Test.j4(int) return int     U4     u4 > j4 (function)     
-new_line     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.newLine()     DBA     null     
-put     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.put(java.lang.String)     DBA     null     
-put_line     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.putLine(java.lang.String)     DBA     null     
 
 ===================================================
 sp_name    index_of    arg_name    data_type    mode    comment    
-enable     0     s     INTEGER     IN     null     
-get_line     0     line     STRING     OUT     null     
-get_line     1     status     INTEGER     OUT     null     
-get_lines     0     lines     STRING     OUT     null     
-get_lines     1     cnt     INTEGER     OUT     null     
 j0     0     arg1     INTEGER     IN     u0 {dba} > j0 > arg1 (in)     
 j0     1     arg2     INTEGER     OUT     u0 {dba} > j0 > arg2 (out)     
 j1     0     arg1     INTEGER     IN     u1 > j1 > arg1 (in)     
@@ -1742,8 +1716,6 @@ j3_1     0     arg1     INTEGER     IN     u3_1 {u3} > j3_1 > arg1 (in)
 j3_1     1     arg2     INTEGER     OUT     u3_1 {u3} > j3_1 > arg2 (out)     
 j4     0     arg1     INTEGER     IN     u4 > j4 > arg1 (in)     
 j4     1     arg2     INTEGER     OUT     u4 > j4 > arg2 (out)     
-put     0     str     STRING     IN     null     
-put_line     0     str     STRING     IN     null     
 
 ===================================================
 meth_name    class_name    owner_name    meth_type    from_class_name    from_owner_name    from_meth_name    func_name    
@@ -1995,10 +1967,6 @@ r_u     U4     t5     U4     c2     INSTANCE     1     2     u4 > r_u (update)
 
 ===================================================
 sp_name    sp_type    return_type    arg_count    lang    target    owner    comment    
-disable     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.disable()     DBA     null     
-enable     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.enable(int)     DBA     null     
-get_line     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLine(java.lang.String[], int[])     DBA     null     
-get_lines     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLines(java.lang.String[], int[])     DBA     null     
 j0     FUNCTION     INTEGER     2     JAVA     test.j0(int) return int     U0     u0 {dba} > j0 (function)     
 j1     FUNCTION     INTEGER     2     JAVA     Test.j1(int) return int     U1     u1 > j1 (function)     
 j1_1     FUNCTION     INTEGER     2     JAVA     Test.j1_1(int) return int     U1_1     u1_1 {u1} > j1_1 (function)     
@@ -2007,17 +1975,9 @@ j2_1     FUNCTION     INTEGER     2     JAVA     Test.j2_1(int) return int     U
 j3     FUNCTION     INTEGER     2     JAVA     Test.j3(int) return int     U3     u3 {u1_1, u2_1} > j3 (function)     
 j3_1     FUNCTION     INTEGER     2     JAVA     Test.j3_1(int) return int     U3_1     u3_1 {u3} > j3_1 (function)     
 j4     FUNCTION     INTEGER     2     JAVA     Test.j4(int) return int     U4     u4 > j4 (function)     
-new_line     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.newLine()     DBA     null     
-put     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.put(java.lang.String)     DBA     null     
-put_line     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.putLine(java.lang.String)     DBA     null     
 
 ===================================================
 sp_name    index_of    arg_name    data_type    mode    comment    
-enable     0     s     INTEGER     IN     null     
-get_line     0     line     STRING     OUT     null     
-get_line     1     status     INTEGER     OUT     null     
-get_lines     0     lines     STRING     OUT     null     
-get_lines     1     cnt     INTEGER     OUT     null     
 j0     0     arg1     INTEGER     IN     u0 {dba} > j0 > arg1 (in)     
 j0     1     arg2     INTEGER     OUT     u0 {dba} > j0 > arg2 (out)     
 j1     0     arg1     INTEGER     IN     u1 > j1 > arg1 (in)     
@@ -2034,8 +1994,6 @@ j3_1     0     arg1     INTEGER     IN     u3_1 {u3} > j3_1 > arg1 (in)
 j3_1     1     arg2     INTEGER     OUT     u3_1 {u3} > j3_1 > arg2 (out)     
 j4     0     arg1     INTEGER     IN     u4 > j4 > arg1 (in)     
 j4     1     arg2     INTEGER     OUT     u4 > j4 > arg2 (out)     
-put     0     str     STRING     IN     null     
-put_line     0     str     STRING     IN     null     
 
 ===================================================
 meth_name    class_name    owner_name    meth_type    from_class_name    from_owner_name    from_meth_name    func_name    
@@ -2243,10 +2201,6 @@ r_u     U4     t5     U4     c2     INSTANCE     1     2     u4 > r_u (update)
 
 ===================================================
 sp_name    sp_type    return_type    arg_count    lang    target    owner    comment    
-disable     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.disable()     DBA     null     
-enable     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.enable(int)     DBA     null     
-get_line     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLine(java.lang.String[], int[])     DBA     null     
-get_lines     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLines(java.lang.String[], int[])     DBA     null     
 j0     FUNCTION     INTEGER     2     JAVA     test.j0(int) return int     U0     u0 {dba} > j0 (function)     
 j1     FUNCTION     INTEGER     2     JAVA     Test.j1(int) return int     U1     u1 > j1 (function)     
 j1_1     FUNCTION     INTEGER     2     JAVA     Test.j1_1(int) return int     U1_1     u1_1 {u1} > j1_1 (function)     
@@ -2255,17 +2209,9 @@ j2_1     FUNCTION     INTEGER     2     JAVA     Test.j2_1(int) return int     U
 j3     FUNCTION     INTEGER     2     JAVA     Test.j3(int) return int     U3     u3 {u1_1, u2_1} > j3 (function)     
 j3_1     FUNCTION     INTEGER     2     JAVA     Test.j3_1(int) return int     U3_1     u3_1 {u3} > j3_1 (function)     
 j4     FUNCTION     INTEGER     2     JAVA     Test.j4(int) return int     U4     u4 > j4 (function)     
-new_line     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.newLine()     DBA     null     
-put     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.put(java.lang.String)     DBA     null     
-put_line     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.putLine(java.lang.String)     DBA     null     
 
 ===================================================
 sp_name    index_of    arg_name    data_type    mode    comment    
-enable     0     s     INTEGER     IN     null     
-get_line     0     line     STRING     OUT     null     
-get_line     1     status     INTEGER     OUT     null     
-get_lines     0     lines     STRING     OUT     null     
-get_lines     1     cnt     INTEGER     OUT     null     
 j0     0     arg1     INTEGER     IN     u0 {dba} > j0 > arg1 (in)     
 j0     1     arg2     INTEGER     OUT     u0 {dba} > j0 > arg2 (out)     
 j1     0     arg1     INTEGER     IN     u1 > j1 > arg1 (in)     
@@ -2282,8 +2228,6 @@ j3_1     0     arg1     INTEGER     IN     u3_1 {u3} > j3_1 > arg1 (in)
 j3_1     1     arg2     INTEGER     OUT     u3_1 {u3} > j3_1 > arg2 (out)     
 j4     0     arg1     INTEGER     IN     u4 > j4 > arg1 (in)     
 j4     1     arg2     INTEGER     OUT     u4 > j4 > arg2 (out)     
-put     0     str     STRING     IN     null     
-put_line     0     str     STRING     IN     null     
 
 ===================================================
 meth_name    class_name    owner_name    meth_type    from_class_name    from_owner_name    from_meth_name    func_name    
@@ -2535,10 +2479,6 @@ r_u     U4     t5     U4     c2     INSTANCE     1     2     u4 > r_u (update)
 
 ===================================================
 sp_name    sp_type    return_type    arg_count    lang    target    owner    comment    
-disable     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.disable()     DBA     null     
-enable     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.enable(int)     DBA     null     
-get_line     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLine(java.lang.String[], int[])     DBA     null     
-get_lines     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLines(java.lang.String[], int[])     DBA     null     
 j0     FUNCTION     INTEGER     2     JAVA     test.j0(int) return int     U0     u0 {dba} > j0 (function)     
 j1     FUNCTION     INTEGER     2     JAVA     Test.j1(int) return int     U1     u1 > j1 (function)     
 j1_1     FUNCTION     INTEGER     2     JAVA     Test.j1_1(int) return int     U1_1     u1_1 {u1} > j1_1 (function)     
@@ -2547,17 +2487,9 @@ j2_1     FUNCTION     INTEGER     2     JAVA     Test.j2_1(int) return int     U
 j3     FUNCTION     INTEGER     2     JAVA     Test.j3(int) return int     U3     u3 {u1_1, u2_1} > j3 (function)     
 j3_1     FUNCTION     INTEGER     2     JAVA     Test.j3_1(int) return int     U3_1     u3_1 {u3} > j3_1 (function)     
 j4     FUNCTION     INTEGER     2     JAVA     Test.j4(int) return int     U4     u4 > j4 (function)     
-new_line     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.newLine()     DBA     null     
-put     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.put(java.lang.String)     DBA     null     
-put_line     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.putLine(java.lang.String)     DBA     null     
 
 ===================================================
 sp_name    index_of    arg_name    data_type    mode    comment    
-enable     0     s     INTEGER     IN     null     
-get_line     0     line     STRING     OUT     null     
-get_line     1     status     INTEGER     OUT     null     
-get_lines     0     lines     STRING     OUT     null     
-get_lines     1     cnt     INTEGER     OUT     null     
 j0     0     arg1     INTEGER     IN     u0 {dba} > j0 > arg1 (in)     
 j0     1     arg2     INTEGER     OUT     u0 {dba} > j0 > arg2 (out)     
 j1     0     arg1     INTEGER     IN     u1 > j1 > arg1 (in)     
@@ -2574,8 +2506,6 @@ j3_1     0     arg1     INTEGER     IN     u3_1 {u3} > j3_1 > arg1 (in)
 j3_1     1     arg2     INTEGER     OUT     u3_1 {u3} > j3_1 > arg2 (out)     
 j4     0     arg1     INTEGER     IN     u4 > j4 > arg1 (in)     
 j4     1     arg2     INTEGER     OUT     u4 > j4 > arg2 (out)     
-put     0     str     STRING     IN     null     
-put_line     0     str     STRING     IN     null     
 
 ===================================================
 meth_name    class_name    owner_name    meth_type    from_class_name    from_owner_name    from_meth_name    func_name    
@@ -3071,10 +3001,6 @@ r_u     U4     t5     U4     c2     INSTANCE     1     2     u4 > r_u (update)
 
 ===================================================
 sp_name    sp_type    return_type    arg_count    lang    target    owner    comment    
-disable     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.disable()     DBA     null     
-enable     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.enable(int)     DBA     null     
-get_line     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLine(java.lang.String[], int[])     DBA     null     
-get_lines     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLines(java.lang.String[], int[])     DBA     null     
 j0     FUNCTION     INTEGER     2     JAVA     test.j0(int) return int     U0     u0 {dba} > j0 (function)     
 j1     FUNCTION     INTEGER     2     JAVA     Test.j1(int) return int     U1     u1 > j1 (function)     
 j1_1     FUNCTION     INTEGER     2     JAVA     Test.j1_1(int) return int     U1_1     u1_1 {u1} > j1_1 (function)     
@@ -3083,17 +3009,9 @@ j2_1     FUNCTION     INTEGER     2     JAVA     Test.j2_1(int) return int     U
 j3     FUNCTION     INTEGER     2     JAVA     Test.j3(int) return int     U3     u3 {u1_1, u2_1} > j3 (function)     
 j3_1     FUNCTION     INTEGER     2     JAVA     Test.j3_1(int) return int     U3_1     u3_1 {u3} > j3_1 (function)     
 j4     FUNCTION     INTEGER     2     JAVA     Test.j4(int) return int     U4     u4 > j4 (function)     
-new_line     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.newLine()     DBA     null     
-put     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.put(java.lang.String)     DBA     null     
-put_line     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.putLine(java.lang.String)     DBA     null     
 
 ===================================================
 sp_name    index_of    arg_name    data_type    mode    comment    
-enable     0     s     INTEGER     IN     null     
-get_line     0     line     STRING     OUT     null     
-get_line     1     status     INTEGER     OUT     null     
-get_lines     0     lines     STRING     OUT     null     
-get_lines     1     cnt     INTEGER     OUT     null     
 j0     0     arg1     INTEGER     IN     u0 {dba} > j0 > arg1 (in)     
 j0     1     arg2     INTEGER     OUT     u0 {dba} > j0 > arg2 (out)     
 j1     0     arg1     INTEGER     IN     u1 > j1 > arg1 (in)     
@@ -3110,8 +3028,6 @@ j3_1     0     arg1     INTEGER     IN     u3_1 {u3} > j3_1 > arg1 (in)
 j3_1     1     arg2     INTEGER     OUT     u3_1 {u3} > j3_1 > arg2 (out)     
 j4     0     arg1     INTEGER     IN     u4 > j4 > arg1 (in)     
 j4     1     arg2     INTEGER     OUT     u4 > j4 > arg2 (out)     
-put     0     str     STRING     IN     null     
-put_line     0     str     STRING     IN     null     
 
 ===================================================
 meth_name    class_name    owner_name    meth_type    from_class_name    from_owner_name    from_meth_name    func_name    
@@ -3763,10 +3679,6 @@ r_u     U4     t5     U4     c2     INSTANCE     1     2     u4 > r_u (update)
 
 ===================================================
 sp_name    sp_type    return_type    arg_count    lang    target    owner    comment    
-disable     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.disable()     DBA     null     
-enable     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.enable(int)     DBA     null     
-get_line     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLine(java.lang.String[], int[])     DBA     null     
-get_lines     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLines(java.lang.String[], int[])     DBA     null     
 j0     FUNCTION     INTEGER     2     JAVA     test.j0(int) return int     U0     u0 {dba} > j0 (function)     
 j1     FUNCTION     INTEGER     2     JAVA     Test.j1(int) return int     U1     u1 > j1 (function)     
 j1_1     FUNCTION     INTEGER     2     JAVA     Test.j1_1(int) return int     U1_1     u1_1 {u1} > j1_1 (function)     
@@ -3775,17 +3687,9 @@ j2_1     FUNCTION     INTEGER     2     JAVA     Test.j2_1(int) return int     U
 j3     FUNCTION     INTEGER     2     JAVA     Test.j3(int) return int     U3     u3 {u1_1, u2_1} > j3 (function)     
 j3_1     FUNCTION     INTEGER     2     JAVA     Test.j3_1(int) return int     U3_1     u3_1 {u3} > j3_1 (function)     
 j4     FUNCTION     INTEGER     2     JAVA     Test.j4(int) return int     U4     u4 > j4 (function)     
-new_line     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.newLine()     DBA     null     
-put     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.put(java.lang.String)     DBA     null     
-put_line     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.putLine(java.lang.String)     DBA     null     
 
 ===================================================
 sp_name    index_of    arg_name    data_type    mode    comment    
-enable     0     s     INTEGER     IN     null     
-get_line     0     line     STRING     OUT     null     
-get_line     1     status     INTEGER     OUT     null     
-get_lines     0     lines     STRING     OUT     null     
-get_lines     1     cnt     INTEGER     OUT     null     
 j0     0     arg1     INTEGER     IN     u0 {dba} > j0 > arg1 (in)     
 j0     1     arg2     INTEGER     OUT     u0 {dba} > j0 > arg2 (out)     
 j1     0     arg1     INTEGER     IN     u1 > j1 > arg1 (in)     
@@ -3802,8 +3706,6 @@ j3_1     0     arg1     INTEGER     IN     u3_1 {u3} > j3_1 > arg1 (in)
 j3_1     1     arg2     INTEGER     OUT     u3_1 {u3} > j3_1 > arg2 (out)     
 j4     0     arg1     INTEGER     IN     u4 > j4 > arg1 (in)     
 j4     1     arg2     INTEGER     OUT     u4 > j4 > arg2 (out)     
-put     0     str     STRING     IN     null     
-put_line     0     str     STRING     IN     null     
 
 ===================================================
 meth_name    class_name    owner_name    meth_type    from_class_name    from_owner_name    from_meth_name    func_name    
@@ -4153,10 +4055,6 @@ r_u     U4     t5     U4     c2     INSTANCE     1     2     u4 > r_u (update)
 
 ===================================================
 sp_name    sp_type    return_type    arg_count    lang    target    owner    comment    
-disable     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.disable()     DBA     null     
-enable     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.enable(int)     DBA     null     
-get_line     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLine(java.lang.String[], int[])     DBA     null     
-get_lines     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLines(java.lang.String[], int[])     DBA     null     
 j0     FUNCTION     INTEGER     2     JAVA     test.j0(int) return int     U0     u0 {dba} > j0 (function)     
 j1     FUNCTION     INTEGER     2     JAVA     Test.j1(int) return int     U1     u1 > j1 (function)     
 j1_1     FUNCTION     INTEGER     2     JAVA     Test.j1_1(int) return int     U1_1     u1_1 {u1} > j1_1 (function)     
@@ -4165,17 +4063,9 @@ j2_1     FUNCTION     INTEGER     2     JAVA     Test.j2_1(int) return int     U
 j3     FUNCTION     INTEGER     2     JAVA     Test.j3(int) return int     U3     u3 {u1_1, u2_1} > j3 (function)     
 j3_1     FUNCTION     INTEGER     2     JAVA     Test.j3_1(int) return int     U3_1     u3_1 {u3} > j3_1 (function)     
 j4     FUNCTION     INTEGER     2     JAVA     Test.j4(int) return int     U4     u4 > j4 (function)     
-new_line     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.newLine()     DBA     null     
-put     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.put(java.lang.String)     DBA     null     
-put_line     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.putLine(java.lang.String)     DBA     null     
 
 ===================================================
 sp_name    index_of    arg_name    data_type    mode    comment    
-enable     0     s     INTEGER     IN     null     
-get_line     0     line     STRING     OUT     null     
-get_line     1     status     INTEGER     OUT     null     
-get_lines     0     lines     STRING     OUT     null     
-get_lines     1     cnt     INTEGER     OUT     null     
 j0     0     arg1     INTEGER     IN     u0 {dba} > j0 > arg1 (in)     
 j0     1     arg2     INTEGER     OUT     u0 {dba} > j0 > arg2 (out)     
 j1     0     arg1     INTEGER     IN     u1 > j1 > arg1 (in)     
@@ -4192,8 +4082,6 @@ j3_1     0     arg1     INTEGER     IN     u3_1 {u3} > j3_1 > arg1 (in)
 j3_1     1     arg2     INTEGER     OUT     u3_1 {u3} > j3_1 > arg2 (out)     
 j4     0     arg1     INTEGER     IN     u4 > j4 > arg1 (in)     
 j4     1     arg2     INTEGER     OUT     u4 > j4 > arg2 (out)     
-put     0     str     STRING     IN     null     
-put_line     0     str     STRING     IN     null     
 
 ===================================================
 meth_name    class_name    owner_name    meth_type    from_class_name    from_owner_name    from_meth_name    func_name    
@@ -4399,10 +4287,6 @@ r_u     U4     t5     U4     c2     INSTANCE     1     2     u4 > r_u (update)
 
 ===================================================
 sp_name    sp_type    return_type    arg_count    lang    target    owner    comment    
-disable     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.disable()     DBA     null     
-enable     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.enable(int)     DBA     null     
-get_line     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLine(java.lang.String[], int[])     DBA     null     
-get_lines     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLines(java.lang.String[], int[])     DBA     null     
 j0     FUNCTION     INTEGER     2     JAVA     test.j0(int) return int     U0     u0 {dba} > j0 (function)     
 j1     FUNCTION     INTEGER     2     JAVA     Test.j1(int) return int     U1     u1 > j1 (function)     
 j1_1     FUNCTION     INTEGER     2     JAVA     Test.j1_1(int) return int     U1_1     u1_1 {u1} > j1_1 (function)     
@@ -4411,17 +4295,9 @@ j2_1     FUNCTION     INTEGER     2     JAVA     Test.j2_1(int) return int     U
 j3     FUNCTION     INTEGER     2     JAVA     Test.j3(int) return int     U3     u3 {u1_1, u2_1} > j3 (function)     
 j3_1     FUNCTION     INTEGER     2     JAVA     Test.j3_1(int) return int     U3_1     u3_1 {u3} > j3_1 (function)     
 j4     FUNCTION     INTEGER     2     JAVA     Test.j4(int) return int     U4     u4 > j4 (function)     
-new_line     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.newLine()     DBA     null     
-put     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.put(java.lang.String)     DBA     null     
-put_line     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.putLine(java.lang.String)     DBA     null     
 
 ===================================================
 sp_name    index_of    arg_name    data_type    mode    comment    
-enable     0     s     INTEGER     IN     null     
-get_line     0     line     STRING     OUT     null     
-get_line     1     status     INTEGER     OUT     null     
-get_lines     0     lines     STRING     OUT     null     
-get_lines     1     cnt     INTEGER     OUT     null     
 j0     0     arg1     INTEGER     IN     u0 {dba} > j0 > arg1 (in)     
 j0     1     arg2     INTEGER     OUT     u0 {dba} > j0 > arg2 (out)     
 j1     0     arg1     INTEGER     IN     u1 > j1 > arg1 (in)     
@@ -4438,8 +4314,6 @@ j3_1     0     arg1     INTEGER     IN     u3_1 {u3} > j3_1 > arg1 (in)
 j3_1     1     arg2     INTEGER     OUT     u3_1 {u3} > j3_1 > arg2 (out)     
 j4     0     arg1     INTEGER     IN     u4 > j4 > arg1 (in)     
 j4     1     arg2     INTEGER     OUT     u4 > j4 > arg2 (out)     
-put     0     str     STRING     IN     null     
-put_line     0     str     STRING     IN     null     
 
 ===================================================
 meth_name    class_name    owner_name    meth_type    from_class_name    from_owner_name    from_meth_name    func_name    
@@ -4644,10 +4518,6 @@ r_u     U4     t5     U4     c2     INSTANCE     1     2     u4 > r_u (update)
 
 ===================================================
 sp_name    sp_type    return_type    arg_count    lang    target    owner    comment    
-disable     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.disable()     DBA     null     
-enable     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.enable(int)     DBA     null     
-get_line     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLine(java.lang.String[], int[])     DBA     null     
-get_lines     PROCEDURE     void     2     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.getLines(java.lang.String[], int[])     DBA     null     
 j0     FUNCTION     INTEGER     2     JAVA     test.j0(int) return int     U0     u0 {dba} > j0 (function)     
 j1     FUNCTION     INTEGER     2     JAVA     Test.j1(int) return int     U1     u1 > j1 (function)     
 j1_1     FUNCTION     INTEGER     2     JAVA     Test.j1_1(int) return int     U1_1     u1_1 {u1} > j1_1 (function)     
@@ -4656,17 +4526,9 @@ j2_1     FUNCTION     INTEGER     2     JAVA     Test.j2_1(int) return int     U
 j3     FUNCTION     INTEGER     2     JAVA     Test.j3(int) return int     U3     u3 {u1_1, u2_1} > j3 (function)     
 j3_1     FUNCTION     INTEGER     2     JAVA     Test.j3_1(int) return int     U3_1     u3_1 {u3} > j3_1 (function)     
 j4     FUNCTION     INTEGER     2     JAVA     Test.j4(int) return int     U4     u4 > j4 (function)     
-new_line     PROCEDURE     void     0     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.newLine()     DBA     null     
-put     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.put(java.lang.String)     DBA     null     
-put_line     PROCEDURE     void     1     JAVA     com.cubrid.plcsql.builtin.DBMS_OUTPUT.putLine(java.lang.String)     DBA     null     
 
 ===================================================
 sp_name    index_of    arg_name    data_type    mode    comment    
-enable     0     s     INTEGER     IN     null     
-get_line     0     line     STRING     OUT     null     
-get_line     1     status     INTEGER     OUT     null     
-get_lines     0     lines     STRING     OUT     null     
-get_lines     1     cnt     INTEGER     OUT     null     
 j0     0     arg1     INTEGER     IN     u0 {dba} > j0 > arg1 (in)     
 j0     1     arg2     INTEGER     OUT     u0 {dba} > j0 > arg2 (out)     
 j1     0     arg1     INTEGER     IN     u1 > j1 > arg1 (in)     
@@ -4683,8 +4545,6 @@ j3_1     0     arg1     INTEGER     IN     u3_1 {u3} > j3_1 > arg1 (in)
 j3_1     1     arg2     INTEGER     OUT     u3_1 {u3} > j3_1 > arg2 (out)     
 j4     0     arg1     INTEGER     IN     u4 > j4 > arg1 (in)     
 j4     1     arg2     INTEGER     OUT     u4 > j4 > arg2 (out)     
-put     0     str     STRING     IN     null     
-put_line     0     str     STRING     IN     null     
 
 ===================================================
 meth_name    class_name    owner_name    meth_type    from_class_name    from_owner_name    from_meth_name    func_name    

--- a/sql/_27_banana_qa/issue_12367_comment/answers/comment_on_jsp_01.answer
+++ b/sql/_27_banana_qa/issue_12367_comment/answers/comment_on_jsp_01.answer
@@ -2,49 +2,21 @@
 0
 ===================================================
 sp_name    comment    
-disable     null     
-enable     null     
 f     this is the comment for function f     
-get_line     null     
-get_lines     null     
-new_line     null     
-put     null     
-put_line     null     
 
 ===================================================
 sp_name    arg_name    comment    
-enable     s     null     
 f     i     arg i     
-get_line     line     null     
-get_line     status     null     
-get_lines     lines     null     
-get_lines     cnt     null     
-put     str     null     
-put_line     str     null     
 
 ===================================================
 0
 ===================================================
 sp_name    comment    
-disable     null     
-enable     null     
 f     new comment for function f     
-get_line     null     
-get_lines     null     
-new_line     null     
-put     null     
-put_line     null     
 
 ===================================================
 sp_name    arg_name    comment    
-enable     s     null     
 f     i     arg i     
-get_line     line     null     
-get_line     status     null     
-get_lines     lines     null     
-get_lines     cnt     null     
-put     str     null     
-put_line     str     null     
 
 ===================================================
 Error:-493
@@ -54,49 +26,21 @@ Error:-493
 0
 ===================================================
 sp_name    comment    
-disable     null     
-enable     null     
-get_line     null     
-get_lines     null     
-new_line     null     
 p     this is the comment for procedure p     
-put     null     
-put_line     null     
 
 ===================================================
 sp_name    arg_name    comment    
-enable     s     null     
-get_line     line     null     
-get_line     status     null     
-get_lines     lines     null     
-get_lines     cnt     null     
 p     i     arg i     
-put     str     null     
-put_line     str     null     
 
 ===================================================
 0
 ===================================================
 sp_name    comment    
-disable     null     
-enable     null     
-get_line     null     
-get_lines     null     
-new_line     null     
 p     new comment for procedure p     
-put     null     
-put_line     null     
 
 ===================================================
 sp_name    arg_name    comment    
-enable     s     null     
-get_line     line     null     
-get_line     status     null     
-get_lines     lines     null     
-get_lines     cnt     null     
 p     i     arg i     
-put     str     null     
-put_line     str     null     
 
 ===================================================
 Error:-493


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25077

By adding the `is_system_genenrated` column in `db_stored_procedure`, DBMS_OUTPUT procedures are not shown anymore.