### PR TITLE
[CBRD-25361] Backport added a new sql test case for Fixed the issue where trace information for CTEs and subqueries not provided (10.2)

### DIFF
--- a/sql/_13_issues/_24_1h/answers/cbrd_25361.answer
+++ b/sql/_13_issues/_24_1h/answers/cbrd_25361.answer
@@ -1,0 +1,1569 @@
+===================================================
+0
+===================================================
+0
+===================================================
+100000
+===================================================
+0
+===================================================
+'1.1 Single CTE: UNION'    
+1.1 Single CTE: UNION     
+
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.2 Single CTE: UNION ALL'    
+1.2 Single CTE: UNION ALL     
+
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.3 Single CTE: DIFFERENCE'    
+1.3 Single CTE: DIFFERENCE     
+
+===================================================
+i    j    k    
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+
+Trace Statistics:
+  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.4 Single CTE: DIFFERENCE ALL'    
+1.4 Single CTE: DIFFERENCE ALL     
+
+===================================================
+i    j    k    
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+
+Trace Statistics:
+  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.5 Single CTE: INTERSECTION'    
+1.5 Single CTE: INTERSECTION     
+
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.6 Single CTE: INTERSECTION ALL'    
+1.6 Single CTE: INTERSECTION ALL     
+
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.7 Multiple CTEs: UNION ALL with Uncorrelated Subqueries'    
+1.7 Multiple CTEs: UNION ALL with Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+0
+===================================================
+100000
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_b)
+
+  rewritten query: select [dba.tbl_b].a, [dba.tbl_b].b, [dba.tbl_b].c from [dba.tbl_b] [dba.tbl_b] order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].i< ?:? ) order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].a, [dba.cte_b].b, [dba.cte_b].c from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].a> ?:? ) order by ?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_b), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+0
+===================================================
+'1.8 Multiple CTEs: UNION with Uncorrelated Subqueries'    
+1.8 Multiple CTEs: UNION with Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+51     51     51     
+52     52     52     
+53     53     53     
+54     54     54     
+55     55     55     
+56     56     56     
+57     57     57     
+58     58     58     
+59     59     59     
+60     60     60     
+61     61     61     
+62     62     62     
+63     63     63     
+64     64     64     
+65     65     65     
+66     66     66     
+67     67     67     
+68     68     68     
+69     69     69     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.9 Multiple CTEs: DIFFERENCE with Uncorrelated Subqueries'    
+1.9 Multiple CTEs: DIFFERENCE with Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].i< ?:? ) order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+
+
+Trace Statistics:
+  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.10 Multiple CTEs: DIFFERENCE ALL with Uncorrelated Subqueries'    
+1.10 Multiple CTEs: DIFFERENCE ALL with Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].i< ?:? ) order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+
+
+Trace Statistics:
+  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.11 Multiple CTEs: INTERSECTION with Uncorrelated Subqueries'    
+1.11 Multiple CTEs: INTERSECTION with Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.12 Multiple CTEs: INTERSECTION ALL with Uncorrelated Subqueries'    
+1.12 Multiple CTEs: INTERSECTION ALL with Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+'1.13 Use limit'    
+1.13 Use limit     
+
+===================================================
+i    
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i from [dba.tbl_a] [dba.tbl_a] where (inst_num()> ?:?  and inst_num()<= ?:? )
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'1.14 Use limit offset'    
+1.14 Use limit offset     
+
+===================================================
+i    
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dual)
+
+  rewritten query: select '?.? Use limit offset' from dual dual
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'1.15 Use rownum'    
+1.15 Use rownum     
+
+===================================================
+i    
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i from [dba.tbl_a] [dba.tbl_a] where (rownum< ?:? )
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'1.16 Use orderby_num()'    
+1.16 Use orderby_num()     
+
+===================================================
+i    
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num() between  ?:?  and  ?:? 
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+  TABLE SCAN (dba.cte?)
+
+  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'2.1 Single CTE: UNION with Correlated Subqueries'    
+2.1 Single CTE: UNION with Correlated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num()<= ?:? 
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].i=[dba.cte_a].i)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].i=[dba.cte_a].i) order by ?)
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].j=[dba.cte_a].j)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].j=[dba.cte_a].j) order by ?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'2.2 Single CTE: INTERSECTION with Correlated Subqueries'    
+2.2 Single CTE: INTERSECTION with Correlated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] order by ? for orderby_num()<= ?:? 
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].j=[dba.cte_a].j)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].j=[dba.cte_a].j) order by ?)
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_a].k)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_a].k) order by ?)
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'2.3 Multiple CTEs: UNION ALL with Mixed Correlated and Uncorrelated Subqueries'    
+2.3 Multiple CTEs: UNION ALL with Mixed Correlated and Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+50     50     50     
+51     51     51     
+52     52     52     
+53     53     53     
+54     54     54     
+55     55     55     
+56     56     56     
+57     57     57     
+58     58     58     
+59     59     59     
+60     60     60     
+61     61     61     
+62     62     62     
+63     63     63     
+64     64     64     
+65     65     65     
+66     66     66     
+67     67     67     
+68     68     68     
+69     69     69     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'2.4 Multiple CTEs: UNION with Mixed Correlated and Uncorrelated Subqueries'    
+2.4 Multiple CTEs: UNION with Mixed Correlated and Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+50     50     50     
+51     51     51     
+52     52     52     
+53     53     53     
+54     54     54     
+55     55     55     
+56     56     56     
+57     57     57     
+58     58     58     
+59     59     59     
+60     60     60     
+61     61     61     
+62     62     62     
+63     63     63     
+64     64     64     
+65     65     65     
+66     66     66     
+67     67     67     
+68     68     68     
+69     69     69     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'2.5 Multiple CTEs: DIFFERENCE with Mixed Correlated and Uncorrelated Subqueries'    
+2.5 Multiple CTEs: DIFFERENCE with Mixed Correlated and Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+
+
+Trace Statistics:
+  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'2.6 Multiple CTEs: DIFFERENCE ALL with Mixed Correlated and Uncorrelated Subqueries'    
+2.6 Multiple CTEs: DIFFERENCE ALL with Mixed Correlated and Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+1     1     1     
+2     2     2     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+
+
+Trace Statistics:
+  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'2.7 Multiple CTEs: INTERSECTION with Mixed Correlated and Uncorrelated Subqueries'    
+2.7 Multiple CTEs: INTERSECTION with Mixed Correlated and Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+'2.8 Multiple CTEs: INTERSECTION ALL with Mixed Correlated and Uncorrelated Subqueries'    
+2.8 Multiple CTEs: INTERSECTION ALL with Mixed Correlated and Uncorrelated Subqueries     
+
+===================================================
+0
+===================================================
+i    j    k    
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i< ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.tbl_a)
+
+  rewritten query: select [dba.tbl_a].i, [dba.tbl_a].j, [dba.tbl_a].k from [dba.tbl_a] [dba.tbl_a] where ([dba.tbl_a].i>= ?:? ) order by ? for orderby_num()<= ?:? 
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_a)
+
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+
+  TABLE SCAN (dba.tbl_a)
+
+  rewritten query: (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k)
+
+  SORT (order by)
+    TABLE SCAN (dba.cte_b)
+
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+0
+===================================================
+0

