### PR TITLE
[CBRD-25184] Revise answers according to system catalog/grammar changes during phase-1

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-02_error_use_char.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-02_error_use_char.answer
@@ -1,10 +1,10 @@
 ===================================================
 Error:-1360
 In line 1, column 27
-Stored procedure compile error: extraneous input '1' expecting {AS, IS, RETURN, LPAREN}
+Stored procedure compile error: extraneous input '1' expecting {AS, AUTHID, IS, RETURN, LPAREN}
 
 ===================================================
 Error:-1360
 In line 1, column 33
-Stored procedure compile error: mismatched input 'int' expecting {AS, IS, RETURN, LPAREN}
+Stored procedure compile error: mismatched input 'int' expecting {AS, AUTHID, IS, RETURN, LPAREN}
 

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_12_comment/answers/01_comment.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_12_comment/answers/01_comment.answer
@@ -2,8 +2,8 @@
 0
 
 ===================================================
-sp_name    sp_type    return_type    arg_count    args    lang    target    owner    comment    
-comment_test     1     0     0          1     Proc_COMMENT_TEST.COMMENT_TEST()     db_user     comment test     
+sp_name    sp_type    return_type    arg_count    args    lang    pkg_name    is_system_generated    directive    target    owner    comment    
+comment_test     1     0     0          0     null     0     0     Proc_COMMENT_TEST.COMMENT_TEST()     db_user     comment test     
 
 
 ===================================================

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_02_create_function/_12_comment/answers/01_comment.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_02_create_function/_12_comment/answers/01_comment.answer
@@ -2,8 +2,8 @@
 0
 
 ===================================================
