### PR TITLE
Revert "[CBRD-25457] Executing the AUTO_INCREMENT and DEFAULT attributes separately using the ALTER TABLE MODIFY syntax on the same column resulted in an error of two attributes co-existing in that column (#1784)"

### DIFF
--- a/sql/_13_issues/_14_1h/answers/bug_bts_12663.answer
+++ b/sql/_13_issues/_14_1h/answers/bug_bts_12663.answer
@@ -227,7 +227,13 @@ col1    clob_to_char(col2)    row_number() over (partition by col1,  clob_to_cha
 col1    clob_to_char(col2)    row_number() over (partition by  clob_to_char(col2))    
 1     cubrid     1     
 2     mysql     1     
+3     cubrid     4     
+3     db2     4     
+3     informix     4     
+3     kingbase     4     
+3     mysql     4     
 3     oracle     1     
+3     oracle     4     
 4     kingbase     1     
 5     informix     1     
 6     db2     1     
@@ -243,18 +249,18 @@ col1    clob_to_char(col2)    row_number() over (partition by  clob_to_char(col2
 16     kingbase     3     
 17     informix     3     
 18     db2     3     
-19     cubrid     4     
-20     mysql     4     
-21     oracle     4     
-22     kingbase     4     
-23     informix     4     
-24     db2     4     
 
 ===================================================
 col1    clob_to_char(col2)    row_number() over (partition by  clob_to_char(col2), col1)    
 1     cubrid     1     
 2     mysql     1     
+3     cubrid     1     
+3     db2     1     
+3     informix     1     
+3     kingbase     1     
+3     mysql     1     
 3     oracle     1     
+3     oracle     2     
 4     kingbase     1     
 5     informix     1     
 6     db2     1     
@@ -270,18 +276,18 @@ col1    clob_to_char(col2)    row_number() over (partition by  clob_to_char(col2
 16     kingbase     1     
 17     informix     1     
 18     db2     1     
-19     cubrid     1     
-20     mysql     1     
-21     oracle     1     
-22     kingbase     1     
-23     informix     1     
-24     db2     1     
 
 ===================================================
 col1    clob_to_char(col2)    row_number() over (partition by col1,  clob_to_char(col2))    
 1     cubrid     1     
 2     mysql     1     
+3     cubrid     1     
+3     db2     1     
+3     informix     1     
+3     kingbase     1     
+3     mysql     1     
 3     oracle     1     
+3     oracle     2     
 4     kingbase     1     
 5     informix     1     
 6     db2     1     
@@ -297,12 +303,6 @@ col1    clob_to_char(col2)    row_number() over (partition by col1,  clob_to_cha
 16     kingbase     1     
 17     informix     1     
 18     db2     1     
-19     cubrid     1     
-20     mysql     1     
-21     oracle     1     
-22     kingbase     1     
-23     informix     1     
-24     db2     1     
 
 ===================================================
 0
@@ -372,7 +372,12 @@ row_number
 col1    blob_to_bit(col2)    row_number() over (partition by  blob_to_bit(col2))    
 1     80     1     
 2     90     1     
+3     80     3     
+3     90     3     
 3     a0     1     
+3     a0     3     
+3     b0     3     
+3     c0     3     
 4     b0     1     
 5     c0     1     
 6     80     2     
@@ -380,17 +385,17 @@ col1    blob_to_bit(col2)    row_number() over (partition by  blob_to_bit(col2))
 8     a0     2     
 9     b0     2     
 10     c0     2     
-11     80     3     
-12     90     3     
-13     a0     3     
-14     b0     3     
-15     c0     3     
 
 ===================================================
 col1    blob_to_bit(col2)    row_number() over (partition by  blob_to_bit(col2), col1)    
 1     80     1     
 2     90     1     
+3     80     1     
+3     90     1     
 3     a0     1     
+3     a0     2     
+3     b0     1     
+3     c0     1     
 4     b0     1     
 5     c0     1     
 6     80     1     
@@ -398,17 +403,17 @@ col1    blob_to_bit(col2)    row_number() over (partition by  blob_to_bit(col2),
 8     a0     1     
 9     b0     1     
 10     c0     1     
-11     80     1     
-12     90     1     
-13     a0     1     
-14     b0     1     
-15     c0     1     
 
 ===================================================
 col1    blob_to_bit(col2)    row_number() over (partition by col1,  blob_to_bit(col2))    
 1     80     1     
 2     90     1     
+3     80     1     
+3     90     1     
 3     a0     1     
+3     a0     2     
+3     b0     1     
+3     c0     1     
 4     b0     1     
 5     c0     1     
 6     80     1     
@@ -416,11 +421,6 @@ col1    blob_to_bit(col2)    row_number() over (partition by col1,  blob_to_bit(
 8     a0     1     
 9     b0     1     
 10     c0     1     
-11     80     1     
-12     90     1     
-13     a0     1     
-14     b0     1     
-15     c0     1     
 
 ===================================================
 row_number    
@@ -456,7 +456,7 @@ row_number
 1     
 1     
 1     
-1     
+2     
 
 ===================================================
 0


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25457, Reverts CUBRID/cubrid-testcases#1797

It is ready for merging in code PR (https://github.com/CUBRID/cubrid/pull/5364).
Therefore, we will revert the reverted TC PR again.