--- a/sql/_13_issues/_24_1h/answers/cbrd_25361.answer
+++ b/sql/_13_issues/_24_1h/answers/cbrd_25361.answer
@@ -7,7 +7,7 @@
 ===================================================
 0
 ===================================================
-'1.1 Single CTE: UNION'    
+    
 1.1 Single CTE: UNION     
 
 ===================================================
@@ -68,7 +68,7 @@ Trace Statistics:
      
 
 ===================================================
-'1.2 Single CTE: UNION ALL'    
+    
 1.2 Single CTE: UNION ALL     
 
 ===================================================
@@ -149,7 +149,7 @@ Trace Statistics:
      
 
 ===================================================
-'1.3 Single CTE: DIFFERENCE'    
+    
 1.3 Single CTE: DIFFERENCE     
 
 ===================================================
@@ -190,7 +190,7 @@ Trace Statistics:
      
 
 ===================================================
-'1.4 Single CTE: DIFFERENCE ALL'    
+    
 1.4 Single CTE: DIFFERENCE ALL     
 
 ===================================================
@@ -231,7 +231,7 @@ Trace Statistics:
      
 
 ===================================================
-'1.5 Single CTE: INTERSECTION'    
+    
 1.5 Single CTE: INTERSECTION     
 
 ===================================================
@@ -292,7 +292,7 @@ Trace Statistics:
      
 
 ===================================================
-'1.6 Single CTE: INTERSECTION ALL'    
+    
 1.6 Single CTE: INTERSECTION ALL     
 
 ===================================================
