### PR TITLE
[CBRD-24407] Add new isolation testcase for changing 'lock_timeout' and 'isolation_level' through 'set system parameters'

### DIFF
--- a/isolation/_01_ReadCommitted/issues/_24_2h/answer/cbrd_24407.answer
+++ b/isolation/_01_ReadCommitted/issues/_24_2h/answer/cbrd_24407.answer
@@ -1,0 +1,43 @@
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+| 0 row selected
+| 1 row affected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    1    2    10  
+| 1 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    1    2    10  
+| 1 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+| 0 row selected
+| 1 row affected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+| 0 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    1    2    10  
+| 1 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+| 0 row selected
+| 1 row affected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+| 0 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    1    2    10  
+| 1 row selected

--- a/isolation/_01_ReadCommitted/issues/_24_2h/answer/cbrd_24407.answer
+++ b/isolation/_01_ReadCommitted/issues/_24_2h/answer/cbrd_24407.answer
@@ -2,7 +2,7 @@
 | 
 | 
 | 0 row selected
-| 1 row affected
+| 3 rows affected
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -17,7 +17,7 @@
 | 
 | 
 | 0 row selected
-| 1 row affected
+| 3 rows affected
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -31,7 +31,7 @@
 | 
 | 
 | 0 row selected
-| 1 row affected
+| 3 rows affected
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/issues/_24_2h/cbrd_24407.ctl
+++ b/isolation/_01_ReadCommitted/issues/_24_2h/cbrd_24407.ctl
@@ -1,0 +1,82 @@
+/*
+Test Case: related to CBRD-24407
+
+Test point:
+same scenario are executed in following three isolation levels:
+  -- read committed
+  -- repeatable read
+  -- serializable
+
+In this test, instead of using the set transaction syntax, we will use different commands to verify these isolation levels. The purpose is to ensure that changing isolation level and lock timeout via set system parameters is correctly applied and functioning.
+
+We replaced the set transaction isolation level command with set system parameters 'isolation_level=value'. 
+Note: The value must be numeric: serializable=6, repeatable read=5, read committed=4.
+
+We also replaced the set transaction lock timeout command with set system parameters 'lock_timeout=value'. 
+Note: The lock_timeout can be set in seconds and must include the unit (s). If the unit is not provided, it is considered milliseconds. Any value less than 1 second is rounded up to 1 second internally.
+*/
+
+/* preparation */
+MC: setup NUM_CLIENTS = 2;
+C1: set system parameters 'lock_timeout=-1';
+C1: set system parameters 'isolation_level=4';
+C2: set system parameters 'lock_timeout=-1';
+C2: set system parameters 'isolation_level=4';
+C2: commit;
+C1: drop table if exists foo;
+C1: create table foo (a int, b int, c int);
+C1: commit;
+MC: wait until C1 ready;
+
+/* test case 1 -- read committed */
+C1: select a, b, c from foo where a > 0 and c = 10;
+MC: wait until C1 ready;
+C2: insert into foo values (1,2,10);
+C2: commit;
+MC: wait until C2 ready;
+C1: select a, b, c from foo where a > 0 and c = 10;
+C1: commit;
+C1: select a, b, c from foo where a > 0 and c = 10;
+MC: wait until C1 ready;
+
+C1: set system parameters 'isolation_level=5';
+C2: set system parameters 'isolation_level=5';
+C2: commit;
+C1: drop table if exists foo;
+C1: create table foo (a int, b int, c int);
+C1: commit;
+MC: wait until C1 ready;
+
+/* test case 2 -- repeatable read */
+C1: select a, b, c from foo where a > 0 and c = 10;
+MC: wait until C1 ready;
+C2: insert into foo values (1,2,10);
+C2: commit;
+MC: wait until C2 ready;
+C1: select a, b, c from foo where a > 0 and c = 10;
+C1: commit;
+C1: select a, b, c from foo where a > 0 and c = 10;
+MC: wait until C1 ready;
+
+C1: set system parameters 'isolation_level=6';
+C2: set system parameters 'isolation_level=6';
+C2: commit;
+C1: drop table if exists foo;
+C1: create table foo (a int, b int, c int);
+C1: commit;
+MC: wait until C1 ready;
+
+/* test case 3 -- serializable */
+C1: select a, b, c from foo where a > 0 and c = 10;
+MC: wait until C1 ready;
+C2: insert into foo values (1,2,10);
+C2: commit;
+MC: wait until C2 ready;
+C1: select a, b, c from foo where a > 0 and c = 10;
+C1: commit;
+C1: select a, b, c from foo where a > 0 and c = 10;
+MC: wait until C1 ready;
+
+C1: quit;
+C2: quit;
+

--- a/isolation/_01_ReadCommitted/issues/_24_2h/cbrd_24407.ctl
+++ b/isolation/_01_ReadCommitted/issues/_24_2h/cbrd_24407.ctl
@@ -31,7 +31,7 @@ MC: wait until C1 ready;
 /* test case 1 -- read committed */
 C1: select a, b, c from foo where a > 0 and c = 10;
 MC: wait until C1 ready;
-C2: insert into foo values (1,2,10);
+C2: insert into foo values (0,1,9), (1,2,10), (2,3,8);
 C2: commit;
 MC: wait until C2 ready;
 C1: select a, b, c from foo where a > 0 and c = 10;
@@ -50,7 +50,7 @@ MC: wait until C1 ready;
 /* test case 2 -- repeatable read */
 C1: select a, b, c from foo where a > 0 and c = 10;
 MC: wait until C1 ready;
-C2: insert into foo values (1,2,10);
+C2: insert into foo values (0,1,9), (1,2,10), (2,3,8);
 C2: commit;
 MC: wait until C2 ready;
 C1: select a, b, c from foo where a > 0 and c = 10;
@@ -69,7 +69,7 @@ MC: wait until C1 ready;
 /* test case 3 -- serializable */
 C1: select a, b, c from foo where a > 0 and c = 10;
 MC: wait until C1 ready;
-C2: insert into foo values (1,2,10);
+C2: insert into foo values (0,1,9), (1,2,10), (2,3,8);
 C2: commit;
 MC: wait until C2 ready;
 C1: select a, b, c from foo where a > 0 and c = 10;


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-24407

set transaction 구문을 검증하기 위해, 두 종류 테스트케이스를 작성할 예정입니다.

1. isolation
- 실제 동작검증 (isolation level에 대해서만)
- level4에서는 유령읽기가 가능하므로 C1 commit 전에도 C1에서 데이터 조회가 가능합니다.
- level5,6에서는 같은 상황에서 commit 후에만 데이터 조회 가능합니다.

2. shell 
- 실제 동작검증 (lock_timeout에 대해서만)
- cubrid lockdb 에서의 항목 검증
- csql 구문 검증 (;get)