-sp_name    sp_type    return_type    arg_count    args    lang    target    owner    comment    
-comment_test     2     4     0          1     Func_COMMENT_TEST.COMMENT_TEST() return java.lang.String     db_user     comment test     
+sp_name    sp_type    return_type    arg_count    args    lang    pkg_name    is_system_generated    directive    target    owner    comment    
+comment_test     2     4     0          0     null     0     0     Func_COMMENT_TEST.COMMENT_TEST() return java.lang.String     db_user     comment test     
 
 
 ===================================================

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_06_cursor/_01_basic/answers/02_06_01-06_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_06_cursor/_01_basic/answers/02_06_01-06_error_typo.answer
@@ -15,7 +15,7 @@ Stored procedure compile error: mismatched input ')' expecting {DEFAULT, NOT, ':
 ===================================================
 Error:-1360
 In line 2, column 19
-Stored procedure compile error: mismatched input 'as' expecting {RPAREN, ','}
+Stored procedure compile error: mismatched input 'as' expecting {DEFAULT, RPAREN, ',', ':='}
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_08_local_func/_01_wo_param/answers/02_08_01-02_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_08_local_func/_01_wo_param/answers/02_08_01-02_error_typo.answer
@@ -124,8 +124,8 @@ dba.INTS is not defined. create function choose(m  integer, n  integer) return [
 
 ===================================================
 Error:-1360
-In line 15, column 1
-Stored procedure compile error: mismatched input 'begin' expecting {<EOF>, COMMENT}
+In line 5, column 1
+Stored procedure compile error: missing {AS, IS} at 'TO'
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_08_local_func/_01_wo_param/answers/02_08_01-02_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_08_local_func/_01_wo_param/answers/02_08_01-02_error_typo.answer
@@ -124,8 +124,8 @@ dba.INTS is not defined. create function choose(m  integer, n  integer) return [
 
 ===================================================
 Error:-1360
-In line 5, column 1
-Stored procedure compile error: missing {AS, IS} at 'TO'
+In line 15, column 1
+Stored procedure compile error: mismatched input 'begin' expecting {<EOF>, COMMENT}
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_03_common/answers/03_04_03-05_error_drop_myself.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_03_common/answers/03_04_03-05_error_drop_myself.answer
@@ -2,8 +2,8 @@
 0
 
 ===================================================
-'before'    sp_name    sp_type    return_type    arg_count    lang    target    owner    comment    
-before     t     PROCEDURE     void     0     JAVA     Proc_T.T()     DBA     null     
+'before'    sp_name    pkg_name    sp_type    return_type    arg_count    lang    authid    target    owner    comment    
+before     t     null     PROCEDURE     void     0     PLCSQL     DEFINER     Proc_T.T()     DBA     null     
 
 
 ===================================================
@@ -13,7 +13,7 @@ null
 
 first call t()
 ===================================================
-'after'    sp_name    sp_type    return_type    arg_count    lang    target    owner    comment    
+'after'    sp_name    pkg_name    sp_type    return_type    arg_count    lang    authid    target    owner    comment    
 
 
 ===================================================

--- a/sql/_05_plcsql/_01_testspec/_05_bug_fix/answers/01_drop_user.answer
+++ b/sql/_05_plcsql/_01_testspec/_05_bug_fix/answers/01_drop_user.answer
@@ -29,8 +29,8 @@ Error:-837
 Cannot drop the user who owns database objects.
 
 ===================================================
-sp_name    sp_type    return_type    arg_count    lang    target    owner    comment    
-test_proc     PROCEDURE     void     0     JAVA     Proc_TEST_PROC.TEST_PROC()     TEST     null     
+sp_name    pkg_name    sp_type    return_type    arg_count    lang    authid    target    owner    comment    
+test_proc     null     PROCEDURE     void     0     PLCSQL     DEFINER     Proc_TEST_PROC.TEST_PROC()     TEST     null     
 
 
 ===================================================
@@ -60,6 +60,6 @@ null
 0
 
 ===================================================
-sp_name    sp_type    return_type    arg_count    lang    target    owner    comment    
+sp_name    pkg_name    sp_type    return_type    arg_count    lang    authid    target    owner    comment    
 
 

--- a/sql/_08_javasp/cases/4110-4.sql
+++ b/sql/_08_javasp/cases/4110-4.sql
@@ -1,9 +1,9 @@
 --+ holdcas on;
 autocommit off;
 
-CREATE  function   testresult(q string)  return string as language java name 'jdbc_cubrid415.testresult(java.lang.String) return java.lang.String ';
-CREATE  function   testResultSet(q string)  return cursor as language java name 'jdbc_cubrid415.testResultSet(java.lang.String) return java.sql.ResultSet ';
-create function func(a int, b int) return int as language java name 'SpTest.testInt(int, int) return int';
+CREATE or replace function   testresult(q string)  return string as language java name 'jdbc_cubrid415.testresult(java.lang.String) return java.lang.String ';
+CREATE or replace function   testResultSet(q string)  return cursor as language java name 'jdbc_cubrid415.testResultSet(java.lang.String) return java.sql.ResultSet ';
+create or replace function func(a int, b int) return int as language java name 'SpTest.testInt(int, int) return int';
 
 create class kor ( id int, name string);
 insert into kor values(1000, 'xxx');
@@ -38,10 +38,10 @@ select testResultSet10() from db_root;
 select testResultSet10() + 1 from db_root;
 call testresult10();
 
-CREATE  procedure   testResultSet2(x out cursor)  as language java name 'jdbc_cubrid415.testResultSet2(java.sql.ResultSet ) ';
+CREATE or replace procedure   testResultSet2(x out cursor)  as language java name 'jdbc_cubrid415.testResultSet2(java.sql.ResultSet ) ';
 drop procedure testResultSet2;
-CREATE  procedure   testResultSet2(x in out cursor)  as language java name 'jdbc_cubrid415.testResultSet2(java.sql.ResultSet ) ';
-CREATE  procedure   testResultSet2(x in  cursor)  as language java name 'jdbc_cubrid415.testResultSet2(java.sql.ResultSet ) ';
+CREATE or replace procedure   testResultSet2(x in out cursor)  as language java name 'jdbc_cubrid415.testResultSet2(java.sql.ResultSet ) ';
+CREATE or replace procedure   testResultSet2(x in  cursor)  as language java name 'jdbc_cubrid415.testResultSet2(java.sql.ResultSet ) ';
 
 CREATE  function   testresult1()  return string as language java name 'jdbc_cubrid415.testresult1() return java.lang.String ';
 CREATE  function   testResultSet1()  return cursor as language java name 'jdbc_cubrid415.testResultSet1() return java.sql.ResultSet ';


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25184

다음의 문법 추가로 인한 답지 변경
- PL/CSQL 관련 문법 추가
  - AUTHID
  - DEFAULT
- _db_stored_procedure 시스템 테이블의 pkg_name, is_system_generated, directive 컬럼 추가
- db_stored_procedure 시스템 뷰의 pkg_name, authid 컬럼 추가