@@ -353,7 +353,7 @@ Trace Statistics:
      
 
 ===================================================
-'1.7 Multiple CTEs: UNION ALL with Uncorrelated Subqueries'    
+    
 1.7 Multiple CTEs: UNION ALL with Uncorrelated Subqueries     
 
 ===================================================
@@ -432,7 +432,7 @@ Trace Statistics:
 ===================================================
 0
 ===================================================
-'1.8 Multiple CTEs: UNION with Uncorrelated Subqueries'    
+    
 1.8 Multiple CTEs: UNION with Uncorrelated Subqueries     
 
 ===================================================
@@ -517,7 +517,7 @@ Trace Statistics:
      
 
 ===================================================
-'1.9 Multiple CTEs: DIFFERENCE with Uncorrelated Subqueries'    
+    
 1.9 Multiple CTEs: DIFFERENCE with Uncorrelated Subqueries     
 
 ===================================================
@@ -588,7 +588,7 @@ Trace Statistics:
      
 
 ===================================================
-'1.10 Multiple CTEs: DIFFERENCE ALL with Uncorrelated Subqueries'    
+    
 1.10 Multiple CTEs: DIFFERENCE ALL with Uncorrelated Subqueries     
 
 ===================================================
@@ -659,7 +659,7 @@ Trace Statistics:
      
 
 ===================================================
-'1.11 Multiple CTEs: INTERSECTION with Uncorrelated Subqueries'    
+    
 1.11 Multiple CTEs: INTERSECTION with Uncorrelated Subqueries     
 
 ===================================================
@@ -711,7 +711,7 @@ Trace Statistics:
      
 
 ===================================================
-'1.12 Multiple CTEs: INTERSECTION ALL with Uncorrelated Subqueries'    
+    
 1.12 Multiple CTEs: INTERSECTION ALL with Uncorrelated Subqueries     
 
 ===================================================
@@ -763,7 +763,7 @@ Trace Statistics:
      
 
 ===================================================
-'1.13 Use limit'    
+    
 1.13 Use limit     
 
 ===================================================
@@ -819,7 +819,7 @@ Trace Statistics:
      
 
 ===================================================
-'1.14 Use limit offset'    
+    
 1.14 Use limit offset     
 
 ===================================================
@@ -827,11 +827,6 @@ i
 
 ===================================================
 trace    
-
-Query Plan:
-  TABLE SCAN (dual)
-
-  rewritten query: select '?.? Use limit offset' from dual dual
 
 Trace Statistics:
   INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -854,7 +849,7 @@ Trace Statistics:
      
 
 ===================================================
-'1.15 Use rownum'    
+    
 1.15 Use rownum     
 
 ===================================================
@@ -910,7 +905,7 @@ Trace Statistics:
      
 
 ===================================================
-'1.16 Use orderby_num()'    
+    
 1.16 Use orderby_num()     
 
 ===================================================
@@ -968,7 +963,7 @@ Trace Statistics:
      
 
 ===================================================
-'2.1 Single CTE: UNION with Correlated Subqueries'    
+    
 2.1 Single CTE: UNION with Correlated Subqueries     
 
 ===================================================
@@ -1045,7 +1040,7 @@ Trace Statistics:
      
 
 ===================================================
-'2.2 Single CTE: INTERSECTION with Correlated Subqueries'    
+    
 2.2 Single CTE: INTERSECTION with Correlated Subqueries     
 
 ===================================================
@@ -1122,7 +1117,7 @@ Trace Statistics:
      
 
 ===================================================
-'2.3 Multiple CTEs: UNION ALL with Mixed Correlated and Uncorrelated Subqueries'    
+    
 2.3 Multiple CTEs: UNION ALL with Mixed Correlated and Uncorrelated Subqueries     
 
 ===================================================
@@ -1213,7 +1208,7 @@ Trace Statistics:
      
 
 ===================================================
-'2.4 Multiple CTEs: UNION with Mixed Correlated and Uncorrelated Subqueries'    
+    
 2.4 Multiple CTEs: UNION with Mixed Correlated and Uncorrelated Subqueries     
 
 ===================================================
@@ -1304,7 +1299,7 @@ Trace Statistics:
      
 
 ===================================================
-'2.5 Multiple CTEs: DIFFERENCE with Mixed Correlated and Uncorrelated Subqueries'    
+    
 2.5 Multiple CTEs: DIFFERENCE with Mixed Correlated and Uncorrelated Subqueries     
 
 ===================================================
