### PR TITLE
[CBRD-24896] Add new testcase for Problem when accesing system table/views with search condition comparing set values

### DIFF
--- a/sql/_13_issues/_24_2h/answers/cbrd_24896.answer
+++ b/sql/_13_issues/_24_2h/answers/cbrd_24896.answer
@@ -1,4 +1,70 @@
 ===================================================
+    
+using seteq for search condition on system table     
+
+===================================================
+grantor    grantee    class_of    auth_type    is_grantable    
+db_user     db_user     _db_class     SELECT     0     
+
+Query plan:
+follow
+    edge:  au node[?] grantee -> db_user node[?]
+    head:  sscan
+              class: au node[?]
+              sargs: term[?]
+              cost:  ? card ?
+    sargs: term[?] AND term[?]
+    cost:  ? card ?
+Query stmt:
+select au.grantor, au.grantee, au.class_of, au.auth_type, au.is_grantable from [_db_auth] au where ({au.grantee.[name]} seteq {'PUBLIC'}) and (inst_num()<= ?:? )
+===================================================
+grantor    grantee    class_of    auth_type    is_grantable    
+
+Query plan:
+follow
+    edge:  au node[?] grantee -> db_user node[?]
+    head:  sscan
+              class: au node[?]
+              sargs: term[?]
+              cost:  ? card ?
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+select au.grantor, au.grantee, au.class_of, au.auth_type, au.is_grantable from [_db_auth] au where {au.grantee.[name]} seteq {} and (au.is_grantable= ?:? )
+===================================================
+    
+using = for search condition on system table     
+
+===================================================
+grantor    grantee    class_of    auth_type    is_grantable    
+db_user     db_user     _db_class     SELECT     0     
+
+Query plan:
+follow
+    edge:  au node[?] grantee -> db_user node[?]
+    head:  sscan
+              class: au node[?]
+              sargs: term[?]
+              cost:  ? card ?
+    sargs: term[?] AND term[?]
+    cost:  ? card ?
+Query stmt:
+select au.grantor, au.grantee, au.class_of, au.auth_type, au.is_grantable from [_db_auth] au where ({au.grantee.[name]}={'PUBLIC'}) and (inst_num()<= ?:? )
+===================================================
+grantor    grantee    class_of    auth_type    is_grantable    
+
+Query plan:
+follow
+    edge:  au node[?] grantee -> db_user node[?]
+    head:  sscan
+              class: au node[?]
+              sargs: term[?]
+              cost:  ? card ?
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+select au.grantor, au.grantee, au.class_of, au.auth_type, au.is_grantable from [_db_auth] au where {au.grantee.[name]}={} and (au.is_grantable= ?:? )
+===================================================
 0
 ===================================================
 0

