### PR TITLE
Revert "[CBRD-24046] Result cache for correlated scalar subquery"

### DIFF
--- a/sql/_13_issues/_23_1h/answers/cbrd_24843_4.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24843_4.answer
@@ -558,7 +558,6 @@ Trace Statistics:
       SUBQUERY (correlated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (index: dba.t_child.fk_t_child_p_a_p_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-          SUBQUERY_CACHE (hit: ?, miss: ?, size: ? Bytes, status: enabled)
      
 
 ===================================================
@@ -587,7 +586,6 @@ Trace Statistics:
       SUBQUERY (correlated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (index: dba.t_child.fk_t_child_p_a_p_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-          SUBQUERY_CACHE (hit: ?, miss: ?, size: ? Bytes, status: enabled)
      
 
 ===================================================

--- a/sql/_13_issues/_23_1h/answers/cbrd_24906_1.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24906_1.answer
@@ -192,7 +192,6 @@ Trace Statistics:
     SUBQUERY (correlated)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (index: dba.tbl_b.pk_tbl_b_col_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-        SUBQUERY_CACHE (hit: ?, miss: ?, size: ? Bytes, status: enabled)
      
 
 ===================================================

--- a/sql/_13_issues/_23_1h/answers/cbrd_24906_2.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24906_2.answer
@@ -204,7 +204,6 @@ Trace Statistics:
     SUBQUERY (correlated)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (index: dba.tbl_b.pk_tbl_b_col_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-        SUBQUERY_CACHE (hit: ?, miss: ?, size: ? Bytes, status: enabled)
      
 
 ===================================================


### PR DESCRIPTION
Reverts CUBRID/cubrid-testcases#1737