### PR TITLE
[CBRD-25361] Backport added a new sql test case for Fixed the issue where trace information for CTEs and subqueries not provided (11.2)

### DIFF
--- a/sql/_13_issues/_24_1h/answers/cbrd_25361.answer
+++ b/sql/_13_issues/_24_1h/answers/cbrd_25361.answer
@@ -1,0 +1,1569 @@
+===================================================
+0
+===================================================
+0
+===================================================
+100000
+===================================================
+0
+===================================================
+'1.1 Single CTE: UNION'    
+1.1 Single CTE: UNION     
+
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.2 Single CTE: UNION ALL'    
+1.2 Single CTE: UNION ALL     
+
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.3 Single CTE: DIFFERENCE'    
+1.3 Single CTE: DIFFERENCE     
+
+===================================================
+i    j    k    
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+
+Trace Statistics:
+  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.4 Single CTE: DIFFERENCE ALL'    
+1.4 Single CTE: DIFFERENCE ALL     
+
+===================================================
+i    j    k    
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+
+Trace Statistics:
+  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.5 Single CTE: INTERSECTION'    
+1.5 Single CTE: INTERSECTION     
+
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.6 Single CTE: INTERSECTION ALL'    
+1.6 Single CTE: INTERSECTION ALL     
+
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.7 Multiple CTEs: UNION ALL with Uncorrelated Subqueries'    
+1.7 Multiple CTEs: UNION ALL with Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+0
+===================================================
+100000
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_b)
+
+  rewritten query: select [dba.tbl_b].a, [dba.tbl_b].b, [dba.tbl_b].c from [dba.tbl_b] [dba.tbl_b] order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].i< ?:? ) order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].a, [dba.cte_b].b, [dba.cte_b].c from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].a> ?:? ) order by ?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_b), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+0
+===================================================
+'1.8 Multiple CTEs: UNION with Uncorrelated Subqueries'    
+1.8 Multiple CTEs: UNION with Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+51     51     51     
+52     52     52     
+53     53     53     
+54     54     54     
+55     55     55     
+56     56     56     
+57     57     57     
+58     58     58     
+59     59     59     
+60     60     60     
+61     61     61     
+62     62     62     
+63     63     63     
+64     64     64     
+65     65     65     
+66     66     66     
+67     67     67     
+68     68     68     
+69     69     69     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.9 Multiple CTEs: DIFFERENCE with Uncorrelated Subqueries'    
+1.9 Multiple CTEs: DIFFERENCE with Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].i< ?:? ) order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+
+
+Trace Statistics:
+  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.10 Multiple CTEs: DIFFERENCE ALL with Uncorrelated Subqueries'    
+1.10 Multiple CTEs: DIFFERENCE ALL with Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].i< ?:? ) order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+
+
+Trace Statistics:
+  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.11 Multiple CTEs: INTERSECTION with Uncorrelated Subqueries'    
+1.11 Multiple CTEs: INTERSECTION with Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.12 Multiple CTEs: INTERSECTION ALL with Uncorrelated Subqueries'    
+1.12 Multiple CTEs: INTERSECTION ALL with Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.13 Use limit'    
+1.13 Use limit     
+
+===================================================
+i    
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i from [dba.tbl_a] [dba.tbl_a] where (inst_num()> ?:?  and inst_num()<= ?:? )
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'1.14 Use limit offset'    
+1.14 Use limit offset     
+
+===================================================
+i    
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dual)
+
+  rewritten query: select '?.? Use limit offset' from dual dual
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'1.15 Use rownum'    
+1.15 Use rownum     
+
+===================================================
+i    
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i from [dba.tbl_a] [dba.tbl_a] where (rownum< ?:? )
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'1.16 Use orderby_num()'    
+1.16 Use orderby_num()     
+
+===================================================
+i    
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num() between  ?:?  and  ?:? 
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'2.1 Single CTE: UNION with Correlated Subqueries'    
+2.1 Single CTE: UNION with Correlated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num()<= ?:? 
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].i=[dba.cte_a].i)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].i=[dba.cte_a].i) order by ?)
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].j=[dba.cte_a].j)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].j=[dba.cte_a].j) order by ?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'2.2 Single CTE: INTERSECTION with Correlated Subqueries'    
+2.2 Single CTE: INTERSECTION with Correlated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num()<= ?:? 
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].j=[dba.cte_a].j)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].j=[dba.cte_a].j) order by ?)
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_a].k)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_a].k) order by ?)
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'2.3 Multiple CTEs: UNION ALL with Mixed Correlated and Uncorrelated Subqueries'    
+2.3 Multiple CTEs: UNION ALL with Mixed Correlated and Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+50     50     50     
+51     51     51     
+52     52     52     
+53     53     53     
+54     54     54     
+55     55     55     
+56     56     56     
+57     57     57     
+58     58     58     
+59     59     59     
+60     60     60     
+61     61     61     
+62     62     62     
+63     63     63     
+64     64     64     
+65     65     65     
+66     66     66     
+67     67     67     
+68     68     68     
+69     69     69     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'2.4 Multiple CTEs: UNION with Mixed Correlated and Uncorrelated Subqueries'    
+2.4 Multiple CTEs: UNION with Mixed Correlated and Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+50     50     50     
+51     51     51     
+52     52     52     
+53     53     53     
+54     54     54     
+55     55     55     
+56     56     56     
+57     57     57     
+58     58     58     
+59     59     59     
+60     60     60     
+61     61     61     
+62     62     62     
+63     63     63     
+64     64     64     
+65     65     65     
+66     66     66     
+67     67     67     
+68     68     68     
+69     69     69     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'2.5 Multiple CTEs: DIFFERENCE with Mixed Correlated and Uncorrelated Subqueries'    
+2.5 Multiple CTEs: DIFFERENCE with Mixed Correlated and Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+
+
+Trace Statistics:
+  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'2.6 Multiple CTEs: DIFFERENCE ALL with Mixed Correlated and Uncorrelated Subqueries'    
+2.6 Multiple CTEs: DIFFERENCE ALL with Mixed Correlated and Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+
+
+Trace Statistics:
+  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'2.7 Multiple CTEs: INTERSECTION with Mixed Correlated and Uncorrelated Subqueries'    
+2.7 Multiple CTEs: INTERSECTION with Mixed Correlated and Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'2.8 Multiple CTEs: INTERSECTION ALL with Mixed Correlated and Uncorrelated Subqueries'    
+2.8 Multiple CTEs: INTERSECTION ALL with Mixed Correlated and Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+0
+===================================================
+0

