### PR TITLE
[CBRD-24046] Result cache for correlated scalar subquery

### DIFF
--- a/sql/_13_issues/_23_1h/answers/cbrd_24843_4.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24843_4.answer
@@ -558,7 +558,7 @@ Trace Statistics:
       SUBQUERY (correlated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (index: dba.t_child.fk_t_child_p_a_p_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-          SUBQUERY_CACHE (hit: ?, miss: ?, size: ? Bytes)
+          SUBQUERY_CACHE (hit: ?, miss: ?, size: ? Bytes, status: enabled)
      
 
 ===================================================
@@ -587,7 +587,7 @@ Trace Statistics:
       SUBQUERY (correlated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (index: dba.t_child.fk_t_child_p_a_p_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-          SUBQUERY_CACHE (hit: ?, miss: ?, size: ? Bytes)
+          SUBQUERY_CACHE (hit: ?, miss: ?, size: ? Bytes, status: enabled)
      
 
 ===================================================

--- a/sql/_13_issues/_23_1h/answers/cbrd_24843_4.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24843_4.answer
@@ -558,6 +558,7 @@ Trace Statistics:
       SUBQUERY (correlated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (index: dba.t_child.fk_t_child_p_a_p_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+          SUBQUERY_CACHE (hit: ?, miss: ?, size: ? Bytes)
      
 
 ===================================================
@@ -586,6 +587,7 @@ Trace Statistics:
       SUBQUERY (correlated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (index: dba.t_child.fk_t_child_p_a_p_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+          SUBQUERY_CACHE (hit: ?, miss: ?, size: ? Bytes)
      
 
 ===================================================

--- a/sql/_13_issues/_23_1h/answers/cbrd_24906_1.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24906_1.answer
@@ -192,6 +192,7 @@ Trace Statistics:
     SUBQUERY (correlated)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (index: dba.tbl_b.pk_tbl_b_col_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+        SUBQUERY_CACHE (hit: ?, miss: ?, size: ? Bytes, status: enabled)
      
 
 ===================================================

--- a/sql/_13_issues/_23_1h/answers/cbrd_24906_2.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24906_2.answer
@@ -204,6 +204,7 @@ Trace Statistics:
     SUBQUERY (correlated)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (index: dba.tbl_b.pk_tbl_b_col_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+        SUBQUERY_CACHE (hit: ?, miss: ?, size: ? Bytes, status: enabled)
      
 
 ===================================================


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24046

A correlated subquery is executed for each row of the main query to get a value. If there are many duplicated inputs, the same query is repeatedly executed, which may cause a decrease in performance. We eliminate the cause of the slowdown through the result cache.