### PR TITLE
[CBRD-25361] Revise answers Backport for Fixed the issue where trace information for CTEs and subqueries not provided.

### DIFF
--- a/sql/_13_issues/_15_1h/answers/bug_bts_14200.answer
+++ b/sql/_13_issues/_15_1h/answers/bug_bts_14200.answer
@@ -23,7 +23,6 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
-      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",

--- a/sql/_13_issues/_15_1h/answers/bug_bts_14200.answer
+++ b/sql/_13_issues/_15_1h/answers/bug_bts_14200.answer
@@ -23,6 +23,7 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
+      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",

--- a/sql/_13_issues/_17_1h/answers/cbrd_20857.answer
+++ b/sql/_13_issues/_17_1h/answers/cbrd_20857.answer
@@ -41,7 +41,6 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
-      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "temp",
@@ -66,7 +65,6 @@ trace
               "SELECT": {
                 "time": ?,
                 "fetch": ?,
-                "fetch_time": ?,
                 "ioread": ?,
                 "SCAN": {
                   "access": "table (dba.t?)",

--- a/sql/_13_issues/_17_1h/answers/cbrd_20857.answer
+++ b/sql/_13_issues/_17_1h/answers/cbrd_20857.answer
@@ -41,6 +41,7 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
+      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "temp",
@@ -58,35 +59,38 @@ trace
         "page": ?,
         "ioread": ?
       },
-      "SUBQUERY (uncorrelated)": {
-        "CTE": {
-          "non_recursive_part": {
-            "SELECT": {
-              "time": ?,
-              "fetch": ?,
-              "ioread": ?,
-              "SCAN": {
-                "access": "table (dba.t?)",
-                "heap": {
+      "SUBQUERY (uncorrelated)": [
+        {
+          "CTE": {
+            "non_recursive_part": {
+              "SELECT": {
+                "time": ?,
+                "fetch": ?,
+                "fetch_time": ?,
+                "ioread": ?,
+                "SCAN": {
+                  "access": "table (dba.t?)",
+                  "heap": {
+                    "time": ?,
+                    "fetch": ?,
+                    "ioread": ?,
+                    "readrows": ?,
+                    "rows": ?
+                  }
+                },
+                "GROUPBY": {
                   "time": ?,
-                  "fetch": ?,
+                  "hash": true,
+                  "sort": true,
+                  "page": ?,
                   "ioread": ?,
-                  "readrows": ?,
                   "rows": ?
                 }
-              },
-              "GROUPBY": {
-                "time": ?,
-                "hash": true,
-                "sort": true,
-                "page": ?,
-                "ioread": ?,
-                "rows": ?
               }
             }
           }
         }
-      }
+      ]
     }
   }
 }     

--- a/sql/_13_issues/_17_1h/answers/cbrd_20865.answer
+++ b/sql/_13_issues/_17_1h/answers/cbrd_20865.answer
@@ -134,6 +134,9 @@ Trace Statistics:
         SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
           GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
+      CTE (non_recursive_part)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================

--- a/sql/_13_issues/_17_1h/answers/cbrd_20865.answer
+++ b/sql/_13_issues/_17_1h/answers/cbrd_20865.answer
@@ -135,7 +135,7 @@ Trace Statistics:
           SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
           GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
       CTE (non_recursive_part)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 

--- a/sql/_13_issues/_20_2h/answers/cbrd_23665.answer
+++ b/sql/_13_issues/_20_2h/answers/cbrd_23665.answer
@@ -140,6 +140,8 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -453,6 +455,8 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -492,6 +496,8 @@ Trace Statistics:
         SCAN (hash temp(m), build time: ?, time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
+        SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -775,6 +781,9 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
 ===================================================
@@ -821,6 +830,12 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
 ===================================================
@@ -890,6 +905,8 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -905,6 +922,8 @@ Trace Statistics:
       SCAN (hash temp(h), build time: ?, time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
+        SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -924,6 +943,8 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -941,6 +962,8 @@ Trace Statistics:
       SCAN (hash temp(h), build time: ?, time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
+        SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -973,6 +996,8 @@ Trace Statistics:
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
+        SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 

--- a/sql/_13_issues/_20_2h/answers/cbrd_23665.answer
+++ b/sql/_13_issues/_20_2h/answers/cbrd_23665.answer
@@ -140,7 +140,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -455,7 +455,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -497,7 +497,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -781,7 +781,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -830,10 +830,10 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -905,7 +905,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -923,7 +923,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -943,7 +943,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -963,7 +963,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -997,7 +997,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 

--- a/sql/_13_issues/_20_2h/answers/cbrd_23665.answer_cci
+++ b/sql/_13_issues/_20_2h/answers/cbrd_23665.answer_cci
@@ -140,6 +140,8 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -453,6 +455,8 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -492,6 +496,8 @@ Trace Statistics:
         SCAN (hash temp(m), build time: ?, time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
+        SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -775,6 +781,9 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
 ===================================================
@@ -821,6 +830,12 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
 ===================================================
@@ -890,6 +905,8 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -905,6 +922,8 @@ Trace Statistics:
       SCAN (hash temp(h), build time: ?, time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
+        SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -924,6 +943,8 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -941,6 +962,8 @@ Trace Statistics:
       SCAN (hash temp(h), build time: ?, time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
+        SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -973,6 +996,8 @@ Trace Statistics:
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
+        SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 

--- a/sql/_13_issues/_20_2h/answers/cbrd_23665.answer_cci
+++ b/sql/_13_issues/_20_2h/answers/cbrd_23665.answer_cci
@@ -140,7 +140,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -455,7 +455,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -497,7 +497,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -781,7 +781,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -830,10 +830,10 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tmp_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -905,7 +905,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -923,7 +923,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -943,7 +943,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -963,7 +963,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -997,7 +997,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 

--- a/sql/_13_issues/_21_2h/answers/cbrd_23816.answer
+++ b/sql/_13_issues/_21_2h/answers/cbrd_23816.answer
@@ -35,7 +35,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -78,7 +78,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 

--- a/sql/_13_issues/_21_2h/answers/cbrd_23816.answer
+++ b/sql/_13_issues/_21_2h/answers/cbrd_23816.answer
@@ -35,6 +35,8 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -75,6 +77,8 @@ Trace Statistics:
       SCAN (hash temp(f), build time: ?, time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
+        SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 

--- a/sql/_13_issues/_22_1h/answers/cbrd_24148.answer
+++ b/sql/_13_issues/_22_1h/answers/cbrd_24148.answer
@@ -36,6 +36,8 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tbl_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================

--- a/sql/_13_issues/_22_1h/answers/cbrd_24148.answer
+++ b/sql/_13_issues/_22_1h/answers/cbrd_24148.answer
@@ -36,7 +36,7 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_hls), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 

--- a/sql/_13_issues/_23_1h/answers/cbrd_24652.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24652.answer
@@ -55,11 +55,16 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          UNION
+          UNION (time: ?, fetch: ?, ioread: ?)
             SELECT (time: ?, fetch: ?, ioread: ?)
               SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
             SELECT (time: ?, fetch: ?, ioread: ?)
               SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      UNION (time: ?, fetch: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
+          SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
+          SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================

--- a/sql/_13_issues/_23_1h/answers/cbrd_24843_4.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24843_4.answer
@@ -730,7 +730,14 @@ Query Plan:
 
 
 Trace Statistics:
-  UNION
+  UNION (time: ?, fetch: ?, ioread: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, ioread: ?)
+        SCAN (index: dba.t_child.fk_t_child_p_a_p_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    CTE (non_recursive_part)
+      SELECT (time: ?, fetch: ?, ioread: ?)
+        SCAN (index: dba.t_parent.pk_t_parent_a_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+          SCAN (index: dba.t_child.fk_t_child_p_a_p_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
     SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     SELECT (time: ?, fetch: ?, ioread: ?)

--- a/sql/_13_issues/_23_1h/answers/cbrd_24906_1.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24906_1.answer
@@ -509,6 +509,8 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_b), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
+        SCAN (table: dba.tbl_c), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -544,6 +546,8 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_b), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
+        SCAN (table: dba.tbl_c), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -628,7 +632,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      UNION
+      UNION (time: ?, fetch: ?, ioread: ?)
         SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         SELECT (time: ?, fetch: ?, ioread: ?)

--- a/sql/_13_issues/_23_1h/answers/cbrd_24906_2.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24906_2.answer
@@ -543,6 +543,8 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_b), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
+        SCAN (table: dba.tbl_c), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -580,6 +582,8 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_b), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
+        SCAN (table: dba.tbl_c), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -670,7 +674,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      UNION
+      UNION (time: ?, fetch: ?, ioread: ?)
         SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         SELECT (time: ?, fetch: ?, ioread: ?)

--- a/sql/_13_issues/_23_1h/answers/cbrd_24906_3.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24906_3.answer
@@ -41,7 +41,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      UNION
+      UNION (time: ?, fetch: ?, ioread: ?)
         SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
             SCAN (index: dba.tbl_b.pk_tbl_b_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
@@ -78,7 +78,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      UNION
+      UNION (time: ?, fetch: ?, ioread: ?)
         SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
             SCAN (index: dba.tbl_b.pk_tbl_b_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)

--- a/sql/_13_issues/_23_1h/cases/cbrd_24652.sql
+++ b/sql/_13_issues/_23_1h/cases/cbrd_24652.sql
@@ -1,6 +1,7 @@
 -- This test case verifies CBRD-24652 issue.
 -- The problem performing hash list scan when VOBJECT is included in predicates.
 -- Hash list scan should not be used in the result.
+-- When using UNION, there is an issue where the output is inconsistent because UNION_PROC is used instead of OBJ_FETCH_PROC for processing.
 
 drop table if exists tbl;
 drop view if exists v_tbl;

--- a/sql/_13_issues/_24_1h/answers/cbrd_25361.answer
+++ b/sql/_13_issues/_24_1h/answers/cbrd_25361.answer
@@ -45,24 +45,24 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
 
 Trace Statistics:
-  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  UNION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -126,24 +126,24 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
 
 Trace Statistics:
-  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  UNION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -167,24 +167,24 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
 
 Trace Statistics:
-  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  DIFFERENCE (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -208,24 +208,24 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
 
 Trace Statistics:
-  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  DIFFERENCE (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -269,24 +269,24 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -330,24 +330,24 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] order by ?)
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -404,28 +404,28 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].i< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].i< ?:? ) order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].a, [dba.cte_b].b, [dba.cte_b].c from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].a> ?:? ) order by ?)
+  rewritten query: (select [dba.cte_b].a, [dba.cte_b].b, [dba.cte_b].c from  [dba.cte_b] where ([dba.cte_b].a> ?:? ) order by ?)
 
 
 Trace Statistics:
-  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  UNION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_b), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -490,28 +490,28 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
 
 
 Trace Statistics:
-  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  UNION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -561,28 +561,28 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].i< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].i< ?:? ) order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
 
 
 Trace Statistics:
