### PR TITLE
[CBRD-24941] minor updates for engine PR 5521

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/23_normal_viewtable_percent_type_cursor.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/23_normal_viewtable_percent_type_cursor.answer
@@ -12,7 +12,7 @@
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 38, column 1) internal server error
+  (line 38, column 1) Missing or invalid position of the bind variable provided
 
 ===================================================
     

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/cases/23_normal_viewtable_percent_type_cursor.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/cases/23_normal_viewtable_percent_type_cursor.sql
@@ -114,7 +114,7 @@ begin
    
 end;
 
---BUG(normal : "Normal execution" , BUG : "internal server error")
+--BUG(normal : "Normal execution" , BUG : "internal server error") CBRD-25606
 call type_support();
 
 


### PR DESCRIPTION
internal server error을 막기 위해 엔진에 작은 변경이 있었고, 
거기에 따라 answer 에 변경이 있었습니다. 
internal server error 에서 SQL error 로 바뀐 셈인데, 에러 해당 이슈 번호도 sql 파일에 주석으로 남겨 두었습니다. 
