### PR TITLE
[CBRD-24817] updating 27 answer files according to an engine update 

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_01_initialized/answers/02_03_01-08_error_change_value.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_01_initialized/answers/02_03_01-08_error_change_value.answer
@@ -1,20 +1,20 @@
 ===================================================
 Error:-1360
 In line 4, column 1
-Stored procedure compile error: A is not assignable to
+Stored procedure compile error: A is not updatable
 
 ===================================================
 Error:-1360
 In line 4, column 1
-Stored procedure compile error: A is not assignable to
+Stored procedure compile error: A is not updatable
 
 ===================================================
 Error:-1360
 In line 4, column 1
-Stored procedure compile error: A is not assignable to
+Stored procedure compile error: A is not updatable
 
 ===================================================
 Error:-1360
 In line 4, column 1
-Stored procedure compile error: A is not assignable to
+Stored procedure compile error: A is not updatable
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_06_cursor/_01_basic/answers/02_06_01-04_error_into_clause.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_06_cursor/_01_basic/answers/02_06_01-04_error_into_clause.answer
@@ -7,7 +7,7 @@
 ===================================================
 Error:-1360
 In line 3, column 13
-Stored procedure compile error: SQL in a cursor definition may not have an into-clause
+Stored procedure compile error: SQL in a cursor definition may not have an INTO clause
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_07_local_proc/_06_writing_rule/answers/02_07_06-01_error_builtin_function_name.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_07_local_proc/_06_writing_rule/answers/02_07_06-01_error_builtin_function_name.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 3, column 1
-Stored procedure compile error: SUBSTR is not a function but procedure in this scope
+Stored procedure compile error: SUBSTR is not a function but a procedure in this scope
 
 ===================================================
 Error:-495

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_07_local_proc/_06_writing_rule/answers/02_07_06-04_error_IN_parameter.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_07_local_proc/_06_writing_rule/answers/02_07_06-04_error_IN_parameter.answer
@@ -16,7 +16,7 @@
 ===================================================
 Error:-1360
 In line 13, column 22
-Stored procedure compile error: variables to store fetch results must be assignable to
+Stored procedure compile error: PARAM_NAME is not updatable
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_07_local_proc/_06_writing_rule/answers/02_07_06-05_error_OUT_parameter.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_07_local_proc/_06_writing_rule/answers/02_07_06-05_error_OUT_parameter.answer
@@ -16,7 +16,7 @@
 ===================================================
 Error:-1360
 In line 19, column 9
-Stored procedure compile error: argument 1 to the procedure LOCAL_T must be assignable to because it is to an OUT parameter
+Stored procedure compile error: argument 1 to the procedure LOCAL_T must be updatable because it is to an OUT parameter
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_07_local_proc/_06_writing_rule/answers/02_07_06-06_error_INOUT_parameter.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_07_local_proc/_06_writing_rule/answers/02_07_06-06_error_INOUT_parameter.answer
@@ -16,7 +16,7 @@
 ===================================================
 Error:-1360
 In line 19, column 9
-Stored procedure compile error: argument 1 to the procedure LOCAL_T must be assignable to because it is to an OUT parameter
+Stored procedure compile error: argument 1 to the procedure LOCAL_T must be updatable because it is to an OUT parameter
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/answers/03_02_01-02_error_no_into_clause.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/answers/03_02_01-02_error_no_into_clause.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 3, column 1
-Stored procedure compile error: SELECT statement must have an into-clause
+Stored procedure compile error: SELECT statement must have an INTO clause
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/answers/03_02_01-03_error_into_unupdatable.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/answers/03_02_01-03_error_into_unupdatable.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 4, column 1
-Stored procedure compile error: variable C in an into-clause must be assignable to
+Stored procedure compile error: C in the INTO clause is not updatable
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/answers/03_02_01-03_error_into_unupdatable_2.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/answers/03_02_01-03_error_into_unupdatable_2.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 3, column 1
-Stored procedure compile error: variable C in an into-clause must be assignable to
+Stored procedure compile error: C in the INTO clause is not updatable
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/answers/03_02_01-05_error_into_type_mismatch.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/answers/03_02_01-05_error_into_type_mismatch.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 4, column 1
-Stored procedure compile error: into-variable B cannot be used there due to its incompatible type
+Stored procedure compile error: B in the INTO clause has an incompatible type
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_02_fetch/answers/03_03_02-03_error_into_unupdatable.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_02_fetch/answers/03_03_02-03_error_into_unupdatable.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 5, column 14
-Stored procedure compile error: variables to store fetch results must be assignable to
+Stored procedure compile error: R is not updatable
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_04_open_for/answers/03_03_04-02_error_unupdatable.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_04_open_for/answers/03_03_04-02_error_unupdatable.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 5, column 6
-Stored procedure compile error: identifier in an OPEN-FOR statement must be assignable to
+Stored procedure compile error: identifier in an OPEN-FOR statement must be updatable
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_04_open_for/answers/03_03_04-02_error_unupdatable_2.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_04_open_for/answers/03_03_04-02_error_unupdatable_2.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 4, column 6
-Stored procedure compile error: identifier in an OPEN-FOR statement must be assignable to
+Stored procedure compile error: identifier in an OPEN-FOR statement must be updatable
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_04_open_for/answers/03_03_04-04_error_into_clause.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_04_open_for/answers/03_03_04-04_error_into_clause.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 5, column 13
-Stored procedure compile error: SQL in an OPEN-FOR statement may not have an into-clause
+Stored procedure compile error: SQL in an OPEN-FOR statement may not have an INTO clause
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_01_into_clause/answers/03_04_01-02_error_into_unupdatable.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_01_into_clause/answers/03_04_01-02_error_into_unupdatable.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 3, column 97
-Stored procedure compile error: variable CHARSET may not be used there in the INTO clause because it is not assignable to
+Stored procedure compile error: CHARSET is not updatable
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_01_into_clause/answers/03_04_01-05_error_in_param.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_01_into_clause/answers/03_04_01-05_error_in_param.answer
@@ -16,7 +16,7 @@
 ===================================================
 Error:-1360
 In line 4, column 75
