### PR TITLE
[CBRD-25097] Revise Isolation Testcase for PL/CSQL Phase-0 Branch Merge

### DIFF
--- a/isolation/_01_ReadCommitted/authorization/granting_authorization/answer/revoke_authorization_01.answer
+++ b/isolation/_01_ReadCommitted/authorization/granting_authorization/answer/revoke_authorization_01.answer
@@ -6,7 +6,7 @@
 |    2  
 |    10  
 | 2 rows selected
-| ERROR RETURNED: Semantic: DELETE is not authorized on dba.t1. delete [dba.t1] from [dba.t1] [dba.t1] where [dba.t1].id=2 
+| ERROR RETURNED: Semantic: DELETE is not authorized on dba.t1. delete [dba.t1] from [dba.t1] where [dba.t1].id=2 
 |    on statement number: 6
 | 1 row affected
 | =================   Q U E R Y   R E S U L T S   =================

--- a/isolation/_01_ReadCommitted/authorization/granting_authorization/answer/revoke_authorization_02.answer
+++ b/isolation/_01_ReadCommitted/authorization/granting_authorization/answer/revoke_authorization_02.answer
@@ -6,7 +6,7 @@
 |    2  
 |    10  
 | 2 rows selected
-| ERROR RETURNED: Semantic: DELETE is not authorized on dba.t1. delete [dba.t1] from [dba.t1] [dba.t1] where [dba.t1].id=2 
+| ERROR RETURNED: Semantic: DELETE is not authorized on dba.t1. delete [dba.t1] from [dba.t1] where [dba.t1].id=2 
 |    on statement number: 6
 | 1 row affected
 | ERROR RETURNED: Semantic: SELECT is not authorized on dba.t1. select [dba.t1].id from [dba.t1] [dba.t1] 


### PR DESCRIPTION
< | ERROR RETURNED: Semantic: DELETE is not authorized on dba.t1. delete [dba.t1] from [dba.t1] where [dba.t1].id=2 --- > | ERROR RETURNED: Semantic: DELETE is not authorized on dba.t1. delete [dba.t1] from [dba.t1] [dba.t1] where [dba.t1].id=2

Cause: pl/csql

Refer: http://jira.cubrid.org/browse/CBRD-25097
http://jira.cubrid.org/browse/CBRD-24745