-  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  DIFFERENCE (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -632,28 +632,28 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].i< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].i< ?:? ) order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
 
 
 Trace Statistics:
-  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  DIFFERENCE (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -684,28 +684,28 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -736,28 +736,28 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
 
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where ([dba.cte_b].k> ?:? ) order by ?)
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
@@ -779,42 +779,42 @@ Query Plan:
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    DIFFERENCE (time: ?, fetch: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, ioread: ?)
+        UNION (time: ?, fetch: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -834,22 +834,22 @@ Query Plan:
   rewritten query: select '?.? Use limit offset' from dual dual
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    DIFFERENCE (time: ?, fetch: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, ioread: ?)
+        UNION (time: ?, fetch: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -870,42 +870,42 @@ Query Plan:
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    DIFFERENCE (time: ?, fetch: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, ioread: ?)
+        UNION (time: ?, fetch: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -927,43 +927,43 @@ Query Plan:
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
   TABLE SCAN (dba.cte?)
 
-  rewritten query: select [dba.cte?].i from [dba.cte?] [dba.cte?]
+  rewritten query: select [dba.cte?].i from  [dba.cte?]
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    DIFFERENCE (time: ?, fetch: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, ioread: ?)
+        UNION (time: ?, fetch: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -1012,7 +1012,7 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].i=[dba.cte_a].i) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].i=[dba.cte_a].i) order by ?)
 
   TABLE SCAN (dba.tbl_a)
 