-Stored procedure compile error: variable R_ID may not be used there in the INTO clause because it is not assignable to
+Stored procedure compile error: R_ID is not updatable
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_02_using_clause/answers/03_04_02-04_error_arg_type_mismatch.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_02_using_clause/answers/03_04_02-04_error_arg_type_mismatch.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 4, column 85
-Stored procedure compile error: expressions in a USING clause cannot be of either BOOLEAN, CURSOR or SYS_REFCURSOR type
+Stored procedure compile error: expressions in a USING clause cannot be of Boolean type
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_02_using_clause/answers/03_04_02-06_error_arg_IN_INOUT.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_02_using_clause/answers/03_04_02-06_error_arg_IN_INOUT.answer
@@ -16,7 +16,7 @@
 ===================================================
 Error:-1360
 In line 6, column 83
-Stored procedure compile error: variable PARAM may not be used there in the INTO clause because it is not assignable to
+Stored procedure compile error: PARAM is not updatable
 
 ===================================================
 '1'    '2'    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_05_assign/_01_basic/answers/03_05_01-02_error_unupdatable.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_05_assign/_01_basic/answers/03_05_01-02_error_unupdatable.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 3, column 1
-Stored procedure compile error: I is not assignable to
+Stored procedure compile error: I is not updatable
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_05_assign/_01_basic/answers/03_05_01-02_error_unupdatable_constant.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_05_assign/_01_basic/answers/03_05_01-02_error_unupdatable_constant.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 5, column 1
-Stored procedure compile error: J is not assignable to
+Stored procedure compile error: J is not updatable
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_05_assign/_01_basic/answers/03_05_01-02_error_unupdatable_cursor.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_05_assign/_01_basic/answers/03_05_01-02_error_unupdatable_cursor.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 4, column 1
-Stored procedure compile error: C is not assignable to
+Stored procedure compile error: C is not updatable
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_05_assign/_01_basic/answers/03_05_01-02_error_unupdatable_for_iterator.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_05_assign/_01_basic/answers/03_05_01-02_error_unupdatable_for_iterator.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 4, column 1
-Stored procedure compile error: J is not assignable to
+Stored procedure compile error: J is not updatable
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_05_assign/_01_basic/answers/03_05_01-02_error_unupdatable_for_record.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_05_assign/_01_basic/answers/03_05_01-02_error_unupdatable_for_record.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 5, column 1
-Stored procedure compile error: J is not assignable to
+In line 5, column 6
+Stored procedure compile error: type of assigned value is not compatible with the type of target variable
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_05_assign/_01_basic/answers/03_05_01-02_error_unupdatable_in_param.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_05_assign/_01_basic/answers/03_05_01-02_error_unupdatable_in_param.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 3, column 1
-Stored procedure compile error: I is not assignable to
+Stored procedure compile error: I is not updatable
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_05_assign/_01_basic/answers/03_05_01-03_error_incompatible.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_05_assign/_01_basic/answers/03_05_01-03_error_incompatible.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 4, column 6
-Stored procedure compile error: type of the value is not compatible with the variable's type
+Stored procedure compile error: type of assigned value is not compatible with the type of target variable
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_05_for_static_sql/answers/03_13_05-02_error_invalid_sql_2.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_05_for_static_sql/answers/03_13_05-02_error_invalid_sql_2.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 4, column 11
-Stored procedure compile error: SELECT in a FOR loop may not have an into-clause
+Stored procedure compile error: SELECT in a FOR loop may not have an INTO clause
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-04_error_incompatible_used_val.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-04_error_incompatible_used_val.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 3, column 82
-Stored procedure compile error: expressions in a USING clause cannot be of either BOOLEAN, CURSOR or SYS_REFCURSOR type
+Stored procedure compile error: expressions in a USING clause cannot be of Boolean type
 
 ===================================================
 count(*)    


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25056

엔진 업데이트 (PR https://github.com/CUBRID/cubrid/pull/5339 )에 따른 answer 파일 업데이트 입니다.
27 건의 answer 파일 업데이트 중 26건은 에러 메시지 교정에 따른 변경이고, 
구조적인 변경은 한건 뿐입니다. (_03_statement/_05_assign/_01_basic/03_05_01-02_error_unupdatable_for_record.sql )

예전에는 루프 레코드 변수에 대입 불가였는데, 
PR 5339 부터는 오라클 스펙에 맞추어 대입 가능하게 수정되었습니다. 

그래서 정수에서 레코드 변수로의 대입문에 대하여 
'대입 불가' 라고 에러 메시지가 나오던 것이 
'타입이 맞지 않아' 라는 에러 메시지가 나오도록 바뀌었습니다. 
