### PR TITLE
[CBRD-25374] Backport from develop to 11.3 - Add a test case that verifies that sort-limit-optimization does not work when there is an expression containing a bind variable in the limit clause.

### DIFF
--- a/sql/_13_issues/_24_1h/answers/cbrd_25374.answer
+++ b/sql/_13_issues/_24_1h/answers/cbrd_25374.answer
@@ -1,0 +1,315 @@
+===================================================
+0
+===================================================
+0
+===================================================
+100000
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+cola    colb    
+101     101     
+102     102     
+103     103     
+104     104     
+105     105     
+106     106     
+107     107     
+108     108     
+109     109     
+110     110     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      NESTED LOOPS (left outer join)
+        SORT (limit)
+          TABLE SCAN (a)
+        INDEX SCAN (b.idx) (key range: a.cola=b.cola, covered: true)
+      INDEX SCAN (c.idx) (key range: a.cola=c.cola, covered: true)
+
+  rewritten query: select a.cola, a.colb from [dba.tbl] a left outer join [dba.tbl] b on a.cola=b.cola left outer join [dba.tbl] c on a.cola=c.cola order by ?, ? for orderby_num()> ?:? *? and orderby_num()<= ?:? *?+ ?:? 
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.tbl.idx), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+        SCAN (index: dba.tbl.idx), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, topnsort: true)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+===================================================
+0
+===================================================
+cola    colb    
+101     101     
+102     102     
+103     103     
+104     104     
+105     105     
+106     106     
+107     107     
+108     108     
+109     109     
+110     110     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      NESTED LOOPS (left outer join)
+        SORT (limit)
+          TABLE SCAN (a)
+        INDEX SCAN (b.idx) (key range: a.cola=b.cola, covered: true)
+      INDEX SCAN (c.idx) (key range: a.cola=c.cola, covered: true)
+
+  rewritten query: select a.cola, a.colb from [dba.tbl] a left outer join [dba.tbl] b on a.cola=b.cola left outer join [dba.tbl] c on a.cola=c.cola order by ?, ? for orderby_num()> ?:? * ?:?  and orderby_num()<= ?:? * ?:? + ?:? 
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.tbl.idx), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+        SCAN (index: dba.tbl.idx), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, topnsort: true)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+===================================================
+0
+===================================================
+cola    colb    
+101     101     
+102     102     
+103     103     
+104     104     
+105     105     
+106     106     
+107     107     
+108     108     
+109     109     
+110     110     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      NESTED LOOPS (left outer join)
+        SORT (limit)
+          TABLE SCAN (a)
+        INDEX SCAN (b.idx) (key range: a.cola=b.cola, covered: true)
+      INDEX SCAN (c.idx) (key range: a.cola=c.cola, covered: true)
+
+  rewritten query: select a.cola, a.colb from [dba.tbl] a left outer join [dba.tbl] b on a.cola=b.cola left outer join [dba.tbl] c on a.cola=c.cola order by ?, ? for orderby_num()> ?:?  and orderby_num()<= ?:? + ?:? 
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.tbl.idx), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+        SCAN (index: dba.tbl.idx), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, topnsort: true)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+===================================================
+0
+===================================================
+cola    colb    
+101     101     
+102     102     
+103     103     
+104     104     
+105     105     
+106     106     
+107     107     
+108     108     
+109     109     
+110     110     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      NESTED LOOPS (left outer join)
+        SORT (limit)
+          TABLE SCAN (a)
+        INDEX SCAN (b.idx) (key range: a.cola=b.cola, covered: true)
+      INDEX SCAN (c.idx) (key range: a.cola=c.cola, covered: true)
+
+  rewritten query: select a.cola, a.colb from [dba.tbl] a left outer join [dba.tbl] b on a.cola=b.cola left outer join [dba.tbl] c on a.cola=c.cola order by ?, ? for orderby_num()> ?:?  and orderby_num()<= ?:? +?* ?:? 
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.tbl.idx), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+        SCAN (index: dba.tbl.idx), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, topnsort: true)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+1000
+===================================================
+2000
+===================================================
+0
+===================================================
+0
+===================================================
+i    j    k    i    j    k    
+12     11     11     12     12     12     
+13     12     12     13     13     13     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    SORT (limit)
+      INDEX SCAN (dba.u.i_u_j) (key range: ([dba.u].j> ?:? ))
+    INDEX SCAN (dba.t.pk_t_i) (key range: [dba.u].i=[dba.t].i)
+
+  rewritten query: select [dba.u].i, [dba.u].j, [dba.u].k, [dba.t].i, [dba.t].j, [dba.t].k from [dba.u] [dba.u], [dba.t] [dba.t] where [dba.u].i=[dba.t].i and ([dba.u].j> ?:? ) order by ? for orderby_num()> ?:? *? and orderby_num()<= ?:? *?+ ?:? 
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.t.pk_t_i), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (index: dba.u.i_u_j), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+===================================================
+0
+===================================================
+i    j    k    i    j    k    
+12     11     11     12     12     12     
+13     12     12     13     13     13     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    SORT (limit)
+      INDEX SCAN (dba.u.i_u_j) (key range: ([dba.u].j> ?:? ))
+    INDEX SCAN (dba.t.pk_t_i) (key range: [dba.u].i=[dba.t].i)
+
+  rewritten query: select [dba.u].i, [dba.u].j, [dba.u].k, [dba.t].i, [dba.t].j, [dba.t].k from [dba.u] [dba.u], [dba.t] [dba.t] where [dba.u].i=[dba.t].i and ([dba.u].j> ?:? ) order by ? for orderby_num()> ?:? * ?:?  and orderby_num()<= ?:? * ?:? + ?:? 
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.t.pk_t_i), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (index: dba.u.i_u_j), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+===================================================
+0
+===================================================
+i    j    k    i    j    k    
+12     11     11     12     12     12     
+13     12     12     13     13     13     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    SORT (limit)
+      INDEX SCAN (dba.u.i_u_j) (key range: ([dba.u].j> ?:? ))
+    INDEX SCAN (dba.t.pk_t_i) (key range: [dba.u].i=[dba.t].i)
+
+  rewritten query: select [dba.u].i, [dba.u].j, [dba.u].k, [dba.t].i, [dba.t].j, [dba.t].k from [dba.u] [dba.u], [dba.t] [dba.t] where [dba.u].i=[dba.t].i and ([dba.u].j> ?:? ) order by ? for orderby_num()> ?:?  and orderby_num()<= ?:? + ?:? 
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.t.pk_t_i), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (index: dba.u.i_u_j), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+===================================================
+0
+===================================================
+i    j    k    i    j    k    
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    SORT (limit)
+      INDEX SCAN (dba.u.i_u_j) (key range: ([dba.u].j> ?:? ))
+    INDEX SCAN (dba.t.pk_t_i) (key range: [dba.u].i=[dba.t].i)
+
+  rewritten query: select [dba.u].i, [dba.u].j, [dba.u].k, [dba.t].i, [dba.t].j, [dba.t].k from [dba.u] [dba.u], [dba.t] [dba.t] where [dba.u].i=[dba.t].i and ([dba.u].j> ?:? ) order by ? for orderby_num()> ?:?  and orderby_num()<= ?:? + cast(? as bigint)*( ?:?  div  ?:? )
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (noscan time: ?, fetch: ?, ioread: ?)
+      SCAN (index: dba.t.pk_t_i), (noscan time: ?, fetch: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (index: dba.u.i_u_j), (noscan time: ?, fetch: ?, ioread: ?)
+     
+
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0

--- a/sql/_13_issues/_24_1h/cases/cbrd_25374.sql
+++ b/sql/_13_issues/_24_1h/cases/cbrd_25374.sql
@@ -1,0 +1,106 @@
+-- sort-limit-optimization does not work when there is an expression containing a bind variable in the limit clause.
+
+-- Check SORT (limit) in plan section and SUBQUERY (uncorrelated) in statistics section. 
+
+-- left join
+drop table if exists tbl;
+create table tbl (cola int, colb int);
+insert into tbl select rownum, rownum  from db_class a, db_class b, db_class c, db_class d limit 100000;
+create index idx on tbl(cola);
+set trace on;
+
+prepare stmta from
+'SELECT a.cola, a.colb
+FROM tbl a
+         LEFT JOIN tbl b ON a.cola = b.cola
+         LEFT JOIN tbl c ON a.cola = c.cola
+ORDER BY a.colb,a.cola
+LIMIT ?*10,?';
+execute stmta using 10,10;
+show trace;
+
+prepare stmta from
+'SELECT a.cola, a.colb
+FROM tbl a
+         LEFT JOIN tbl b ON a.cola = b.cola
+         LEFT JOIN tbl c ON a.cola = c.cola
+ORDER BY a.colb,a.cola
+LIMIT ?*?,?';
+execute stmta using 10,10,10;
+show trace;
+
+prepare stmta from
+'SELECT a.cola, a.colb
+FROM tbl a
+         LEFT JOIN tbl b ON a.cola = b.cola
+         LEFT JOIN tbl c ON a.cola = c.cola
+ORDER BY a.colb,a.cola
+LIMIT ?,?';
+execute stmta using 100,10;
+show trace;
+
+prepare stmta from
+'SELECT a.cola, a.colb
+FROM tbl a
+         LEFT JOIN tbl b ON a.cola = b.cola
+         LEFT JOIN tbl c ON a.cola = c.cola
+ORDER BY a.colb,a.cola
+LIMIT ?,10*?';
+execute stmta using 100,1;
+show trace;
+
+set trace off;
+-- inner join 
+drop table if exists u;
+drop table if exists t;
+
+create table t(i int primary key, j int, k int);
+create table u(i int not null, j int, k int);
+alter table u add constraint fk_t_u_i foreign key(i) references t(i);
+create index i_u_j on u(j);
+
+insert into t select rownum, rownum, rownum from _db_class a, _db_class b limit 1000;
+insert into u select 1+(rownum % 1000), rownum, rownum from _db_class a, _db_class b, _db_class c limit 2000;
+
+set trace on;
+
+prepare stmtb from
+'select /*+ recompile */ * 
+from u, t where u.i = t.i and u.j > 0 
+order by u.j 
+limit ?*5,?';
+execute stmtb using 2,2;
+show trace;
+
+prepare stmtb from
+'select /*+ recompile */ * 
+from u, t where u.i = t.i and u.j > 0 
+order by u.j 
+LIMIT ?*?,?';
+execute stmtb using 2,5,2;
+show trace;
+
+prepare stmtb from
+'select /*+ recompile */ * 
+from u, t where u.i = t.i and u.j > 0 
+order by u.j 
+LIMIT ?,?';
+execute stmtb using 10,2;
+show trace;
+
+prepare stmtb from
+'select /*+ recompile */ * 
+from u, t where u.i = t.i and u.j > 0 
+order by u.j 
+LIMIT ?,10*(?/?)';
+execute stmtb using 10,1,5;
+show trace;
+
+
+set trace off;
+
+drop prepare stmta;
+drop prepare stmtb;
+drop table tbl;
+drop table u;
+drop table t; 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25374

Refer to https://github.com/CUBRID/cubrid-testcases/pull/1782