--- a/sql/_13_issues/_24_1h/answers/cbrd_25361.answer
+++ b/sql/_13_issues/_24_1h/answers/cbrd_25361.answer
@@ -45,24 +45,24 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
 
 Trace Statistics:
-  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  UNION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -126,24 +126,24 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
 
 Trace Statistics:
-  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  UNION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -167,24 +167,24 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
 
 Trace Statistics:
-  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  DIFFERENCE (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -208,24 +208,24 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
 
 Trace Statistics:
-  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  DIFFERENCE (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -269,24 +269,24 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -330,24 +330,24 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -404,28 +404,28 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].i< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].i< ?:? ) order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].a, [dba.cte_b].b, [dba.cte_b].c from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].a> ?:? ) order by ?)
+  rewritten query: (select [dba.cte_b].a, [dba.cte_b].b, [dba.cte_b].c from  [dba.cte_b] where ([dba.cte_b].a> ?:? ) order by ?)
 
 
 Trace Statistics:
-  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  UNION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_b), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -490,28 +490,28 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
 
 
 Trace Statistics:
-  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  UNION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -561,28 +561,28 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].i< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].i< ?:? ) order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
 
 
 Trace Statistics:
-  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  DIFFERENCE (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -632,28 +632,28 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].i< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].i< ?:? ) order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
 
 
 Trace Statistics:
-  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  DIFFERENCE (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -684,28 +684,28 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -736,28 +736,28 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -779,42 +779,42 @@ Query Plan:
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    DIFFERENCE (time: ?, fetch: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, ioread: ?)
+        UNION (time: ?, fetch: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -828,28 +828,23 @@ i
 ===================================================
 trace    
 
-Query Plan:
-  TABLE SCAN (dual)
-
-  rewritten query: select '?.? Use limit offset' from dual dual
-
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    DIFFERENCE (time: ?, fetch: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, ioread: ?)
+        UNION (time: ?, fetch: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -870,42 +865,42 @@ Query Plan:
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    DIFFERENCE (time: ?, fetch: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, ioread: ?)
+        UNION (time: ?, fetch: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -927,43 +922,43 @@ Query Plan:
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    DIFFERENCE (time: ?, fetch: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, ioread: ?)
+        UNION (time: ?, fetch: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -1012,7 +1007,7 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].i=[dba.cte_a].i) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].i=[dba.cte_a].i) order by ?)
 
   TABLE SCAN (dba.tbl_a)
 
@@ -1021,26 +1016,26 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].j=[dba.cte_a].j) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].j=[dba.cte_a].j) order by ?)
 
 
 Trace Statistics:
-  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  UNION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -1089,7 +1084,7 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].j=[dba.cte_a].j) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].j=[dba.cte_a].j) order by ?)
 
   TABLE SCAN (dba.tbl_a)
 
@@ -1098,26 +1093,26 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_a].k) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_a].k) order by ?)
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -1179,7 +1174,7 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
 
   TABLE SCAN (dba.tbl_a)
 
@@ -1188,27 +1183,27 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
 
 
 Trace Statistics:
-  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  UNION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -1270,7 +1265,7 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
 
   TABLE SCAN (dba.tbl_a)
 
@@ -1279,27 +1274,27 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
 
 
 Trace Statistics:
-  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  UNION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -1341,7 +1336,7 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
 
   TABLE SCAN (dba.tbl_a)
 
@@ -1350,27 +1345,27 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
 
 
 Trace Statistics:
-  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  DIFFERENCE (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -1412,7 +1407,7 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
 
   TABLE SCAN (dba.tbl_a)
 
@@ -1421,27 +1416,27 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
 
 
 Trace Statistics:
-  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  DIFFERENCE (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -1471,7 +1466,7 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
 
   TABLE SCAN (dba.tbl_a)
 
@@ -1480,27 +1475,27 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -1530,7 +1525,7 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
 
   TABLE SCAN (dba.tbl_a)
 
@@ -1539,27 +1534,27 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 

--- a/sql/_13_issues/_24_1h/cases/cbrd_25361.sql
+++ b/sql/_13_issues/_24_1h/cases/cbrd_25361.sql
@@ -1,0 +1,313 @@
+-- Test Cases for CBRD-25361: Fixed the issue where trace information for CTEs and subqueries are not provided.
+
+--------------------------------------------------------------------------------
+-- These test cases verify the fix for CBRD-25361, ensuring that trace information
+-- is correctly outputted for various scenarios involving CTEs and subqueries,
+-- including UNION, UNION ALL, DIFFERENCE, DIFFERENCE ALL, INTERSECTION, 
+-- INTERSECTION ALL, and combinations of correlated and uncorrelated subqueries.
+--------------------------------------------------------------------------------
+
+-- 1. Uncorrelated Subqueries
+
+drop table if exists tbl_a;
+
+create table tbl_a ( i int, j varchar, k varchar);
+
+insert into tbl_a select rownum, rownum, rownum 
+from db_class a, db_class c, db_class d limit 100000;
+
+set trace on;
+
+-- 1.1 Single CTE: UNION
+SELECT '1.1 Single CTE: UNION';
+WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a ORDER BY i)
+UNION
+(SELECT * FROM cte_a ORDER BY i);
+
+show trace;
+
+-- 1.2 Single CTE: UNION ALL
+SELECT '1.2 Single CTE: UNION ALL';
+WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a ORDER BY i)
+UNION ALL
+(SELECT * FROM cte_a ORDER BY i);
+
+show trace;
+
+-- 1.3 Single CTE: DIFFERENCE
+SELECT '1.3 Single CTE: DIFFERENCE';
+WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a ORDER BY i)
+DIFFERENCE
+(SELECT * FROM cte_a ORDER BY i);
+
+show trace;
+
+-- 1.4 Single CTE: DIFFERENCE ALL
+SELECT '1.4 Single CTE: DIFFERENCE ALL';
+WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a ORDER BY i)
+DIFFERENCE ALL
+(SELECT * FROM cte_a ORDER BY i);
+
+show trace;
+
+-- 1.5 Single CTE: INTERSECTION
+SELECT '1.5 Single CTE: INTERSECTION';
+WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a ORDER BY i)
+INTERSECTION
+(SELECT * FROM cte_a ORDER BY i);
+
+show trace;
+
+-- 1.6 Single CTE: INTERSECTION ALL
+SELECT '1.6 Single CTE: INTERSECTION ALL';
+WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a ORDER BY i)
+INTERSECTION ALL
+(SELECT * FROM cte_a ORDER BY i);
+
+show trace;
+
+-- 1.7 Multiple CTEs: UNION ALL with Uncorrelated Subqueries
+SELECT '1.7 Multiple CTEs: UNION ALL with Uncorrelated Subqueries';
+drop table if exists tbl_b;
+
+create table tbl_b ( a int, b varchar, c varchar);
+
+insert into tbl_b select rownum, rownum, rownum 
+from db_class a, db_class c, db_class d limit 100000;
+
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_b ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE i < 50 ORDER BY i)
+UNION ALL
+(SELECT * FROM cte_b WHERE a > 50 ORDER BY a);
+
+show trace;
+drop table tbl_b;
+
+-- 1.8 Multiple CTEs: UNION with Uncorrelated Subqueries
+SELECT '1.8 Multiple CTEs: UNION with Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE j < 30 ORDER BY i)
+UNION
+(SELECT * FROM cte_b WHERE k > 50 ORDER BY i);
+
+show trace;
+
+-- 1.9 Multiple CTEs: DIFFERENCE with Uncorrelated Subqueries
+SELECT '1.9 Multiple CTEs: DIFFERENCE with Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE i < 20 ORDER BY i)
+DIFFERENCE
+(SELECT * FROM cte_b WHERE k > 30 ORDER BY i);
+
+show trace;
+
+-- 1.10 Multiple CTEs: DIFFERENCE ALL with Uncorrelated Subqueries
+SELECT '1.10 Multiple CTEs: DIFFERENCE ALL with Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE i < 20 ORDER BY i)
+DIFFERENCE ALL
+(SELECT * FROM cte_b WHERE k > 30 ORDER BY i);
+
+show trace;
+
+-- 1.11 Multiple CTEs: INTERSECTION with Uncorrelated Subqueries
+SELECT '1.11 Multiple CTEs: INTERSECTION with Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE j < 30 ORDER BY i)
+INTERSECTION
+(SELECT * FROM cte_b WHERE k > 50 ORDER BY i);
+
+show trace;
+
+-- 1.12 Multiple CTEs: INTERSECTION ALL with Uncorrelated Subqueries
+SELECT '1.12 Multiple CTEs: INTERSECTION ALL with Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE j < 30 ORDER BY i)
+INTERSECTION ALL
+(SELECT * FROM cte_b WHERE k > 50 ORDER BY i);
+
+show trace;
+
+-- 1.13 Use limit
+SELECT '1.13 Use limit';
+WITH cte1 AS (SELECT i FROM tbl_a limit 1, 10)
+(SELECT * FROM cte1)
+UNION ALL
+(SELECT * FROM cte1)
+UNION
+(SELECT * FROM cte1)
+DIFFERENCE
+(SELECT * FROM cte1)
+INTERSECTION
+(SELECT * FROM cte1);
+
+show trace;
+
+-- 1.14 Use limit offset
+SELECT '1.14 Use limit offset';
+WITH cte1 AS (SELECT i FROM tbl_a limit 3 offset 7)
+(SELECT * FROM cte1)
+UNION ALL
+(SELECT * FROM cte1)
+UNION
+(SELECT * FROM cte1)
+DIFFERENCE
+(SELECT * FROM cte1)
+INTERSECTION
+(SELECT * FROM cte1);
+
+show trace;
+
+-- 1.15 Use rownum
+SELECT '1.15 Use rownum';
+WITH cte1 AS (SELECT i FROM tbl_a where rownum < 5 )
+(SELECT * FROM cte1)
+UNION ALL
+(SELECT * FROM cte1)
+UNION
+(SELECT * FROM cte1)
+DIFFERENCE
+(SELECT * FROM cte1)
+INTERSECTION
+(SELECT * FROM cte1);
+
+show trace;
+
+-- 1.16 Use orderby_num()
+SELECT '1.16 Use orderby_num()';
+WITH cte1 AS (SELECT i FROM tbl_a order by 1 for orderby_num() between 3 and 5)
+(SELECT * FROM cte1)
+UNION ALL
+(SELECT * FROM cte1)
+UNION
+(SELECT * FROM cte1)
+DIFFERENCE
+(SELECT * FROM cte1)
+INTERSECTION
+(SELECT * FROM cte1);
+
+show trace;
+
+-- 2. Correlated Subqueries
+
+-- 2.1 Single CTE: UNION with Correlated Subqueries
+SELECT '2.1 Single CTE: UNION with Correlated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.i = cte_a.i) ORDER BY i)
+UNION
+(SELECT * FROM cte_a WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.j = cte_a.j) ORDER BY i);
+
+show trace;
+
+-- 2.2 Single CTE: INTERSECTION with Correlated Subqueries
+SELECT '2.2 Single CTE: INTERSECTION with Correlated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.j = cte_a.j) ORDER BY i)
+INTERSECTION
+(SELECT * FROM cte_a WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.k = cte_a.k) ORDER BY i);
+
+show trace;
+
+-- 2.3 Multiple CTEs: UNION ALL with Mixed Correlated and Uncorrelated Subqueries
+SELECT '2.3 Multiple CTEs: UNION ALL with Mixed Correlated and Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE j < 20 ORDER BY i)
+UNION ALL
+(SELECT * FROM cte_b WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.k = cte_b.k) ORDER BY i);
+
+show trace;
+
+-- 2.4 Multiple CTEs: UNION with Mixed Correlated and Uncorrelated Subqueries
+SELECT '2.4 Multiple CTEs: UNION with Mixed Correlated and Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE j < 20 ORDER BY i)
+UNION
+(SELECT * FROM cte_b WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.k = cte_b.k) ORDER BY i);
+
+show trace;
+
+-- 2.5 Multiple CTEs: DIFFERENCE with Mixed Correlated and Uncorrelated Subqueries
+SELECT '2.5 Multiple CTEs: DIFFERENCE with Mixed Correlated and Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE j < 20 ORDER BY i)
+DIFFERENCE
+(SELECT * FROM cte_b WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.k = cte_b.k) ORDER BY i);
+
+show trace;
+
+-- 2.6 Multiple CTEs: DIFFERENCE ALL with Mixed Correlated and Uncorrelated Subqueries
+SELECT '2.6 Multiple CTEs: DIFFERENCE ALL with Mixed Correlated and Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE j < 20 ORDER BY i)
+DIFFERENCE ALL
+(SELECT * FROM cte_b WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.k = cte_b.k) ORDER BY i);
+
+show trace;
+
+-- 2.7 Multiple CTEs: INTERSECTION with Mixed Correlated and Uncorrelated Subqueries
+SELECT '2.7 Multiple CTEs: INTERSECTION with Mixed Correlated and Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE j < 20 ORDER BY i)
+INTERSECTION
+(SELECT * FROM cte_b WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.k = cte_b.k) ORDER BY i);
+
+show trace;
+
+-- 2.8 Multiple CTEs: INTERSECTION ALL with Mixed Correlated and Uncorrelated Subqueries
+SELECT '2.8 Multiple CTEs: INTERSECTION ALL with Mixed Correlated and Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE j < 20 ORDER BY i)
+INTERSECTION ALL
+(SELECT * FROM cte_b WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.k = cte_b.k) ORDER BY i);
+
+show trace;
+
+set trace off;
+drop table tbl_a;
+


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-25361, https://github.com/CUBRID/cubrid-testcases/pull/1767

Note: also needs to backport the revised answers for https://github.com/CUBRID/cubrid-testcases/pull/1818 (exclude fetch_time info) --> DONE (https://github.com/CUBRID/cubrid-testcases/pull/1833)

^ For the revise, we'll need to wait for the 11.2.9 build and verify the files before merging --> VERIFIED in 11.2.9.0862-f78ea00