@@ -1375,7 +1370,7 @@ Trace Statistics:
      
 
 ===================================================
-'2.6 Multiple CTEs: DIFFERENCE ALL with Mixed Correlated and Uncorrelated Subqueries'    
+    
 2.6 Multiple CTEs: DIFFERENCE ALL with Mixed Correlated and Uncorrelated Subqueries     
 
 ===================================================
@@ -1446,7 +1441,7 @@ Trace Statistics:
      
 
 ===================================================
-'2.7 Multiple CTEs: INTERSECTION with Mixed Correlated and Uncorrelated Subqueries'    
+    
 2.7 Multiple CTEs: INTERSECTION with Mixed Correlated and Uncorrelated Subqueries     
 
 ===================================================
@@ -1505,7 +1500,7 @@ Trace Statistics:
      
 
 ===================================================
-'2.8 Multiple CTEs: INTERSECTION ALL with Mixed Correlated and Uncorrelated Subqueries'    
+    
 2.8 Multiple CTEs: INTERSECTION ALL with Mixed Correlated and Uncorrelated Subqueries     
 
 ===================================================

--- a/sql/_13_issues/_24_1h/cases/cbrd_25361.sql
+++ b/sql/_13_issues/_24_1h/cases/cbrd_25361.sql
@@ -19,7 +19,7 @@ from db_class a, db_class c, db_class d limit 100000;
 set trace on;
 
 -- 1.1 Single CTE: UNION
-SELECT '1.1 Single CTE: UNION';
+EVALUATE '1.1 Single CTE: UNION';
 WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
 (SELECT * FROM cte_a ORDER BY i)
 UNION
@@ -28,7 +28,7 @@ UNION
 show trace;
 
 -- 1.2 Single CTE: UNION ALL
-SELECT '1.2 Single CTE: UNION ALL';
+EVALUATE '1.2 Single CTE: UNION ALL';
 WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
 (SELECT * FROM cte_a ORDER BY i)
 UNION ALL
@@ -37,7 +37,7 @@ UNION ALL
 show trace;
 
 -- 1.3 Single CTE: DIFFERENCE
-SELECT '1.3 Single CTE: DIFFERENCE';
+EVALUATE '1.3 Single CTE: DIFFERENCE';
 WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
 (SELECT * FROM cte_a ORDER BY i)
 DIFFERENCE
@@ -46,7 +46,7 @@ DIFFERENCE
 show trace;
 
 -- 1.4 Single CTE: DIFFERENCE ALL
-SELECT '1.4 Single CTE: DIFFERENCE ALL';
+EVALUATE '1.4 Single CTE: DIFFERENCE ALL';
 WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
 (SELECT * FROM cte_a ORDER BY i)
 DIFFERENCE ALL
@@ -55,7 +55,7 @@ DIFFERENCE ALL
 show trace;
 
 -- 1.5 Single CTE: INTERSECTION
-SELECT '1.5 Single CTE: INTERSECTION';
+EVALUATE '1.5 Single CTE: INTERSECTION';
 WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
 (SELECT * FROM cte_a ORDER BY i)
 INTERSECTION
@@ -64,7 +64,7 @@ INTERSECTION
 show trace;
 
 -- 1.6 Single CTE: INTERSECTION ALL
-SELECT '1.6 Single CTE: INTERSECTION ALL';
+EVALUATE '1.6 Single CTE: INTERSECTION ALL';
 WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
 (SELECT * FROM cte_a ORDER BY i)
 INTERSECTION ALL
@@ -73,7 +73,7 @@ INTERSECTION ALL
 show trace;
 
 -- 1.7 Multiple CTEs: UNION ALL with Uncorrelated Subqueries
-SELECT '1.7 Multiple CTEs: UNION ALL with Uncorrelated Subqueries';
+EVALUATE '1.7 Multiple CTEs: UNION ALL with Uncorrelated Subqueries';
 drop table if exists tbl_b;
 
 create table tbl_b ( a int, b varchar, c varchar);
@@ -93,7 +93,7 @@ show trace;
 drop table tbl_b;
 
 -- 1.8 Multiple CTEs: UNION with Uncorrelated Subqueries
-SELECT '1.8 Multiple CTEs: UNION with Uncorrelated Subqueries';
+EVALUATE '1.8 Multiple CTEs: UNION with Uncorrelated Subqueries';
 set trace on;
 
 WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
