### PR TITLE
[CBRD-25428] Backport added a sql test for The problem is that pr_clear_value is needed for decompressed strings, but it is not called (11.3)

### DIFF
--- a/sql/_13_issues/_24_1h/answers/cbrd_25428.answer
+++ b/sql/_13_issues/_24_1h/answers/cbrd_25428.answer
@@ -1,0 +1,40 @@
+===================================================
+0
+===================================================
+0
+===================================================
+1
+===================================================
+1
+===================================================
+id    parent_id    name    
+1     null     A     
+2     1     CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC     
+
+===================================================
+0
+===================================================
+0
+===================================================
+1
+===================================================
+1
+===================================================
+1
+===================================================
+1
+===================================================
+1
+===================================================
+1
+===================================================
+id    parent_id    name    
+1     null     AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA     
+2     null     BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB     
+10     1     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa     
+11     1     bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb     
+20     2     ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc     
+21     2     ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd     
+
+===================================================
+0

--- a/sql/_13_issues/_24_1h/cases/cbrd_25428.sql
+++ b/sql/_13_issues/_24_1h/cases/cbrd_25428.sql
@@ -1,0 +1,43 @@
+-- This test case verifies the following issue: CBRD-25428.
+-- Validate that a core dump does not occur when using recursive CTEs with string compression
+
+-- Test Case 1: Simple hierarchy with compressed strings
+-- Ensures that a compressed string of 255 characters is processed correctly 
+-- and the expected results are returned without memory issues (core dump).
+drop if exists tbl;
+create table tbl (id int, parent_id int, name varchar);
+insert into tbl values(1, NULL, repeat('A', 1));
+insert into tbl values(2, 1, repeat('C', 255));
+
+
+-- Recursive CTE query
+with recursive c as (
+  select a.id, a.parent_id, a.name from tbl a where a.parent_id is null
+  union all
+  select /*+ use_merge */ b.id, b.parent_id, b.name from tbl b inner join c on b.parent_id = c.id
+)
+select /*+ recompile */ * from c order by id;
+
+-- Test Case 2: Complex hierarchy with multiple levels of recursion
+-- Verify multiple levels of recursion properly handle compressed strings 
+-- and return the expected results without memory issues (core dump).
+drop table tbl;
+create table tbl (id int, parent_id int, name varchar);
+
+insert into tbl values(1, NULL, repeat('A', 255));
+insert into tbl values(2, NULL, repeat('B', 255));
+insert into tbl values(10, 1, repeat('a', 255));
+insert into tbl values(11, 1, repeat('b', 255));
+insert into tbl values(20, 2, repeat('c', 255));
+insert into tbl values(21, 2, repeat('d', 255));
+
+
+-- Recursive CTE query
+with recursive c as (
+  select a.id, a.parent_id, a.name from tbl a where a.parent_id is null
+  union all
+  select /*+ use_merge */ b.id, b.parent_id, b.name from tbl b inner join c on b.parent_id = c.id
+)
+select /*+ recompile */ * from c order by id;
+
+drop table tbl;


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-25428, https://github.com/CUBRID/cubrid-testcases/pull/1777