### PR TITLE
[CBRD-25172] updated 5 TC answers for CBRD-25172

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_04_with_parameters/answers/01_01_04-02_error_invalid_param_type.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_04_with_parameters/answers/01_01_04-02_error_invalid_param_type.answer
@@ -4,7 +4,7 @@ Semantic: before ' ) as
 begin
 null;
 end; '
-foo is not defined. create or replace procedure t(a  foo) as 
+dba.foo is not defined. create or replace procedure t(a  [dba.foo]) as 
 null;
 end;
 

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_04_with_parameters/answers/01_01_04-04_error_sys_refcursor_param_type.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_04_with_parameters/answers/01_01_04-04_error_sys_refcursor_param_type.answer
@@ -4,10 +4,8 @@ Semantic: before ' ) as
 begin
 null;
 end; '
-sys_refcursor is not defined. create or replace procedure t(a  sys_refcursor) as 
-null;
-end;
-
+dba.sys_refcursor is not defined. create or replace procedure t(a  [dba.sys_refcursor]) as 
+nu...
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-07_error_bit_type.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-07_error_bit_type.answer
@@ -4,7 +4,7 @@ Semantic: before ' ) as
 begin
 dbms_output.put_line('i BIT : ' || i);
 end; '
-Unsupported argument type of stored procedure: bit create or replace procedure pp(i  bit(1)) as 
+Unsupported argument type 'bit' of the stored procedure create or replace procedure pp(i  bit(1)) as 
 dbms_output.pu...
 
 ===================================================
@@ -14,6 +14,5 @@ Stored procedure compile error: no viable alternative at input 'BIT;'
 
 ===================================================
 Error:-494
-Semantic: before ' ; '
-Unsupported return type of stored procedure: bit create or replace function ff() return bit(1) as  BIT := B'1...
+Semantic: Unsupported return type 'bit' of the stored procedure create or replace function ff() return bit(1) as  BIT := B'1...
 

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_02_create_function/_11_common/answers/01_02_11-10_error_sys_refcursor_return_type.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_02_create_function/_11_common/answers/01_02_11-10_error_sys_refcursor_return_type.answer
@@ -4,7 +4,7 @@ Semantic: before '  as
 begin
 return null;
 end; '
-sys_refcursor is not defined. create or replace function t(i  integer) return sys_refcurso...
+dba.sys_refcursor is not defined. create or replace function t(i  integer) return [dba.sys_ref...
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_08_local_func/_01_wo_param/answers/02_08_01-02_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_08_local_func/_01_wo_param/answers/02_08_01-02_error_typo.answer
@@ -120,7 +120,7 @@ Semantic: before '
 AS
 invalid_argument EXCEPTION;
 FUNCTION factorial(n INT) RET...'
-INTS is not defined. create function choose(m  integer, n  integer) return INTS a...
+dba.INTS is not defined. create function choose(m  integer, n  integer) return [dba.I...
 
 ===================================================
 Error:-1360


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25172

. types names in sp param and return types can have user schema in error messages
  _01_basic_structure/_01_create_procedure/_04_with_parameters/answers/01_01_04-02_error_invalid_param_type.answer
  _01_basic_structure/_01_create_procedure/_04_with_parameters/answers/01_01_04-04_error_sys_refcursor_param_type.answer
  _01_basic_structure/_02_create_function/_11_common/answers/01_02_11-10_error_sys_refcursor_return_type.answer
  _02_declaration/_08_local_func/_01_wo_param/answers/02_08_01-02_error_typo.answer
. updated error messages because the error case is mapped to a different error code
  _01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-07_error_bit_type.answer