@@ -105,7 +105,7 @@ UNION
 show trace;
 
 -- 1.9 Multiple CTEs: DIFFERENCE with Uncorrelated Subqueries
-SELECT '1.9 Multiple CTEs: DIFFERENCE with Uncorrelated Subqueries';
+EVALUATE '1.9 Multiple CTEs: DIFFERENCE with Uncorrelated Subqueries';
 set trace on;
 
 WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
@@ -117,7 +117,7 @@ DIFFERENCE
 show trace;
 
 -- 1.10 Multiple CTEs: DIFFERENCE ALL with Uncorrelated Subqueries
-SELECT '1.10 Multiple CTEs: DIFFERENCE ALL with Uncorrelated Subqueries';
+EVALUATE '1.10 Multiple CTEs: DIFFERENCE ALL with Uncorrelated Subqueries';
 set trace on;
 
 WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
@@ -129,7 +129,7 @@ DIFFERENCE ALL
 show trace;
 
 -- 1.11 Multiple CTEs: INTERSECTION with Uncorrelated Subqueries
-SELECT '1.11 Multiple CTEs: INTERSECTION with Uncorrelated Subqueries';
+EVALUATE '1.11 Multiple CTEs: INTERSECTION with Uncorrelated Subqueries';
 set trace on;
 
 WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
@@ -141,7 +141,7 @@ INTERSECTION
 show trace;
 
 -- 1.12 Multiple CTEs: INTERSECTION ALL with Uncorrelated Subqueries
-SELECT '1.12 Multiple CTEs: INTERSECTION ALL with Uncorrelated Subqueries';
+EVALUATE '1.12 Multiple CTEs: INTERSECTION ALL with Uncorrelated Subqueries';
 set trace on;
 
 WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
@@ -153,7 +153,7 @@ INTERSECTION ALL
 show trace;
 
 -- 1.13 Use limit
-SELECT '1.13 Use limit';
+EVALUATE '1.13 Use limit';
 WITH cte1 AS (SELECT i FROM tbl_a limit 1, 10)
 (SELECT * FROM cte1)
 UNION ALL
@@ -168,7 +168,7 @@ INTERSECTION
 show trace;
 
 -- 1.14 Use limit offset
-SELECT '1.14 Use limit offset';
+EVALUATE '1.14 Use limit offset';
 WITH cte1 AS (SELECT i FROM tbl_a limit 3 offset 7)
 (SELECT * FROM cte1)
 UNION ALL
@@ -183,7 +183,7 @@ INTERSECTION
 show trace;
 
 -- 1.15 Use rownum
-SELECT '1.15 Use rownum';
+EVALUATE '1.15 Use rownum';
 WITH cte1 AS (SELECT i FROM tbl_a where rownum < 5 )
 (SELECT * FROM cte1)
 UNION ALL
@@ -198,7 +198,7 @@ INTERSECTION
 show trace;
 
 -- 1.16 Use orderby_num()
-SELECT '1.16 Use orderby_num()';
+EVALUATE '1.16 Use orderby_num()';
 WITH cte1 AS (SELECT i FROM tbl_a order by 1 for orderby_num() between 3 and 5)
 (SELECT * FROM cte1)
 UNION ALL
@@ -215,7 +215,7 @@ show trace;
 -- 2. Correlated Subqueries
 
 -- 2.1 Single CTE: UNION with Correlated Subqueries
-SELECT '2.1 Single CTE: UNION with Correlated Subqueries';
+EVALUATE '2.1 Single CTE: UNION with Correlated Subqueries';
 set trace on;
 
 WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
@@ -226,7 +226,7 @@ UNION
 show trace;
 
 -- 2.2 Single CTE: INTERSECTION with Correlated Subqueries
-SELECT '2.2 Single CTE: INTERSECTION with Correlated Subqueries';
+EVALUATE '2.2 Single CTE: INTERSECTION with Correlated Subqueries';
 set trace on;
 
 WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
@@ -237,7 +237,7 @@ INTERSECTION
 show trace;
 
 -- 2.3 Multiple CTEs: UNION ALL with Mixed Correlated and Uncorrelated Subqueries
-SELECT '2.3 Multiple CTEs: UNION ALL with Mixed Correlated and Uncorrelated Subqueries';
+EVALUATE '2.3 Multiple CTEs: UNION ALL with Mixed Correlated and Uncorrelated Subqueries';
 set trace on;
 
 WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
