### PR TITLE
Revert "[CBRD-24658] Add temporary exclusion case to Ha_repl test"

### DIFF
--- a/sql/config/daily_regression_test_exclude_list_ha_repl.conf
+++ b/sql/config/daily_regression_test_exclude_list_ha_repl.conf
@@ -305,6 +305,3 @@ sql/_27_banana_qa/issue_8909_unquoted_keywords/cases/_004_update.test
 
 #[PERMANENT] don't support 'call' on HA.
 sql/_33_elderberry/cbrd_23845/cases/_02_permission_check.test
-
-#[temporary] CBRD-24658 , If the problem is resolved, this case should be removed from this exclude file.
-sql/_08_javasp/cases/case_cte_01.test


### PR DESCRIPTION
Reverts CUBRID/cubrid-testcases#1416

CBRD-24658 이슈가 해결되었으므로 core때문에 ha_repl test 제외 리스트에 포함시켰던 testcase를 
test 제외 리스트에서 삭제합니다.