### PR TITLE
[CBRD-24941] update six answer files for the CUBRID engine updates

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_04_with_parameters/answers/01_01_04-02_error_invalid_param_type.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_04_with_parameters/answers/01_01_04-02_error_invalid_param_type.answer
@@ -4,10 +4,9 @@ Semantic: before ' ) as
 begin
 null;
 end; '
-dba.foo is not defined. create or replace procedure t(a  [dba.foo]) as 
+dba.foo is not defined. create or replace procedure t(a  [dba.foo]) as begin
 null;
 end;
-
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_04_with_parameters/answers/01_01_04-04_error_sys_refcursor_param_type.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_04_with_parameters/answers/01_01_04-04_error_sys_refcursor_param_type.answer
@@ -4,8 +4,7 @@ Semantic: before ' ) as
 begin
 null;
 end; '
-dba.sys_refcursor is not defined. create or replace procedure t(a  [dba.sys_refcursor]) as 
-nu...
+dba.sys_refcursor is not defined. create or replace procedure t(a  [dba.sys_refcursor]) as beg...
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_04_with_parameters/answers/08_invalid_parameter.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_04_with_parameters/answers/08_invalid_parameter.answer
@@ -17,8 +17,8 @@ Semantic: before ' ) as
 begin
 dbms_output.put_line('check unsupported param');
 e...'
-Unsupported argument type 'json' of the stored procedure create or replace procedure test_proc1(a  json) as 
-dbms_out...
+Unsupported argument type 'json' of the stored procedure create or replace procedure test_proc1(a  json) as begin
+dbm...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-07_error_bit_type.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-07_error_bit_type.answer
@@ -4,8 +4,8 @@ Semantic: before ' ) as
 begin
 dbms_output.put_line('i BIT : ' || i);
 end; '
-Unsupported argument type 'bit' of the stored procedure create or replace procedure pp(i  bit(1)) as 
-dbms_output.pu...
+Unsupported argument type 'bit' of the stored procedure create or replace procedure pp(i  bit(1)) as begin
+dbms_outp...
 
 ===================================================
 Error:-1360
@@ -14,5 +14,5 @@ Stored procedure compile error: no viable alternative at input 'BIT;'
 
 ===================================================
 Error:-494
-Semantic: Unsupported return type 'bit' of the stored procedure create or replace function ff() return bit(1) as  BIT := B'1...
+Semantic: Unsupported return type 'bit' of the stored procedure create or replace function ff() return bit(1) as var_bit BIT...
 

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_04_for_cursor/answers/03_13_04-07_error_unknown_field_lookup.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_04_for_cursor/answers/03_13_04-07_error_unknown_field_lookup.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 5, column 33
-Stored procedure compile error: no such column 'NAME' in the query result
+Stored procedure compile error: no field named 'NAME' in the record type
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_05_for_static_sql/answers/03_13_05-02_error_unknown_field.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_05_for_static_sql/answers/03_13_05-02_error_unknown_field.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 4, column 33
-Stored procedure compile error: no such column 'NAME' in the query result
+Stored procedure compile error: no field named 'NAME' in the record type
 
 ===================================================
 count(*)    


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24941

- bugfix of missing first word of plcsql program body (PR 5444)
  - 01_01_04-02_error_invalid_param_type.answer
  - 01_01_04-04_error_sys_refcursor_param_type.answer
  - 08_invalid_parameter.answer
  - 01_01_07-07_error_bit_type.answer
- fix in error message ('no such column ...' --> 'no field named ...')
  - 03_13_04-07_error_unknown_field_lookup.answer
  - 03_13_05-02_error_unknown_field.answer