@@ -249,7 +249,7 @@ UNION ALL
 show trace;
 
 -- 2.4 Multiple CTEs: UNION with Mixed Correlated and Uncorrelated Subqueries
-SELECT '2.4 Multiple CTEs: UNION with Mixed Correlated and Uncorrelated Subqueries';
+EVALUATE '2.4 Multiple CTEs: UNION with Mixed Correlated and Uncorrelated Subqueries';
 set trace on;
 
 WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
@@ -261,7 +261,7 @@ UNION
 show trace;
 
 -- 2.5 Multiple CTEs: DIFFERENCE with Mixed Correlated and Uncorrelated Subqueries
-SELECT '2.5 Multiple CTEs: DIFFERENCE with Mixed Correlated and Uncorrelated Subqueries';
+EVALUATE '2.5 Multiple CTEs: DIFFERENCE with Mixed Correlated and Uncorrelated Subqueries';
 set trace on;
 
 WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
@@ -273,7 +273,7 @@ DIFFERENCE
 show trace;
 
 -- 2.6 Multiple CTEs: DIFFERENCE ALL with Mixed Correlated and Uncorrelated Subqueries
-SELECT '2.6 Multiple CTEs: DIFFERENCE ALL with Mixed Correlated and Uncorrelated Subqueries';
+EVALUATE '2.6 Multiple CTEs: DIFFERENCE ALL with Mixed Correlated and Uncorrelated Subqueries';
 set trace on;
 
 WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
@@ -285,7 +285,7 @@ DIFFERENCE ALL
 show trace;
 
 -- 2.7 Multiple CTEs: INTERSECTION with Mixed Correlated and Uncorrelated Subqueries
-SELECT '2.7 Multiple CTEs: INTERSECTION with Mixed Correlated and Uncorrelated Subqueries';
+EVALUATE '2.7 Multiple CTEs: INTERSECTION with Mixed Correlated and Uncorrelated Subqueries';
 set trace on;
 
 WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
@@ -297,7 +297,7 @@ INTERSECTION
 show trace;
 
 -- 2.8 Multiple CTEs: INTERSECTION ALL with Mixed Correlated and Uncorrelated Subqueries
-SELECT '2.8 Multiple CTEs: INTERSECTION ALL with Mixed Correlated and Uncorrelated Subqueries';
+EVALUATE '2.8 Multiple CTEs: INTERSECTION ALL with Mixed Correlated and Uncorrelated Subqueries';
 set trace on;
 
 WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
@@ -310,4 +310,5 @@ show trace;
 
 set trace off;
 drop table tbl_a;
+
 