--- a/sql/_13_issues/_24_2h/answers/cbrd_24896.answer
+++ b/sql/_13_issues/_24_2h/answers/cbrd_24896.answer
@@ -1,0 +1,91 @@
+===================================================
+0
+===================================================
+0
+===================================================
+3
+===================================================
+0
+===================================================
+0
+===================================================
+    
+index scan case     
+
+===================================================
+col_a    col_b    col_c    col_d    
+1     1     1     1     
+2     2     2     2     
+
+Query plan:
+iscan
+    class: tbl node[?]
+    index: idx term[?]
+    cost:  ? card ?
+Query stmt:
+select tbl.col_a, tbl.col_b, tbl.col_c, tbl.col_d from tbl tbl where (({tbl.col_a, tbl.col_b}={?, ?}) or ({tbl.col_a, tbl.col_b}={?, ?}))
+===================================================
+col_a    col_b    col_c    col_d    
+1     1     1     1     
+2     2     2     2     
+
+Query plan:
+iscan
+    class: tbl node[?]
+    index: idx term[?]
+    filtr: term[?]
+    cost:  ? card ?
+Query stmt:
+select tbl.col_a, tbl.col_b, tbl.col_c, tbl.col_d from tbl tbl where (({tbl.col_a, tbl.col_c}={?, ?}) or ({tbl.col_a, tbl.col_c}={?, ?}))
+===================================================
+col_a    col_b    col_c    col_d    
+1     1     1     1     
+2     2     2     2     
+
+Query plan:
+iscan
+    class: tbl node[?]
+    index: idx term[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+select tbl.col_a, tbl.col_b, tbl.col_c, tbl.col_d from tbl tbl where (({tbl.col_a, tbl.col_d}={?, ?}) or ({tbl.col_a, tbl.col_d}={?, ?}))
+===================================================
+    
+sscan case     
+
+===================================================
+col_a    col_b    col_c    col_d    
+1     1     1     1     
+2     2     2     2     
+
+Query plan:
+sscan
+    class: tbl node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+select tbl.col_a, tbl.col_b, tbl.col_c, tbl.col_d from tbl tbl where (({tbl.col_a, tbl.col_b}={?, ?}) or ({tbl.col_a, tbl.col_b}={?, ?}))
+===================================================
+col_a    col_b    col_c    col_d    
+2     2     2     2     
+
+Query plan:
+sscan
+    class: tbl node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+select tbl.col_a, tbl.col_b, tbl.col_c, tbl.col_d from tbl tbl where {tbl.col_a}={?}
+===================================================
+col_a    col_b    col_c    col_d    
+
+Query plan:
+sscan
+    class: tbl node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+select tbl.col_a, tbl.col_b, tbl.col_c, tbl.col_d from tbl tbl where {tbl.col_a}={}
+===================================================
+0

--- a/sql/_13_issues/_24_2h/cases/cbrd_24896.sql
+++ b/sql/_13_issues/_24_2h/cases/cbrd_24896.sql
@@ -1,5 +1,13 @@
 -- This testcase verifies CBRD-24896 issue.
 
+EVALUATE 'using seteq for search condition on system table';
+SELECT /*+ recompile */ * FROM [_db_auth] AS [au] WHERE {[au].[grantee].[name]} seteq {'PUBLIC'} LIMIT 1;
+SELECT /*+ recompile */ * FROM [_db_auth] AS [au] WHERE  (is_grantable = 1) AND {[au].[grantee].[name]} seteq {};
+
+EVALUATE 'using = for search condition on system table';
+SELECT /*+ recompile */ * FROM [_db_auth] AS [au] WHERE {[au].[grantee].[name]} = {'PUBLIC'} LIMIT 1;
+SELECT /*+ recompile */ * FROM [_db_auth] AS [au] WHERE  (is_grantable = 1) AND {[au].[grantee].[name]} = {};
+
 -- create table
 drop table if exists tbl;
 create table tbl (col_a int, col_b int, col_c int, col_d int);

--- a/sql/_13_issues/_24_2h/cases/cbrd_24896.sql
+++ b/sql/_13_issues/_24_2h/cases/cbrd_24896.sql
@@ -1,0 +1,18 @@
+-- create table
+drop table if exists tbl;
+create table tbl (col_a int, col_b int, col_c int, col_d int);
+insert into tbl values(1,1,1,1),(2,2,2,2),(3,3,3,3);
+create index idx on tbl(col_a,col_b,col_c);
+update statistics on tbl;
+
+EVALUATE 'index scan case';
+select /*+ recompile */ * from tbl where (col_a,col_b) in ((1,1),(2,2));
+select /*+ recompile */ * from tbl where (col_a,col_c) in ((1,1),(2,2));
+select /*+ recompile */ * from tbl where (col_a,col_d) in ((1,1),(2,2));
+
+EVALUATE 'sscan case';
+select /*+ recompile */ * from tbl where {col_a,col_b} in ((1,1),(2,2));
+select /*+ recompile */ * from tbl where {col_a} = {2};
+select /*+ recompile */ * from tbl where {col_a} = {};
+
+drop table tbl;

--- a/sql/_13_issues/_24_2h/cases/cbrd_24896.sql
+++ b/sql/_13_issues/_24_2h/cases/cbrd_24896.sql
@@ -1,3 +1,5 @@
+-- This testcase verifies CBRD-24896 issue.
+
 -- create table
 drop table if exists tbl;
 create table tbl (col_a int, col_b int, col_c int, col_d int);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24896

Modified to determine that index scan is impossible in the following cases
`set = set`
`{col1,col2} = {1,2}`
fix so that only collaction types written in parentheses can index-scan.