@@ -1021,26 +1021,26 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].j=[dba.cte_a].j) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].j=[dba.cte_a].j) order by ?)
 
 
 Trace Statistics:
-  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  UNION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -1089,7 +1089,7 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].j=[dba.cte_a].j) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].j=[dba.cte_a].j) order by ?)
 
   TABLE SCAN (dba.tbl_a)
 
@@ -1098,26 +1098,26 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_a].k) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_a].k) order by ?)
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -1179,7 +1179,7 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
 
   TABLE SCAN (dba.tbl_a)
 
@@ -1188,27 +1188,27 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
 
 
 Trace Statistics:
-  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  UNION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -1270,7 +1270,7 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
 
   TABLE SCAN (dba.tbl_a)
 
@@ -1279,27 +1279,27 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
 
 
 Trace Statistics:
-  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  UNION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -1341,7 +1341,7 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
 
   TABLE SCAN (dba.tbl_a)
 
@@ -1350,27 +1350,27 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
 
 
 Trace Statistics:
-  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  DIFFERENCE (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -1412,7 +1412,7 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
 
   TABLE SCAN (dba.tbl_a)
 
@@ -1421,27 +1421,27 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
 
 
 Trace Statistics:
-  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  DIFFERENCE (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -1471,7 +1471,7 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
 
   TABLE SCAN (dba.tbl_a)
 
@@ -1480,27 +1480,27 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
@@ -1530,7 +1530,7 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_a)
 
-  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from [dba.cte_a] [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
+  rewritten query: (select [dba.cte_a].i, [dba.cte_a].j, [dba.cte_a].k from  [dba.cte_a] where ([dba.cte_a].j< ?:? ) order by ?)
 
   TABLE SCAN (dba.tbl_a)
 
@@ -1539,27 +1539,27 @@ Query Plan:
   SORT (order by)
     TABLE SCAN (dba.cte_b)
 
-  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from [dba.cte_b] [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
+  rewritten query: (select [dba.cte_b].i, [dba.cte_b].j, [dba.cte_b].k from  [dba.cte_b] where  exists (select ? from [dba.tbl_a] [dba.tbl_a] where [dba.tbl_a].k=[dba.cte_b].k) order by ?)
 
 
 Trace Statistics:
-  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  INTERSECTION (time: ?, fetch: ?, ioread: ?)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
     CTE (non_recursive_part)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, topnsort: true)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 

--- a/sql/_28_features_930/issue_13133_hash_query_profile/answers/hash_agg_query_profile.answer
+++ b/sql/_28_features_930/issue_13133_hash_query_profile/answers/hash_agg_query_profile.answer
@@ -88,7 +88,6 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
-      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",
@@ -125,7 +124,6 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
-      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",
@@ -170,7 +168,6 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
-      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",
@@ -215,7 +212,6 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
-      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",
@@ -260,7 +256,6 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
-      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",

--- a/sql/_28_features_930/issue_13133_hash_query_profile/answers/hash_agg_query_profile.answer
+++ b/sql/_28_features_930/issue_13133_hash_query_profile/answers/hash_agg_query_profile.answer
@@ -88,6 +88,7 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
+      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",
@@ -124,6 +125,7 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
+      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",
@@ -168,6 +170,7 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
+      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",
@@ -212,6 +215,7 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
+      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",
@@ -256,6 +260,7 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
+      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",

--- a/sql/_28_features_930/issue_13133_hash_query_profile/answers/hash_agg_query_profile.answer_cci
+++ b/sql/_28_features_930/issue_13133_hash_query_profile/answers/hash_agg_query_profile.answer_cci
@@ -88,7 +88,6 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
-      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",
@@ -125,7 +124,6 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
-      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",
@@ -170,7 +168,6 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
-      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",
@@ -215,7 +212,6 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
-      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",
@@ -260,7 +256,6 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
-      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",

--- a/sql/_28_features_930/issue_13133_hash_query_profile/answers/hash_agg_query_profile.answer_cci
+++ b/sql/_28_features_930/issue_13133_hash_query_profile/answers/hash_agg_query_profile.answer_cci
@@ -88,6 +88,7 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
+      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",
@@ -124,6 +125,7 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
+      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",
@@ -168,6 +170,7 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
+      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",
@@ -212,6 +215,7 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
+      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",
@@ -256,6 +260,7 @@ trace
     "SELECT": {
       "time": ?,
       "fetch": ?,
+      "fetch_time": ?,
       "ioread": ?,
       "SCAN": {
         "access": "table (dba.t?)",

--- a/sql/_34_fig/cbrd_24252/answers/cbrd_24252_32.answer
+++ b/sql/_34_fig/cbrd_24252/answers/cbrd_24252_32.answer
@@ -53,7 +53,7 @@ Query Plan:
 
 
 Trace Statistics:
-  UNION
+  UNION (time: ?, fetch: ?, ioread: ?)
     SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (table: dba.t_child), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     SELECT (time: ?, fetch: ?, ioread: ?)
@@ -80,7 +80,7 @@ Query Plan:
 
 
 Trace Statistics:
-  UNION
+  UNION (time: ?, fetch: ?, ioread: ?)
     SELECT (time: ?, fetch: ?, ioread: ?)
       SCAN (table: dba.t_child), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     SELECT (time: ?, fetch: ?, ioread: ?)


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-25361


Backport: https://github.com/CUBRID/cubrid-testcases/pull/1748, https://github.com/CUBRID/cubrid-testcases/pull/1764
+
Revised answers from the files from the two PRs above #1748, #1764, as well as #1806 to exclude fetch_time info for CUBRID versions 11.3 and lower.