--- a/sql/_13_issues/_24_1h/cases/cbrd_25361.sql
+++ b/sql/_13_issues/_24_1h/cases/cbrd_25361.sql
@@ -1,0 +1,313 @@
+-- Test Cases for CBRD-25361: Fixed the issue where trace information for CTEs and subqueries are not provided.
+
+--------------------------------------------------------------------------------
+-- These test cases verify the fix for CBRD-25361, ensuring that trace information
+-- is correctly outputted for various scenarios involving CTEs and subqueries,
+-- including UNION, UNION ALL, DIFFERENCE, DIFFERENCE ALL, INTERSECTION, 
+-- INTERSECTION ALL, and combinations of correlated and uncorrelated subqueries.
+--------------------------------------------------------------------------------
+
+-- 1. Uncorrelated Subqueries
+
+drop table if exists tbl_a;
+
+create table tbl_a ( i int, j varchar, k varchar);
+
+insert into tbl_a select rownum, rownum, rownum 
+from db_class a, db_class c, db_class d limit 100000;
+
+set trace on;
+
+-- 1.1 Single CTE: UNION
+SELECT '1.1 Single CTE: UNION';
+WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a ORDER BY i)
+UNION
+(SELECT * FROM cte_a ORDER BY i);
+
+show trace;
+
+-- 1.2 Single CTE: UNION ALL
+SELECT '1.2 Single CTE: UNION ALL';
+WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a ORDER BY i)
+UNION ALL
+(SELECT * FROM cte_a ORDER BY i);
+
+show trace;
+
+-- 1.3 Single CTE: DIFFERENCE
+SELECT '1.3 Single CTE: DIFFERENCE';
+WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a ORDER BY i)
+DIFFERENCE
+(SELECT * FROM cte_a ORDER BY i);
+
+show trace;
+
+-- 1.4 Single CTE: DIFFERENCE ALL
+SELECT '1.4 Single CTE: DIFFERENCE ALL';
+WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a ORDER BY i)
+DIFFERENCE ALL
+(SELECT * FROM cte_a ORDER BY i);
+
+show trace;
+
+-- 1.5 Single CTE: INTERSECTION
+SELECT '1.5 Single CTE: INTERSECTION';
+WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a ORDER BY i)
+INTERSECTION
+(SELECT * FROM cte_a ORDER BY i);
+
+show trace;
+
+-- 1.6 Single CTE: INTERSECTION ALL
+SELECT '1.6 Single CTE: INTERSECTION ALL';
+WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a ORDER BY i)
+INTERSECTION ALL
+(SELECT * FROM cte_a ORDER BY i);
+
+show trace;
+
+-- 1.7 Multiple CTEs: UNION ALL with Uncorrelated Subqueries
+SELECT '1.7 Multiple CTEs: UNION ALL with Uncorrelated Subqueries';
+drop table if exists tbl_b;
+
+create table tbl_b ( a int, b varchar, c varchar);
+
+insert into tbl_b select rownum, rownum, rownum 
+from db_class a, db_class c, db_class d limit 100000;
+
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_b ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE i < 50 ORDER BY i)
+UNION ALL
+(SELECT * FROM cte_b WHERE a > 50 ORDER BY a);
+
+show trace;
+drop table tbl_b;
+
+-- 1.8 Multiple CTEs: UNION with Uncorrelated Subqueries
+SELECT '1.8 Multiple CTEs: UNION with Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE j < 30 ORDER BY i)
+UNION
+(SELECT * FROM cte_b WHERE k > 50 ORDER BY i);
+
+show trace;
+
+-- 1.9 Multiple CTEs: DIFFERENCE with Uncorrelated Subqueries
+SELECT '1.9 Multiple CTEs: DIFFERENCE with Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE i < 20 ORDER BY i)
+DIFFERENCE
+(SELECT * FROM cte_b WHERE k > 30 ORDER BY i);
+
+show trace;
+
+-- 1.10 Multiple CTEs: DIFFERENCE ALL with Uncorrelated Subqueries
+SELECT '1.10 Multiple CTEs: DIFFERENCE ALL with Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE i < 20 ORDER BY i)
+DIFFERENCE ALL
+(SELECT * FROM cte_b WHERE k > 30 ORDER BY i);
+
+show trace;
+
+-- 1.11 Multiple CTEs: INTERSECTION with Uncorrelated Subqueries
+SELECT '1.11 Multiple CTEs: INTERSECTION with Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE j < 30 ORDER BY i)
+INTERSECTION
+(SELECT * FROM cte_b WHERE k > 50 ORDER BY i);
+
+show trace;
+
+-- 1.12 Multiple CTEs: INTERSECTION ALL with Uncorrelated Subqueries
+SELECT '1.12 Multiple CTEs: INTERSECTION ALL with Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE j < 30 ORDER BY i)
+INTERSECTION ALL
+(SELECT * FROM cte_b WHERE k > 50 ORDER BY i);
+
+show trace;
+
+-- 1.13 Use limit
+SELECT '1.13 Use limit';
+WITH cte1 AS (SELECT i FROM tbl_a limit 1, 10)
+(SELECT * FROM cte1)
+UNION ALL
+(SELECT * FROM cte1)
+UNION
+(SELECT * FROM cte1)
+DIFFERENCE
+(SELECT * FROM cte1)
+INTERSECTION
+(SELECT * FROM cte1);
+
+show trace;
+
+-- 1.14 Use limit offset
+SELECT '1.14 Use limit offset';
+WITH cte1 AS (SELECT i FROM tbl_a limit 3 offset 7)
+(SELECT * FROM cte1)
+UNION ALL
+(SELECT * FROM cte1)
+UNION
+(SELECT * FROM cte1)
+DIFFERENCE
+(SELECT * FROM cte1)
+INTERSECTION
+(SELECT * FROM cte1);
+
+show trace;
+
+-- 1.15 Use rownum
+SELECT '1.15 Use rownum';
+WITH cte1 AS (SELECT i FROM tbl_a where rownum < 5 )
+(SELECT * FROM cte1)
+UNION ALL
+(SELECT * FROM cte1)
+UNION
+(SELECT * FROM cte1)
+DIFFERENCE
+(SELECT * FROM cte1)
+INTERSECTION
+(SELECT * FROM cte1);
+
+show trace;
+
+-- 1.16 Use orderby_num()
+SELECT '1.16 Use orderby_num()';
+WITH cte1 AS (SELECT i FROM tbl_a order by 1 for orderby_num() between 3 and 5)
+(SELECT * FROM cte1)
+UNION ALL
+(SELECT * FROM cte1)
+UNION
+(SELECT * FROM cte1)
+DIFFERENCE
+(SELECT * FROM cte1)
+INTERSECTION
+(SELECT * FROM cte1);
+
+show trace;
+
+-- 2. Correlated Subqueries
+
+-- 2.1 Single CTE: UNION with Correlated Subqueries
+SELECT '2.1 Single CTE: UNION with Correlated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.i = cte_a.i) ORDER BY i)
+UNION
+(SELECT * FROM cte_a WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.j = cte_a.j) ORDER BY i);
+
+show trace;
+
+-- 2.2 Single CTE: INTERSECTION with Correlated Subqueries
+SELECT '2.2 Single CTE: INTERSECTION with Correlated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.j = cte_a.j) ORDER BY i)
+INTERSECTION
+(SELECT * FROM cte_a WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.k = cte_a.k) ORDER BY i);
+
+show trace;
+
+-- 2.3 Multiple CTEs: UNION ALL with Mixed Correlated and Uncorrelated Subqueries
+SELECT '2.3 Multiple CTEs: UNION ALL with Mixed Correlated and Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE j < 20 ORDER BY i)
+UNION ALL
+(SELECT * FROM cte_b WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.k = cte_b.k) ORDER BY i);
+
+show trace;
+
+-- 2.4 Multiple CTEs: UNION with Mixed Correlated and Uncorrelated Subqueries
+SELECT '2.4 Multiple CTEs: UNION with Mixed Correlated and Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE j < 20 ORDER BY i)
+UNION
+(SELECT * FROM cte_b WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.k = cte_b.k) ORDER BY i);
+
+show trace;
+
+-- 2.5 Multiple CTEs: DIFFERENCE with Mixed Correlated and Uncorrelated Subqueries
+SELECT '2.5 Multiple CTEs: DIFFERENCE with Mixed Correlated and Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE j < 20 ORDER BY i)
+DIFFERENCE
+(SELECT * FROM cte_b WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.k = cte_b.k) ORDER BY i);
+
+show trace;
+
+-- 2.6 Multiple CTEs: DIFFERENCE ALL with Mixed Correlated and Uncorrelated Subqueries
+SELECT '2.6 Multiple CTEs: DIFFERENCE ALL with Mixed Correlated and Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE j < 20 ORDER BY i)
+DIFFERENCE ALL
+(SELECT * FROM cte_b WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.k = cte_b.k) ORDER BY i);
+
+show trace;
+
+-- 2.7 Multiple CTEs: INTERSECTION with Mixed Correlated and Uncorrelated Subqueries
+SELECT '2.7 Multiple CTEs: INTERSECTION with Mixed Correlated and Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE j < 20 ORDER BY i)
+INTERSECTION
+(SELECT * FROM cte_b WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.k = cte_b.k) ORDER BY i);
+
+show trace;
+
+-- 2.8 Multiple CTEs: INTERSECTION ALL with Mixed Correlated and Uncorrelated Subqueries
+SELECT '2.8 Multiple CTEs: INTERSECTION ALL with Mixed Correlated and Uncorrelated Subqueries';
+set trace on;
+
+WITH cte_a AS (SELECT * FROM tbl_a WHERE i < 50 ORDER BY 1 LIMIT 20),
+     cte_b AS (SELECT * FROM tbl_a WHERE i >= 50 ORDER BY 1 LIMIT 20)
+(SELECT * FROM cte_a WHERE j < 20 ORDER BY i)
+INTERSECTION ALL
+(SELECT * FROM cte_b WHERE EXISTS (SELECT 1 FROM tbl_a WHERE tbl_a.k = cte_b.k) ORDER BY i);
+
+show trace;
+
+set trace off;
+drop table tbl_a;
+


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-25361, https://github.com/CUBRID/cubrid-testcases/pull/1767

Note: needs to backport the revised answers for https://github.com/CUBRID/cubrid-testcases/pull/1818 (exclude fetch_time info) 

^ In progress: To continue, awaiting the 10.2.16 build to scrape the revised answers and continue on from there.

Note: needs to commit backport from #1839 <-- DONE with commit (150556cd1b9d551d1c2676bb3ba5cc39d883e4e6)