### PR TITLE
[CBRD-25457] Executing the “AUTO_INCREMENT” and “DEFAULT” attributes separately using the “ALTER TABLE MODIFY” syntax on the same column resulted in an error of two attributes co-existing in that column

### DIFF
--- a/sql/_13_issues/_14_1h/answers/bug_bts_12663.answer
+++ b/sql/_13_issues/_14_1h/answers/bug_bts_12663.answer
@@ -227,7 +227,13 @@ col1    clob_to_char(col2)    row_number() over (partition by col1,  clob_to_cha
 col1    clob_to_char(col2)    row_number() over (partition by  clob_to_char(col2))    
 1     cubrid     1     
 2     mysql     1     
+3     cubrid     4     
+3     db2     4     
+3     informix     4     
+3     kingbase     4     
+3     mysql     4     
 3     oracle     1     
+3     oracle     4     
 4     kingbase     1     
 5     informix     1     
 6     db2     1     
@@ -243,18 +249,18 @@ col1    clob_to_char(col2)    row_number() over (partition by  clob_to_char(col2
 16     kingbase     3     
 17     informix     3     
 18     db2     3     
-19     cubrid     4     
-20     mysql     4     
-21     oracle     4     
-22     kingbase     4     
-23     informix     4     
-24     db2     4     
 
 ===================================================
 col1    clob_to_char(col2)    row_number() over (partition by  clob_to_char(col2), col1)    
 1     cubrid     1     
 2     mysql     1     
+3     cubrid     1     
+3     db2     1     
+3     informix     1     
+3     kingbase     1     
+3     mysql     1     
 3     oracle     1     
+3     oracle     2     
 4     kingbase     1     
 5     informix     1     
 6     db2     1     
@@ -270,18 +276,18 @@ col1    clob_to_char(col2)    row_number() over (partition by  clob_to_char(col2
 16     kingbase     1     
 17     informix     1     
 18     db2     1     
-19     cubrid     1     
-20     mysql     1     
-21     oracle     1     
-22     kingbase     1     
-23     informix     1     
-24     db2     1     
 
 ===================================================
 col1    clob_to_char(col2)    row_number() over (partition by col1,  clob_to_char(col2))    
 1     cubrid     1     
 2     mysql     1     
+3     cubrid     1     
+3     db2     1     
+3     informix     1     
+3     kingbase     1     
+3     mysql     1     
 3     oracle     1     
+3     oracle     2     
 4     kingbase     1     
 5     informix     1     
 6     db2     1     
@@ -297,12 +303,6 @@ col1    clob_to_char(col2)    row_number() over (partition by col1,  clob_to_cha
 16     kingbase     1     
 17     informix     1     
 18     db2     1     
-19     cubrid     1     
-20     mysql     1     
-21     oracle     1     
-22     kingbase     1     
-23     informix     1     
-24     db2     1     
 
 ===================================================
 0
@@ -372,7 +372,12 @@ row_number
 col1    blob_to_bit(col2)    row_number() over (partition by  blob_to_bit(col2))    
 1     80     1     
 2     90     1     
+3     80     3     
+3     90     3     
 3     a0     1     
+3     a0     3     
+3     b0     3     
+3     c0     3     
 4     b0     1     
 5     c0     1     
 6     80     2     
@@ -380,17 +385,17 @@ col1    blob_to_bit(col2)    row_number() over (partition by  blob_to_bit(col2))
 8     a0     2     
 9     b0     2     
 10     c0     2     
-11     80     3     
-12     90     3     
-13     a0     3     
-14     b0     3     
-15     c0     3     
 
 ===================================================
 col1    blob_to_bit(col2)    row_number() over (partition by  blob_to_bit(col2), col1)    
 1     80     1     
 2     90     1     
+3     80     1     
+3     90     1     
 3     a0     1     
+3     a0     2     
+3     b0     1     
+3     c0     1     
 4     b0     1     
 5     c0     1     
 6     80     1     
@@ -398,17 +403,17 @@ col1    blob_to_bit(col2)    row_number() over (partition by  blob_to_bit(col2),
 8     a0     1     
 9     b0     1     
 10     c0     1     
-11     80     1     
-12     90     1     
-13     a0     1     
-14     b0     1     
-15     c0     1     
 
 ===================================================
 col1    blob_to_bit(col2)    row_number() over (partition by col1,  blob_to_bit(col2))    
 1     80     1     
 2     90     1     
+3     80     1     
+3     90     1     
 3     a0     1     
+3     a0     2     
+3     b0     1     
+3     c0     1     
 4     b0     1     
 5     c0     1     
 6     80     1     
@@ -416,11 +421,6 @@ col1    blob_to_bit(col2)    row_number() over (partition by col1,  blob_to_bit(
 8     a0     1     
 9     b0     1     
 10     c0     1     
-11     80     1     
-12     90     1     
-13     a0     1     
-14     b0     1     
-15     c0     1     
 
 ===================================================
 row_number    
@@ -456,7 +456,7 @@ row_number
 1     
 1     
 1     
-1     
+2     
 
 ===================================================
 0


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25457, https://github.com/CUBRID/cubrid/pull/5364

Purpose

- 기존 auto_increment와 default 속성이 공존하는 경우, 다음 insert 값이 입력될 때 auto_increment 속성 값이 입력됩니다.
- 수정된 버전에서는 auto_increment와 default 속성이 공존할 수 없고 마지막으로 수행된 속성이 적용되며, 다음 insert 값이 입력될 때 마지막으로 수행된 속성 값이 입력됩니다.
- 위와 같은 차이로 test-case 결과가 달라져 수정 했습니다.

TEST CASE
```sql
drop table t;
create table t(col1 int auto_increment,col2 clob);
insert into t(col2) values('cubrid'),('mysql'),('oracle'),('kingbase'),('informix'),('db2');
insert into t(col2) values('cubrid'),('mysql'),('oracle'),('kingbase'),('informix'),('db2');
insert into t(col2) values('cubrid'),('mysql'),('oracle'),('kingbase'),('informix'),('db2');
alter table t modify col1 int default 3;
insert into t(col2) values('cubrid'),('mysql'),('oracle'),('kingbase'),('informix'),('db2');
```

AS-IS (11.2 ~ 11.3v)
```sql
select * from t;
/*
         col1  col2                
===================================
            1  file:/home/cubrid/CUBRID/databases/demodb/lob/ces_454/dba.t.00001722173423603118_0721
            2  file:/home/cubrid/CUBRID/databases/demodb/lob/ces_412/dba.t.00001722173423604376_6661
           ...
           18  file:/home/cubrid/CUBRID/databases/demodb/lob/ces_136/dba.t.00001722173423617951_9445
           19  file:/home/cubrid/CUBRID/databases/demodb/lob/ces_063/dba.t.00001722173431392572_6545
           20  file:/home/cubrid/CUBRID/databases/demodb/lob/ces_172/dba.t.00001722173431393510_9534
           21  file:/home/cubrid/CUBRID/databases/demodb/lob/ces_292/dba.t.00001722173431394247_8065
           22  file:/home/cubrid/CUBRID/databases/demodb/lob/ces_188/dba.t.00001722173431394945_2957
           23  file:/home/cubrid/CUBRID/databases/demodb/lob/ces_215/dba.t.00001722173431395599_4032
           24  file:/home/cubrid/CUBRID/databases/demodb/lob/ces_301/dba.t.00001722173431396210_5378
*/
```

TO-BE (~ 11.0v, [CBRD-25457]이슈 수정 버전)
```sql
select * from t;
/*
         col1  col2                
===================================
            1  file:/home/cubrid/CUBRID/databases/demodb/lob/ces_748/dba.t.00001722173339458710_8592
            2  file:/home/cubrid/CUBRID/databases/demodb/lob/ces_332/dba.t.00001722173339459531_2946
           ...
           18  file:/home/cubrid/CUBRID/databases/demodb/lob/ces_096/dba.t.00001722173340010412_2383
            3  file:/home/cubrid/CUBRID/databases/demodb/lob/ces_347/dba.t.00001722173371121789_8121
            3  file:/home/cubrid/CUBRID/databases/demodb/lob/ces_493/dba.t.00001722173371123165_0244
            3  file:/home/cubrid/CUBRID/databases/demodb/lob/ces_172/dba.t.00001722173371124275_2066
            3  file:/home/cubrid/CUBRID/databases/demodb/lob/ces_629/dba.t.00001722173371125012_8458
            3  file:/home/cubrid/CUBRID/databases/demodb/lob/ces_353/dba.t.00001722173371125849_7403
            3  file:/home/cubrid/CUBRID/databases/demodb/lob/ces_412/dba.t.00001722173371126565_4446
*/
```

Implementation
N/A

Remarks
N/A