### PR TITLE
[CBRD-25477] remove precision and scale spec in parameter types and return types in TCs

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_02_all_types/answers/02_01_05-05_numeric_param_value.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_02_all_types/answers/02_01_05-05_numeric_param_value.answer
@@ -63,8 +63,7 @@ This is a normal case because an error occurred in the parameter "NUMERIC(3,4)" 
 
 
 ===================================================
-Error:-493
-Syntax: Invalid combination of precision (3) and scale (4). 
+0
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_02_all_types/cases/02_01_05-05_char_param_value.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_02_all_types/cases/02_01_05-05_char_param_value.sql
@@ -20,7 +20,7 @@ call t();
 select cast('a' as char(5) ) ||'char';
 
 
-create or replace procedure t(i_min CHAR(5), i_max CHAR(5) ) as
+create or replace procedure t(i_min CHAR, i_max CHAR) as
     var_min CHAR(5) := i_min;
     var_max CHAR(5) := i_max;
 begin

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_02_all_types/cases/02_01_05-05_numeric_param_value.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_02_all_types/cases/02_01_05-05_numeric_param_value.sql
@@ -40,7 +40,7 @@ select cast( 0.123456789 as numeric(4,4)) ;
 
 
 
-create or replace procedure t(i_min NUMERIC(4,4), i_max NUMERIC(4,4) ) as
+create or replace procedure t(i_min NUMERIC, i_max NUMERIC) as
     var_min NUMERIC := i_min;
     var_max NUMERIC := i_max;
 begin
@@ -55,7 +55,7 @@ select cast( cast( 0.123456789 as numeric(4,4)) as NUMERIC);
 
 select 'This is a normal case because an error occurred in the parameter "NUMERIC(3,4)" when creating.';
 
-create or replace procedure t(i_min NUMERIC(3,4), i_max NUMERIC(3,4) ) as
+create or replace procedure t(i_min NUMERIC, i_max NUMERIC) as
     var_min NUMERIC := i_min;
     var_max NUMERIC := i_max;
 begin

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_02_all_types/cases/02_01_05-05_varchar_param_value.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_02_all_types/cases/02_01_05-05_varchar_param_value.sql
@@ -20,7 +20,7 @@ call t();
 
 
 -- normal
-create or replace procedure t(i_min VARCHAR(5), i_max VARCHAR(5) ) as
+create or replace procedure t(i_min VARCHAR, i_max VARCHAR ) as
     var_min VARCHAR(5) := i_min;
     var_max VARCHAR(5) := i_max;
 begin

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_03_type_conversion/answers/02_01_03-17_sql_to_param_NUMERIC.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_03_type_conversion/answers/02_01_03-17_sql_to_param_NUMERIC.answer
@@ -6,7 +6,7 @@
 null     
 
 
-t_DATETIME_NUMERIC(38,15). This scenario is a failure.
+t_DATETIME_NUMERIC. This scenario is a failure.
 ===================================================
 0
 
@@ -22,7 +22,7 @@ Stored procedure execute error: com.cubrid.jsp.exception.TypeMismatchException
 null     
 
 
-t_DATETIMELTZ_NUMERIC(38,15). This scenario is a failure.
+t_DATETIMELTZ_NUMERIC. This scenario is a failure.
 ===================================================
 0
 
@@ -38,7 +38,7 @@ Stored procedure execute error: Unsupported argument type of stored procedure: d
 null     
 
 
-t_DATETIMETZ_NUMERIC(38,15). This scenario is a failure.
+t_DATETIMETZ_NUMERIC. This scenario is a failure.
 ===================================================
 0
 
@@ -54,7 +54,7 @@ Stored procedure execute error: Unsupported argument type of stored procedure: d
 null     
 
 
-t_DATE_NUMERIC(38,15). This scenario is a failure.
+t_DATE_NUMERIC. This scenario is a failure.
 ===================================================
 0
 
@@ -70,7 +70,7 @@ Stored procedure execute error: com.cubrid.jsp.exception.TypeMismatchException
 null     
 
 
-t_TIME_NUMERIC(38,15). This scenario is a failure.
+t_TIME_NUMERIC. This scenario is a failure.
 ===================================================
 0
 
@@ -86,7 +86,7 @@ Stored procedure execute error: com.cubrid.jsp.exception.TypeMismatchException
 null     
 
 
-t_TIMESTAMP_NUMERIC(38,15). This scenario is a failure.
+t_TIMESTAMP_NUMERIC. This scenario is a failure.
 ===================================================
 0
 
@@ -102,7 +102,7 @@ Stored procedure execute error: com.cubrid.jsp.exception.TypeMismatchException
 null     
 
 
-t_TIMESTAMPLTZ_NUMERIC(38,15). This scenario is a failure.
+t_TIMESTAMPLTZ_NUMERIC. This scenario is a failure.
 ===================================================
 0
 
@@ -118,7 +118,7 @@ Stored procedure execute error: Unsupported argument type of stored procedure: t
 null     
 
 
-t_TIMESTAMPTZ_NUMERIC(38,15). This scenario is a failure.
+t_TIMESTAMPTZ_NUMERIC. This scenario is a failure.
 ===================================================
 0
 
@@ -143,7 +143,7 @@ t_DOUBLE_NUMERIC. This scenario is a success.
 null     
 
 
-sql_type = DOUBLE, procedure_type = NUMERIC(38,15), current_value = 1234.567890000000033978722058236598968505859375
+sql_type = DOUBLE, procedure_type = NUMERIC, current_value = 1234.567890000000033978722058236598968505859375
 ===================================================
 0
 
@@ -161,7 +161,7 @@ t_FLOAT_NUMERIC. This scenario is a success.
 null     
 
 
-sql_type = FLOAT, procedure_type = NUMERIC(38,15), current_value = 16777.216796875
+sql_type = FLOAT, procedure_type = NUMERIC, current_value = 16777.216796875
 ===================================================
 0
 
@@ -179,13 +179,13 @@ t_NUMERIC_NUMERIC. This scenario is a success.
 null     
 
 
-sql_type = NUMERIC(4,4), procedure_type = NUMERIC(38,15), current_value = 0.1235
+sql_type = NUMERIC(4,4), procedure_type = NUMERIC, current_value = 0.1235
 ===================================================
     
 null     
 
 
-sql_type = NUMERIC(8,4), procedure_type = NUMERIC(38,15), current_value = 0.1235
+sql_type = NUMERIC(8,4), procedure_type = NUMERIC, current_value = 0.1235
 ===================================================
 0
 
@@ -203,7 +203,7 @@ t_BIGINT_NUMERIC. This scenario is a success.
 null     
 
 
-sql_type = BIGINT, procedure_type = NUMERIC(38,15), current_value = 34589012
+sql_type = BIGINT, procedure_type = NUMERIC, current_value = 34589012
 ===================================================
 0
 
@@ -221,7 +221,7 @@ t_INT_NUMERIC. This scenario is a success.
 null     
 
 
-sql_type = INT, procedure_type = NUMERIC(38,15), current_value = 782346
+sql_type = INT, procedure_type = NUMERIC, current_value = 782346
 ===================================================
 0
 
@@ -239,7 +239,7 @@ t_SHORT_NUMERIC. This scenario is a success.
 null     
 
 
-sql_type = SHORT, procedure_type = NUMERIC(38,15), current_value = 8934
+sql_type = SHORT, procedure_type = NUMERIC, current_value = 8934
 ===================================================
 0
 
@@ -248,7 +248,7 @@ sql_type = SHORT, procedure_type = NUMERIC(38,15), current_value = 8934
 null     
 
 
-t_BIT(8)_NUMERIC(38,15). This scenario is a failure.
+t_BIT(8)_NUMERIC. This scenario is a failure.
 ===================================================
 0
 
@@ -264,7 +264,7 @@ Stored procedure execute error: Unsupported argument type of stored procedure: b
 null     
 
 
-t_BIT VARYING_NUMERIC(38,15). This scenario is a failure.
+t_BIT VARYING_NUMERIC. This scenario is a failure.
 ===================================================
 0
 
@@ -289,7 +289,7 @@ t_CHAR_NUMERIC. This scenario is a success.
 null     
 
 
-sql_type = CHAR, procedure_type = NUMERIC(38,15), current_value = 123
+sql_type = CHAR, procedure_type = NUMERIC, current_value = 123
 ===================================================
 0
 
@@ -307,7 +307,7 @@ t_VARCHAR_NUMERIC. This scenario is a success.
 null     
 
 
-sql_type = VARCHAR, procedure_type = NUMERIC(38,15), current_value = 567
+sql_type = VARCHAR, procedure_type = NUMERIC, current_value = 567
 ===================================================
 0
 
@@ -316,7 +316,7 @@ sql_type = VARCHAR, procedure_type = NUMERIC(38,15), current_value = 567
 null     
 
 
-t_SET_NUMERIC(38,15). This scenario is a failure.
+t_SET_NUMERIC. This scenario is a failure.
 ===================================================
 0
 
@@ -332,7 +332,7 @@ Stored procedure execute error: com.cubrid.jsp.exception.TypeMismatchException
 null     
 
 
-t_MULTISET_NUMERIC(38,15). This scenario is a failure.
+t_MULTISET_NUMERIC. This scenario is a failure.
 ===================================================
 0
 
@@ -348,7 +348,7 @@ Stored procedure execute error: com.cubrid.jsp.exception.TypeMismatchException
 null     
 
 
-t_LIST_NUMERIC(38,15). This scenario is a failure.
+t_LIST_NUMERIC. This scenario is a failure.
 ===================================================
 0
 
@@ -364,7 +364,7 @@ Stored procedure execute error: com.cubrid.jsp.exception.TypeMismatchException
 null     
 
 
-t_ENUM_NUMERIC(38,15). This scenario is a failure.
+t_ENUM_NUMERIC. This scenario is a failure.
 ===================================================
 0
 
@@ -380,7 +380,7 @@ Stored procedure execute error: com.cubrid.jsp.exception.TypeMismatchException
 null     
 
 
-t_BLOB_NUMERIC(38,15). This scenario is a failure.
+t_BLOB_NUMERIC. This scenario is a failure.
 ===================================================
 0
 
@@ -396,7 +396,7 @@ Stored procedure execute error: Unsupported argument type of stored procedure: b
 null     
 
 
-t_CLOB_NUMERIC(38,15). This scenario is a failure.
+t_CLOB_NUMERIC. This scenario is a failure.
 ===================================================
 0
 
@@ -412,7 +412,7 @@ Stored procedure execute error: Unsupported argument type of stored procedure: c
 null     
 
 
-t_JSON_NUMERIC(38,15). This scenario is a failure.
+t_JSON_NUMERIC. This scenario is a failure.
 ===================================================
 0
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_03_type_conversion/cases/02_01_03-13_sql_to_param_CHAR.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_03_type_conversion/cases/02_01_03-13_sql_to_param_CHAR.sql
@@ -175,7 +175,7 @@ drop procedure t_LIST_CHAR ;
 
 
 call print_message('t_ENUM_CHAR. This scenario is a failure.');
-create or replace function t_ENUM_CHAR(sql_type string, procedure_type string, param CHAR ) return varchar(100) as begin
+create or replace function t_ENUM_CHAR(sql_type string, procedure_type string, param CHAR ) return varchar as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param );
     return 'abc';
 end;

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_03_type_conversion/cases/02_01_03-14_sql_to_param_VARCHAR.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_03_type_conversion/cases/02_01_03-14_sql_to_param_VARCHAR.sql
@@ -175,7 +175,7 @@ drop procedure t_LIST_VARCHAR ;
 
 
 call print_message('t_ENUM_VARCHAR. This scenario is a failure.');
-create or replace function t_ENUM_VARCHAR(sql_type string, procedure_type string, param VARCHAR ) return varchar(100) as begin
+create or replace function t_ENUM_VARCHAR(sql_type string, procedure_type string, param VARCHAR ) return varchar as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param );
     return 'abc';
 end;

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_03_type_conversion/cases/02_01_03-17_sql_to_param_NUMERIC.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_03_type_conversion/cases/02_01_03-17_sql_to_param_NUMERIC.sql
@@ -196,7 +196,7 @@ call print_message('t_JSON_NUMERIC. This scenario is a failure.');
 create or replace procedure t_JSON_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_JSON_NUMERIC('JSON', 'NUMERIC ;
+call t_JSON_NUMERIC('JSON', 'NUMERIC', '{"a":1}' ) ;
 drop procedure t_JSON_NUMERIC ;
 drop procedure print_message;
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_03_type_conversion/cases/02_01_03-17_sql_to_param_NUMERIC.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_03_type_conversion/cases/02_01_03-17_sql_to_param_NUMERIC.sql
@@ -5,198 +5,198 @@ create or replace procedure print_message(print_message string ) as begin
 end;
 
 
-call print_message('t_DATETIME_NUMERIC(38,15). This scenario is a failure.');
-create or replace procedure t_DATETIME_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+call print_message('t_DATETIME_NUMERIC. This scenario is a failure.');
+create or replace procedure t_DATETIME_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_DATETIME_NUMERIC('DATETIME', 'NUMERIC(38,15)', DATETIME'2023-02-14 10:51:28.999' ) ;
+call t_DATETIME_NUMERIC('DATETIME', 'NUMERIC', DATETIME'2023-02-14 10:51:28.999' ) ;
 drop procedure t_DATETIME_NUMERIC ;
 
 
-call print_message('t_DATETIMELTZ_NUMERIC(38,15). This scenario is a failure.');
-create or replace procedure t_DATETIMELTZ_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+call print_message('t_DATETIMELTZ_NUMERIC. This scenario is a failure.');
+create or replace procedure t_DATETIMELTZ_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_DATETIMELTZ_NUMERIC('DATETIMELTZ', 'NUMERIC(38,15)', datetimeltz '09/01/2009 01:10:10 pm' ) ;
+call t_DATETIMELTZ_NUMERIC('DATETIMELTZ', 'NUMERIC', datetimeltz '09/01/2009 01:10:10 pm' ) ;
 drop procedure t_DATETIMELTZ_NUMERIC ;
 
 
-call print_message('t_DATETIMETZ_NUMERIC(38,15). This scenario is a failure.');
-create or replace procedure t_DATETIMETZ_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+call print_message('t_DATETIMETZ_NUMERIC. This scenario is a failure.');
+create or replace procedure t_DATETIMETZ_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_DATETIMETZ_NUMERIC('DATETIMETZ', 'NUMERIC(38,15)', datetimetz '09/01/2008 02:20:20 pm' ) ;
+call t_DATETIMETZ_NUMERIC('DATETIMETZ', 'NUMERIC', datetimetz '09/01/2008 02:20:20 pm' ) ;
 drop procedure t_DATETIMETZ_NUMERIC ;
 
 
-call print_message('t_DATE_NUMERIC(38,15). This scenario is a failure.');
-create or replace procedure t_DATE_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+call print_message('t_DATE_NUMERIC. This scenario is a failure.');
+create or replace procedure t_DATE_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_DATE_NUMERIC('DATE', 'NUMERIC(38,15)', DATE'2008-10-31' ) ;
+call t_DATE_NUMERIC('DATE', 'NUMERIC', DATE'2008-10-31' ) ;
 drop procedure t_DATE_NUMERIC ;
 
 
-call print_message('t_TIME_NUMERIC(38,15). This scenario is a failure.');
-create or replace procedure t_TIME_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+call print_message('t_TIME_NUMERIC. This scenario is a failure.');
+create or replace procedure t_TIME_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_TIME_NUMERIC('TIME', 'NUMERIC(38,15)', TIME'13:15:45' ) ;
+call t_TIME_NUMERIC('TIME', 'NUMERIC', TIME'13:15:45' ) ;
 drop procedure t_TIME_NUMERIC ;
 
 
-call print_message('t_TIMESTAMP_NUMERIC(38,15). This scenario is a failure.');
-create or replace procedure t_TIMESTAMP_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+call print_message('t_TIMESTAMP_NUMERIC. This scenario is a failure.');
+create or replace procedure t_TIMESTAMP_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_TIMESTAMP_NUMERIC('TIMESTAMP', 'NUMERIC(38,15)', TIMESTAMP'2023-10-31 13:15:45' ) ;
+call t_TIMESTAMP_NUMERIC('TIMESTAMP', 'NUMERIC', TIMESTAMP'2023-10-31 13:15:45' ) ;
 drop procedure t_TIMESTAMP_NUMERIC ;
 
 
-call print_message('t_TIMESTAMPLTZ_NUMERIC(38,15). This scenario is a failure.');
-create or replace procedure t_TIMESTAMPLTZ_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+call print_message('t_TIMESTAMPLTZ_NUMERIC. This scenario is a failure.');
+create or replace procedure t_TIMESTAMPLTZ_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_TIMESTAMPLTZ_NUMERIC('TIMESTAMPLTZ', 'NUMERIC(38,15)', timestamptz '09/01/2007 03:30:30 pm' ) ;
+call t_TIMESTAMPLTZ_NUMERIC('TIMESTAMPLTZ', 'NUMERIC', timestamptz '09/01/2007 03:30:30 pm' ) ;
 drop procedure t_TIMESTAMPLTZ_NUMERIC ;
 
 
-call print_message('t_TIMESTAMPTZ_NUMERIC(38,15). This scenario is a failure.');
-create or replace procedure t_TIMESTAMPTZ_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+call print_message('t_TIMESTAMPTZ_NUMERIC. This scenario is a failure.');
+create or replace procedure t_TIMESTAMPTZ_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_TIMESTAMPTZ_NUMERIC('TIMESTAMPTZ', 'NUMERIC(38,15)', timestamptz '09/01/2006 04:40:40 pm' ) ;
+call t_TIMESTAMPTZ_NUMERIC('TIMESTAMPTZ', 'NUMERIC', timestamptz '09/01/2006 04:40:40 pm' ) ;
 drop procedure t_TIMESTAMPTZ_NUMERIC ;
 
 --BUG( normal : 1234.567890000000000,  BUG : 1234.567890000000033978722058236598968505859375 ) - CBRD-25566
 call print_message('t_DOUBLE_NUMERIC. This scenario is a success.');
-create or replace procedure t_DOUBLE_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+create or replace procedure t_DOUBLE_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_DOUBLE_NUMERIC('DOUBLE', 'NUMERIC(38,15)', cast( 1234.56789 as double) ) ;
+call t_DOUBLE_NUMERIC('DOUBLE', 'NUMERIC', cast( 1234.56789 as double) ) ;
 drop procedure t_DOUBLE_NUMERIC ;
 
 --BUG ( normal : 16777.210000000000000, BUG : 16777.216796875 ) - CBRD-25566
 call print_message('t_FLOAT_NUMERIC. This scenario is a success.');
-create or replace procedure t_FLOAT_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+create or replace procedure t_FLOAT_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_FLOAT_NUMERIC('FLOAT', 'NUMERIC(38,15)', cast( 16777.217 as float ) ) ;
+call t_FLOAT_NUMERIC('FLOAT', 'NUMERIC', cast( 16777.217 as float ) ) ;
 drop procedure t_FLOAT_NUMERIC ;
 
 call print_message('t_NUMERIC_NUMERIC. This scenario is a success.');
-create or replace procedure t_NUMERIC_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+create or replace procedure t_NUMERIC_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_NUMERIC_NUMERIC('NUMERIC(4,4)', 'NUMERIC(38,15)', cast( 0.123456789 as numeric(4,4) ) ) ;
-call t_NUMERIC_NUMERIC('NUMERIC(8,4)', 'NUMERIC(38,15)', cast( 0.123456789 as numeric(8,4) ) ) ;
+call t_NUMERIC_NUMERIC('NUMERIC(4,4)', 'NUMERIC', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_NUMERIC('NUMERIC(8,4)', 'NUMERIC', cast( 0.123456789 as numeric(8,4) ) ) ;
 drop procedure t_NUMERIC_NUMERIC ;
 
 call print_message('t_BIGINT_NUMERIC. This scenario is a success.');
-create or replace procedure t_BIGINT_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+create or replace procedure t_BIGINT_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_BIGINT_NUMERIC('BIGINT', 'NUMERIC(38,15)', cast( 34589012 as bigint ) ) ;
+call t_BIGINT_NUMERIC('BIGINT', 'NUMERIC', cast( 34589012 as bigint ) ) ;
 drop procedure t_BIGINT_NUMERIC ;
 
 call print_message('t_INT_NUMERIC. This scenario is a success.');
-create or replace procedure t_INT_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+create or replace procedure t_INT_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_INT_NUMERIC('INT', 'NUMERIC(38,15)', cast( 782346 as int ) ) ;
+call t_INT_NUMERIC('INT', 'NUMERIC', cast( 782346 as int ) ) ;
 drop procedure t_INT_NUMERIC ;
 
 call print_message('t_SHORT_NUMERIC. This scenario is a success.');
-create or replace procedure t_SHORT_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+create or replace procedure t_SHORT_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_SHORT_NUMERIC('SHORT', 'NUMERIC(38,15)', cast( 8934 as short ) ) ;
+call t_SHORT_NUMERIC('SHORT', 'NUMERIC', cast( 8934 as short ) ) ;
 drop procedure t_SHORT_NUMERIC ;
 
 
-call print_message('t_BIT(8)_NUMERIC(38,15). This scenario is a failure.');
-create or replace procedure t_BIT_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+call print_message('t_BIT(8)_NUMERIC. This scenario is a failure.');
+create or replace procedure t_BIT_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_BIT_NUMERIC('BIT(8)', 'NUMERIC(38,15)', 0xaa ) ;
+call t_BIT_NUMERIC('BIT(8)', 'NUMERIC', 0xaa ) ;
 drop procedure t_BIT_NUMERIC ;
 
 
-call print_message('t_BIT VARYING_NUMERIC(38,15). This scenario is a failure.');
-create or replace procedure t_BITVARYING_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+call print_message('t_BIT VARYING_NUMERIC. This scenario is a failure.');
+create or replace procedure t_BITVARYING_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_BITVARYING_NUMERIC('BIT VARYING', 'NUMERIC(38,15)', 0xaa ) ;
+call t_BITVARYING_NUMERIC('BIT VARYING', 'NUMERIC', 0xaa ) ;
 drop procedure t_BITVARYING_NUMERIC ;
 
 call print_message('t_CHAR_NUMERIC. This scenario is a success.');
-create or replace procedure t_CHAR_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+create or replace procedure t_CHAR_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_CHAR_NUMERIC('CHAR', 'NUMERIC(38,15)', cast( '123' as char(3) ) ) ;
+call t_CHAR_NUMERIC('CHAR', 'NUMERIC', cast( '123' as char(3) ) ) ;
 drop procedure t_CHAR_NUMERIC ;
 
 call print_message('t_VARCHAR_NUMERIC. This scenario is a success.');
-create or replace procedure t_VARCHAR_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+create or replace procedure t_VARCHAR_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_VARCHAR_NUMERIC('VARCHAR', 'NUMERIC(38,15)', cast('567' as varchar ) ) ;
+call t_VARCHAR_NUMERIC('VARCHAR', 'NUMERIC', cast('567' as varchar ) ) ;
 drop procedure t_VARCHAR_NUMERIC ;
 
 
-call print_message('t_SET_NUMERIC(38,15). This scenario is a failure.');
-create or replace procedure t_SET_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+call print_message('t_SET_NUMERIC. This scenario is a failure.');
+create or replace procedure t_SET_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_SET_NUMERIC('SET', 'NUMERIC(38,15)', {'c','c','c','b','b','a'} ) ;
+call t_SET_NUMERIC('SET', 'NUMERIC', {'c','c','c','b','b','a'} ) ;
 drop procedure t_SET_NUMERIC ;
 
 
-call print_message('t_MULTISET_NUMERIC(38,15). This scenario is a failure.');
-create or replace procedure t_MULTISET_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+call print_message('t_MULTISET_NUMERIC. This scenario is a failure.');
+create or replace procedure t_MULTISET_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_MULTISET_NUMERIC('MULTISET', 'NUMERIC(38,15)', {'c','c','c','b','b','a'} ) ;
+call t_MULTISET_NUMERIC('MULTISET', 'NUMERIC', {'c','c','c','b','b','a'} ) ;
 drop procedure t_MULTISET_NUMERIC ;
 
 
-call print_message('t_LIST_NUMERIC(38,15). This scenario is a failure.');
-create or replace procedure t_LIST_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+call print_message('t_LIST_NUMERIC. This scenario is a failure.');
+create or replace procedure t_LIST_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_LIST_NUMERIC('LIST', 'NUMERIC(38,15)', {'c','c','c','b','b', 'a'} ) ;
+call t_LIST_NUMERIC('LIST', 'NUMERIC', {'c','c','c','b','b', 'a'} ) ;
 drop procedure t_LIST_NUMERIC ;
 
 
-call print_message('t_ENUM_NUMERIC(38,15). This scenario is a failure.');
-create or replace procedure t_ENUM_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+call print_message('t_ENUM_NUMERIC. This scenario is a failure.');
+create or replace procedure t_ENUM_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_ENUM_NUMERIC('ENUM', 'NUMERIC(38,15)', 'yellow' ) ;
+call t_ENUM_NUMERIC('ENUM', 'NUMERIC', 'yellow' ) ;
 drop procedure t_ENUM_NUMERIC ;
 
 
-call print_message('t_BLOB_NUMERIC(38,15). This scenario is a failure.');
-create or replace procedure t_BLOB_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+call print_message('t_BLOB_NUMERIC. This scenario is a failure.');
+create or replace procedure t_BLOB_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_BLOB_NUMERIC('BLOB', 'NUMERIC(38,15)', BIT_TO_BLOB(X'000010') ) ;
+call t_BLOB_NUMERIC('BLOB', 'NUMERIC', BIT_TO_BLOB(X'000010') ) ;
 drop procedure t_BLOB_NUMERIC ;
 
 
-call print_message('t_CLOB_NUMERIC(38,15). This scenario is a failure.');
-create or replace procedure t_CLOB_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+call print_message('t_CLOB_NUMERIC. This scenario is a failure.');
+create or replace procedure t_CLOB_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_CLOB_NUMERIC('CLOB', 'NUMERIC(38,15)', CHAR_TO_CLOB('This is a Dog') ) ;
+call t_CLOB_NUMERIC('CLOB', 'NUMERIC', CHAR_TO_CLOB('This is a Dog') ) ;
 drop procedure t_CLOB_NUMERIC ;
 
 
-call print_message('t_JSON_NUMERIC(38,15). This scenario is a failure.');
-create or replace procedure t_JSON_NUMERIC(sql_type string, procedure_type string, param NUMERIC(38,15) ) as begin
+call print_message('t_JSON_NUMERIC. This scenario is a failure.');
+create or replace procedure t_JSON_NUMERIC(sql_type string, procedure_type string, param NUMERIC ) as begin
     dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param ); 
 end;
-call t_JSON_NUMERIC('JSON', 'NUMERIC(38,15)', '{"a":1}' ) ;
+call t_JSON_NUMERIC('JSON', 'NUMERIC ;
 drop procedure t_JSON_NUMERIC ;
 drop procedure print_message;
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_06_type_conversion_potential/answers/02_01_06-06_conversion_potential_numeric.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_06_type_conversion_potential/answers/02_01_06-06_conversion_potential_numeric.answer
@@ -1,6 +1,6 @@
 ===================================================
-'It is called normally. ( t_boolean, numeric(8,3) )'    
-It is called normally. ( t_boolean, numeric(8,3) )     
+'It is called normally. ( t_boolean, numeric )'    
+It is called normally. ( t_boolean, numeric )     
 
 
 ===================================================
@@ -11,14 +11,14 @@ It is called normally. ( t_boolean, numeric(8,3) )
 null     
 
 
-boolean to numeric(8,3) 
+boolean to numeric 
 param value = 0
 ===================================================
 0
 
 ===================================================
-'It is called normally. ( t_string, numeric(8,3) )'    
-It is called normally. ( t_string, numeric(8,3) )     
+'It is called normally. ( t_string, numeric )'    
+It is called normally. ( t_string, numeric )     
 
 
 ===================================================
@@ -29,14 +29,14 @@ It is called normally. ( t_string, numeric(8,3) )
 null     
 
 
-string to numeric(8,3) 
+string to numeric 
 param value = 123
 ===================================================
 0
 
 ===================================================
-'It is called normally. ( t_short, numeric(8,3) )'    
-It is called normally. ( t_short, numeric(8,3) )     
+'It is called normally. ( t_short, numeric )'    
+It is called normally. ( t_short, numeric )     
 
 
 ===================================================
@@ -47,14 +47,14 @@ It is called normally. ( t_short, numeric(8,3) )
 null     
 
 
-short to numeric(8,3) 
+short to numeric 
 param value = 8934
 ===================================================
 0
 
 ===================================================
-'It is called normally. ( t_int, numeric(8,3) )'    
-It is called normally. ( t_int, numeric(8,3) )     
+'It is called normally. ( t_int, numeric )'    
+It is called normally. ( t_int, numeric )     
 
 
 ===================================================
@@ -65,14 +65,14 @@ It is called normally. ( t_int, numeric(8,3) )
 null     
 
 
-int to numeric(8,3) 
+int to numeric 
 param value = 78234
 ===================================================
 0
 
 ===================================================
-'It is called normally. ( t_bigint, numeric(8,3) )'    
-It is called normally. ( t_bigint, numeric(8,3) )     
+'It is called normally. ( t_bigint, numeric )'    
+It is called normally. ( t_bigint, numeric )     
 
 
 ===================================================
@@ -83,14 +83,14 @@ It is called normally. ( t_bigint, numeric(8,3) )
 null     
 
 
-bigint to numeric(8,3) 
+bigint to numeric 
 param value = 278234
 ===================================================
 0
 
 ===================================================
-'It is called normally. ( t_numeric(8,3), numeric(8,3) )'    
-It is called normally. ( t_numeric(8,3), numeric(8,3) )     
+'It is called normally. ( t_numeric(8,3), numeric )'    
+It is called normally. ( t_numeric(8,3), numeric )     
 
 
 ===================================================
@@ -101,14 +101,14 @@ It is called normally. ( t_numeric(8,3), numeric(8,3) )
 null     
 
 
-numeric(8,3) to numeric(8,3) 
+numeric(8,3) to numeric 
 param value = 5678.123
 ===================================================
 0
 
 ===================================================
-'It is called normally. ( t_float, numeric(8,3) )'    
-It is called normally. ( t_float, numeric(8,3) )     
+'It is called normally. ( t_float, numeric )'    
+It is called normally. ( t_float, numeric )     
 
 
 ===================================================
@@ -119,14 +119,14 @@ It is called normally. ( t_float, numeric(8,3) )
 null     
 
 
-float to numeric(8,3) 
+float to numeric 
 param value = 3677.344970703125
 ===================================================
 0
 
 ===================================================
-'It is called normally. ( t_double, numeric(8,3) )'    
-It is called normally. ( t_double, numeric(8,3) )     
+'It is called normally. ( t_double, numeric )'    
+It is called normally. ( t_double, numeric )     
 
 
 ===================================================
@@ -137,14 +137,14 @@ It is called normally. ( t_double, numeric(8,3) )
 null     
 
 
-double to numeric(8,3) 
+double to numeric 
 param value = 56789.123399999996763654053211212158203125
 ===================================================
 0
 
 ===================================================
-'An error occurs. ( t_date, numeric(8,3) )'    
-An error occurs. ( t_date, numeric(8,3) )     
+'An error occurs. ( t_date, numeric )'    
+An error occurs. ( t_date, numeric )     
 
 
 ===================================================
@@ -158,8 +158,8 @@ Stored procedure execute error: com.cubrid.jsp.exception.TypeMismatchException
 0
 
 ===================================================
-'An error occurs. ( t_time, numeric(8,3) )'    
-An error occurs. ( t_time, numeric(8,3) )     
+'An error occurs. ( t_time, numeric )'    
+An error occurs. ( t_time, numeric )     
 
 
 ===================================================
@@ -173,8 +173,8 @@ Stored procedure execute error: com.cubrid.jsp.exception.TypeMismatchException
 0
 
 ===================================================
-'An error occurs. ( t_datetime, numeric(8,3) )'    
-An error occurs. ( t_datetime, numeric(8,3) )     
+'An error occurs. ( t_datetime, numeric )'    
+An error occurs. ( t_datetime, numeric )     
 
 
 ===================================================
@@ -188,8 +188,8 @@ Stored procedure execute error: com.cubrid.jsp.exception.TypeMismatchException
 0
 
 ===================================================
-'An error occurs. ( t_timestamp, numeric(8,3) )'    
-An error occurs. ( t_timestamp, numeric(8,3) )     
+'An error occurs. ( t_timestamp, numeric )'    
+An error occurs. ( t_timestamp, numeric )     
 
 
 ===================================================

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_06_type_conversion_potential/cases/02_01_06-06_conversion_potential_numeric.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_06_type_conversion_potential/cases/02_01_06-06_conversion_potential_numeric.sql
@@ -1,9 +1,9 @@
 --+ server-message on
 
-select 'It is called normally. ( t_boolean, numeric(8,3) )' ;
-create or replace procedure t_numeric( from_type string, param numeric(8,3) ) as 
+select 'It is called normally. ( t_boolean, numeric )' ;
+create or replace procedure t_numeric( from_type string, param numeric ) as 
 begin 
-    dbms_output.put_line(from_type||' to numeric(8,3) ' ) ;
+    dbms_output.put_line(from_type||' to numeric ' ) ;
     dbms_output.put_line('param value = '|| param );
 end;
 
@@ -12,10 +12,10 @@ drop procedure t_numeric ;
 
 
 
-select 'It is called normally. ( t_string, numeric(8,3) )' ;
-create or replace procedure t_numeric( from_type string, param numeric(8,3) ) as 
+select 'It is called normally. ( t_string, numeric )' ;
+create or replace procedure t_numeric( from_type string, param numeric ) as 
 begin 
-    dbms_output.put_line(from_type||' to numeric(8,3) ' ) ;
+    dbms_output.put_line(from_type||' to numeric ' ) ;
     dbms_output.put_line('param value = '|| param );
 end;
 
@@ -24,10 +24,10 @@ drop procedure t_numeric ;
 
 
 
-select 'It is called normally. ( t_short, numeric(8,3) )' ;
-create or replace procedure t_numeric( from_type string, param numeric(8,3) ) as 
+select 'It is called normally. ( t_short, numeric )' ;
+create or replace procedure t_numeric( from_type string, param numeric ) as 
 begin 
-    dbms_output.put_line(from_type||' to numeric(8,3) ' ) ;
+    dbms_output.put_line(from_type||' to numeric ' ) ;
     dbms_output.put_line('param value = '|| param );
 end;
 
@@ -36,10 +36,10 @@ drop procedure t_numeric ;
 
 
 
-select 'It is called normally. ( t_int, numeric(8,3) )' ;
-create or replace procedure t_numeric( from_type string, param numeric(8,3) ) as 
+select 'It is called normally. ( t_int, numeric )' ;
+create or replace procedure t_numeric( from_type string, param numeric ) as 
 begin 
-    dbms_output.put_line(from_type||' to numeric(8,3) ' ) ;
+    dbms_output.put_line(from_type||' to numeric ' ) ;
     dbms_output.put_line('param value = '|| param );
 end;
 
@@ -48,10 +48,10 @@ drop procedure t_numeric ;
 
 
 
-select 'It is called normally. ( t_bigint, numeric(8,3) )' ;
-create or replace procedure t_numeric( from_type string, param numeric(8,3) ) as 
+select 'It is called normally. ( t_bigint, numeric )' ;
+create or replace procedure t_numeric( from_type string, param numeric ) as 
 begin 
-    dbms_output.put_line(from_type||' to numeric(8,3) ' ) ;
+    dbms_output.put_line(from_type||' to numeric ' ) ;
     dbms_output.put_line('param value = '|| param );
 end;
 
@@ -60,10 +60,10 @@ drop procedure t_numeric ;
 
 
 
-select 'It is called normally. ( t_numeric(8,3), numeric(8,3) )' ;
-create or replace procedure t_numeric( from_type string, param numeric(8,3) ) as 
+select 'It is called normally. ( t_numeric(8,3), numeric )' ;
+create or replace procedure t_numeric( from_type string, param numeric ) as 
 begin 
-    dbms_output.put_line(from_type||' to numeric(8,3) ' ) ;
+    dbms_output.put_line(from_type||' to numeric ' ) ;
     dbms_output.put_line('param value = '|| param );
 end;
 
@@ -72,10 +72,10 @@ drop procedure t_numeric ;
 
 
 -- BUG ( normal : 3677.344, BUG : 3677.344970703125 ) - CBRD-25566
-select 'It is called normally. ( t_float, numeric(8,3) )' ;
-create or replace procedure t_numeric( from_type string, param numeric(8,3) ) as 
+select 'It is called normally. ( t_float, numeric )' ;
+create or replace procedure t_numeric( from_type string, param numeric ) as 
 begin 
-    dbms_output.put_line(from_type||' to numeric(8,3) ' ) ;
+    dbms_output.put_line(from_type||' to numeric ' ) ;
     dbms_output.put_line('param value = '|| param );
 end;
 
@@ -84,10 +84,10 @@ drop procedure t_numeric ;
 
 
 -- BUG ( normal : 56789.123, BUG : 56789.123399999996763654053211212158203125 ) - CBRD-25566
-select 'It is called normally. ( t_double, numeric(8,3) )' ;
-create or replace procedure t_numeric( from_type string, param numeric(8,3) ) as 
+select 'It is called normally. ( t_double, numeric )' ;
+create or replace procedure t_numeric( from_type string, param numeric ) as 
 begin 
-    dbms_output.put_line(from_type||' to numeric(8,3) ' ) ;
+    dbms_output.put_line(from_type||' to numeric ' ) ;
     dbms_output.put_line('param value = '|| param );
 end;
 
@@ -96,10 +96,10 @@ drop procedure t_numeric ;
 
 
 
-select 'An error occurs. ( t_date, numeric(8,3) )' ;
-create or replace procedure t_numeric( from_type string, param numeric(8,3) ) as 
+select 'An error occurs. ( t_date, numeric )' ;
+create or replace procedure t_numeric( from_type string, param numeric ) as 
 begin 
-    dbms_output.put_line(from_type||' to numeric(8,3) ' ) ;
+    dbms_output.put_line(from_type||' to numeric ' ) ;
     dbms_output.put_line('param value = '|| param );
 end;
 
@@ -108,10 +108,10 @@ drop procedure t_numeric ;
 
 
 
-select 'An error occurs. ( t_time, numeric(8,3) )' ;
-create or replace procedure t_numeric( from_type string, param numeric(8,3) ) as 
+select 'An error occurs. ( t_time, numeric )' ;
+create or replace procedure t_numeric( from_type string, param numeric ) as 
 begin 
-    dbms_output.put_line(from_type||' to numeric(8,3) ' ) ;
+    dbms_output.put_line(from_type||' to numeric ' ) ;
     dbms_output.put_line('param value = '|| param );
 end;
 
@@ -120,10 +120,10 @@ drop procedure t_numeric ;
 
 
 
-select 'An error occurs. ( t_datetime, numeric(8,3) )' ;
-create or replace procedure t_numeric( from_type string, param numeric(8,3) ) as 
+select 'An error occurs. ( t_datetime, numeric )' ;
+create or replace procedure t_numeric( from_type string, param numeric ) as 
 begin 
-    dbms_output.put_line(from_type||' to numeric(8,3) ' ) ;
+    dbms_output.put_line(from_type||' to numeric ' ) ;
     dbms_output.put_line('param value = '|| param );
 end;
 
@@ -132,10 +132,10 @@ drop procedure t_numeric ;
 
 
 
-select 'An error occurs. ( t_timestamp, numeric(8,3) )' ;
-create or replace procedure t_numeric( from_type string, param numeric(8,3) ) as 
+select 'An error occurs. ( t_timestamp, numeric )' ;
+create or replace procedure t_numeric( from_type string, param numeric ) as 
 begin 
-    dbms_output.put_line(from_type||' to numeric(8,3) ' ) ;
+    dbms_output.put_line(from_type||' to numeric ' ) ;
     dbms_output.put_line('param value = '|| param );
 end;
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_07_local_type_conversion_potential/answers/02_01_07-06_local_conversion_potential_numeric.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_07_local_type_conversion_potential/answers/02_01_07-06_local_conversion_potential_numeric.answer
@@ -1,6 +1,6 @@
 ===================================================
-'An error occurs. ( t_boolean, numeric(8,3) )'    
-An error occurs. ( t_boolean, numeric(8,3) )     
+'An error occurs. ( t_boolean, numeric )'    
+An error occurs. ( t_boolean, numeric )     
 
 
 ===================================================
@@ -18,8 +18,8 @@ Error:-894
 Stored procedure/function 't_numeric' does not exist.
 
 ===================================================
-'It is called normally. ( t_string, numeric(8,3) )'    
-It is called normally. ( t_string, numeric(8,3) )     
+'It is called normally. ( t_string, numeric )'    
+It is called normally. ( t_string, numeric )     
 
 
 ===================================================
@@ -30,14 +30,14 @@ It is called normally. ( t_string, numeric(8,3) )
 null     
 
 
-string to numeric(8,3)
+string to numeric
 string => 123
 ===================================================
 0
 
 ===================================================
-'It is called normally. ( t_short, numeric(8,3) )'    
-It is called normally. ( t_short, numeric(8,3) )     
+'It is called normally. ( t_short, numeric )'    
+It is called normally. ( t_short, numeric )     
 
 
 ===================================================
@@ -48,14 +48,14 @@ It is called normally. ( t_short, numeric(8,3) )
 null     
 
 
-short to numeric(8,3)
+short to numeric
 short => 8934
 ===================================================
 0
 
 ===================================================
-'It is called normally. ( t_int, numeric(8,3) )'    
-It is called normally. ( t_int, numeric(8,3) )     
+'It is called normally. ( t_int, numeric )'    
+It is called normally. ( t_int, numeric )     
 
 
 ===================================================
@@ -66,14 +66,14 @@ It is called normally. ( t_int, numeric(8,3) )
 null     
 
 
-int to numeric(8,3)
+int to numeric
 int => 8234
 ===================================================
 0
 
 ===================================================
-'It is called normally. ( t_bigint, numeric(8,3) )'    
-It is called normally. ( t_bigint, numeric(8,3) )     
+'It is called normally. ( t_bigint, numeric )'    
+It is called normally. ( t_bigint, numeric )     
 
 
 ===================================================
@@ -84,14 +84,14 @@ It is called normally. ( t_bigint, numeric(8,3) )
 null     
 
 
-bigint to numeric(8,3)
+bigint to numeric
 bigint => 278
 ===================================================
 0
 
 ===================================================
-'It is called normally. ( t_numeric(8,3), numeric(8,3) )'    
-It is called normally. ( t_numeric(8,3), numeric(8,3) )     
+'It is called normally. ( t_numeric(8,3), numeric )'    
+It is called normally. ( t_numeric(8,3), numeric )     
 
 
 ===================================================
@@ -102,14 +102,14 @@ It is called normally. ( t_numeric(8,3), numeric(8,3) )
 null     
 
 
-numeric(8,3) to numeric(8,3)
+numeric(8,3) to numeric
 numeric(8,3) => 5678.123
 ===================================================
 0
 
 ===================================================
-'It is called normally. ( t_float, numeric(8,3) )'    
-It is called normally. ( t_float, numeric(8,3) )     
+'It is called normally. ( t_float, numeric )'    
+It is called normally. ( t_float, numeric )     
 
 
 ===================================================
@@ -120,14 +120,14 @@ It is called normally. ( t_float, numeric(8,3) )
 null     
 
 
-float to numeric(8,3)
+float to numeric
 float => 3677.344970703125
 ===================================================
 0
 
 ===================================================
-'It is called normally. ( t_double, numeric(8,3) )'    
-It is called normally. ( t_double, numeric(8,3) )     
+'It is called normally. ( t_double, numeric )'    
+It is called normally. ( t_double, numeric )     
 
 
 ===================================================
@@ -138,14 +138,14 @@ It is called normally. ( t_double, numeric(8,3) )
 null     
 
 
-double to numeric(8,3)
+double to numeric
 double => 789.1234
 ===================================================
 0
 
 ===================================================
-'An error occurs. ( t_date, numeric(8,3) )'    
-An error occurs. ( t_date, numeric(8,3) )     
+'An error occurs. ( t_date, numeric )'    
+An error occurs. ( t_date, numeric )     
 
 
 ===================================================
@@ -163,8 +163,8 @@ Error:-894
 Stored procedure/function 't_numeric' does not exist.
 
 ===================================================
-'An error occurs. ( t_time, numeric(8,3) )'    
-An error occurs. ( t_time, numeric(8,3) )     
+'An error occurs. ( t_time, numeric )'    
+An error occurs. ( t_time, numeric )     
 
 
 ===================================================
@@ -182,8 +182,8 @@ Error:-894
 Stored procedure/function 't_numeric' does not exist.
 
 ===================================================
-'An error occurs. ( t_datetime, numeric(8,3) )'    
-An error occurs. ( t_datetime, numeric(8,3) )     
+'An error occurs. ( t_datetime, numeric )'    
+An error occurs. ( t_datetime, numeric )     
 
 
 ===================================================
@@ -201,8 +201,8 @@ Error:-894
 Stored procedure/function 't_numeric' does not exist.
 
 ===================================================
-'An error occurs. ( t_timestamp, numeric(8,3) )'    
-An error occurs. ( t_timestamp, numeric(8,3) )     
+'An error occurs. ( t_timestamp, numeric )'    
+An error occurs. ( t_timestamp, numeric )     
 
 
 ===================================================

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_07_local_type_conversion_potential/cases/02_01_07-06_local_conversion_potential_numeric.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_07_local_type_conversion_potential/cases/02_01_07-06_local_conversion_potential_numeric.sql
@@ -1,12 +1,12 @@
 --+ server-message on
 
-select 'An error occurs. ( t_boolean, numeric(8,3) )' ;
+select 'An error occurs. ( t_boolean, numeric )' ;
 create or replace procedure t_numeric( from_type string ) as 
     a_param boolean := False ;
-    procedure t_local(from_type string, param numeric(8,3)) 
+    procedure t_local(from_type string, param numeric) 
     AS 
     begin 
-        dbms_output.put_line(from_type||' to numeric(8,3)' ); 
+        dbms_output.put_line(from_type||' to numeric' ); 
         dbms_output.put_line('boolean => ' ||  param ) ; 
     END;
 begin
@@ -18,13 +18,13 @@ drop procedure t_numeric ;
 
 
 
-select 'It is called normally. ( t_string, numeric(8,3) )' ;
+select 'It is called normally. ( t_string, numeric )' ;
 create or replace procedure t_numeric( from_type string ) as 
     a_param string := '123' ;
-    procedure t_local(from_type string, param numeric(8,3)) 
+    procedure t_local(from_type string, param numeric) 
     AS 
     begin 
-        dbms_output.put_line(from_type||' to numeric(8,3)' ); 
+        dbms_output.put_line(from_type||' to numeric' ); 
         dbms_output.put_line('string => ' ||  param ) ; 
     END;
 begin
@@ -36,13 +36,13 @@ drop procedure t_numeric ;
 
 
 
-select 'It is called normally. ( t_short, numeric(8,3) )' ;
+select 'It is called normally. ( t_short, numeric )' ;
 create or replace procedure t_numeric( from_type string ) as 
     a_param short := 8934 ;
-    procedure t_local(from_type string, param numeric(8,3)) 
+    procedure t_local(from_type string, param numeric) 
     AS 
     begin 
-        dbms_output.put_line(from_type||' to numeric(8,3)' ); 
+        dbms_output.put_line(from_type||' to numeric' ); 
         dbms_output.put_line('short => ' ||  param ) ; 
     END;
 begin
@@ -54,13 +54,13 @@ drop procedure t_numeric ;
 
 
 
-select 'It is called normally. ( t_int, numeric(8,3) )' ;
+select 'It is called normally. ( t_int, numeric )' ;
 create or replace procedure t_numeric( from_type string ) as 
     a_param int := 8234 ;
-    procedure t_local(from_type string, param numeric(8,3)) 
+    procedure t_local(from_type string, param numeric) 
     AS 
     begin 
-        dbms_output.put_line(from_type||' to numeric(8,3)' ); 
+        dbms_output.put_line(from_type||' to numeric' ); 
         dbms_output.put_line('int => ' ||  param ) ; 
     END;
 begin
@@ -72,13 +72,13 @@ drop procedure t_numeric ;
 
 
 
-select 'It is called normally. ( t_bigint, numeric(8,3) )' ;
+select 'It is called normally. ( t_bigint, numeric )' ;
 create or replace procedure t_numeric( from_type string ) as 
     a_param bigint := 278 ;
-    procedure t_local(from_type string, param numeric(8,3)) 
+    procedure t_local(from_type string, param numeric) 
     AS 
     begin 
-        dbms_output.put_line(from_type||' to numeric(8,3)' ); 
+        dbms_output.put_line(from_type||' to numeric' ); 
         dbms_output.put_line('bigint => ' ||  param ) ; 
     END;
 begin
@@ -90,13 +90,13 @@ drop procedure t_numeric ;
 
 
 
-select 'It is called normally. ( t_numeric(8,3), numeric(8,3) )' ;
+select 'It is called normally. ( t_numeric(8,3), numeric )' ;
 create or replace procedure t_numeric( from_type string ) as 
     a_param numeric(8,3) := 5678.123 ;
-    procedure t_local(from_type string, param numeric(8,3)) 
+    procedure t_local(from_type string, param numeric) 
     AS 
     begin 
-        dbms_output.put_line(from_type||' to numeric(8,3)' ); 
+        dbms_output.put_line(from_type||' to numeric' ); 
         dbms_output.put_line('numeric(8,3) => ' ||  param ) ; 
     END;
 begin
@@ -108,13 +108,13 @@ drop procedure t_numeric ;
 
 
 
-select 'It is called normally. ( t_float, numeric(8,3) )' ;
+select 'It is called normally. ( t_float, numeric )' ;
 create or replace procedure t_numeric( from_type string ) as 
     a_param float := 3677.345 ;
-    procedure t_local(from_type string, param numeric(8,3)) 
+    procedure t_local(from_type string, param numeric) 
     AS 
     begin 
-        dbms_output.put_line(from_type||' to numeric(8,3)' ); 
+        dbms_output.put_line(from_type||' to numeric' ); 
         dbms_output.put_line('float => ' ||  param ) ; 
     END;
 begin
@@ -126,13 +126,13 @@ drop procedure t_numeric ;
 
 
 
-select 'It is called normally. ( t_double, numeric(8,3) )' ;
+select 'It is called normally. ( t_double, numeric )' ;
 create or replace procedure t_numeric( from_type string ) as 
     a_param double := 789.1234 ;
-    procedure t_local(from_type string, param numeric(8,3)) 
+    procedure t_local(from_type string, param numeric) 
     AS 
     begin 
-        dbms_output.put_line(from_type||' to numeric(8,3)' ); 
+        dbms_output.put_line(from_type||' to numeric' ); 
         dbms_output.put_line('double => ' ||  param ) ; 
     END;
 begin
@@ -144,13 +144,13 @@ drop procedure t_numeric ;
 
 
 
-select 'An error occurs. ( t_date, numeric(8,3) )' ;
+select 'An error occurs. ( t_date, numeric )' ;
 create or replace procedure t_numeric( from_type string ) as 
     a_param date := '2024-03-05' ;
-    procedure t_local(from_type string, param numeric(8,3)) 
+    procedure t_local(from_type string, param numeric) 
     AS 
     begin 
-        dbms_output.put_line(from_type||' to numeric(8,3)' ); 
+        dbms_output.put_line(from_type||' to numeric' ); 
         dbms_output.put_line('date => ' ||  param ) ; 
     END;
 begin
@@ -162,13 +162,13 @@ drop procedure t_numeric ;
 
 
 
-select 'An error occurs. ( t_time, numeric(8,3) )' ;
+select 'An error occurs. ( t_time, numeric )' ;
 create or replace procedure t_numeric( from_type string ) as 
     a_param time := '23:59:59' ;
-    procedure t_local(from_type string, param numeric(8,3)) 
+    procedure t_local(from_type string, param numeric) 
     AS 
     begin 
-        dbms_output.put_line(from_type||' to numeric(8,3)' ); 
+        dbms_output.put_line(from_type||' to numeric' ); 
         dbms_output.put_line('time => ' ||  param ) ; 
     END;
 begin
@@ -180,13 +180,13 @@ drop procedure t_numeric ;
 
 
 
-select 'An error occurs. ( t_datetime, numeric(8,3) )' ;
+select 'An error occurs. ( t_datetime, numeric )' ;
 create or replace procedure t_numeric( from_type string ) as 
     a_param datetime := '2024-03-01 22:15:25' ;
-    procedure t_local(from_type string, param numeric(8,3)) 
+    procedure t_local(from_type string, param numeric) 
     AS 
     begin 
-        dbms_output.put_line(from_type||' to numeric(8,3)' ); 
+        dbms_output.put_line(from_type||' to numeric' ); 
         dbms_output.put_line('datetime => ' ||  param ) ; 
     END;
 begin
@@ -198,13 +198,13 @@ drop procedure t_numeric ;
 
 
 
-select 'An error occurs. ( t_timestamp, numeric(8,3) )' ;
+select 'An error occurs. ( t_timestamp, numeric )' ;
 create or replace procedure t_numeric( from_type string ) as 
     a_param timestamp := '2024-05-05 23:30:45' ;
-    procedure t_local(from_type string, param numeric(8,3)) 
+    procedure t_local(from_type string, param numeric) 
     AS 
     begin 
-        dbms_output.put_line(from_type||' to numeric(8,3)' ); 
+        dbms_output.put_line(from_type||' to numeric' ); 
         dbms_output.put_line('timestamp => ' ||  param ) ; 
     END;
 begin

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-01_param_to_variable_DATETIME.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-01_param_to_variable_DATETIME.answer
@@ -219,7 +219,7 @@ Stored procedure/function 't_FLOAT_DATETIME' does not exist.
 null     
 
 
-t_NUMERIC(8,4)_DATETIME. This scenario is a failure.
+t_NUMERIC_DATETIME. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 2, column 17
@@ -299,7 +299,7 @@ Stored procedure/function 't_SHORT_DATETIME' does not exist.
 null     
 
 
-t_BIT(8)_DATETIME. This scenario is a failure.
+t_BIT_DATETIME. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -312,7 +312,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_DATETIME('DATETIME', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_DATETIME('DATETIME', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-02_param_to_variable_DATETIMELTZ.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-02_param_to_variable_DATETIMELTZ.answer
@@ -222,7 +222,7 @@ Stored procedure/function 't_FLOAT_DATETIMELTZ' does not exist.
 null     
 
 
-t_NUMERIC(8,4)_DATETIMELTZ. This scenario is a failure.
+t_NUMERIC_DATETIMELTZ. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 2, column 5
@@ -302,7 +302,7 @@ Stored procedure/function 't_SHORT_DATETIMELTZ' does not exist.
 null     
 
 
-t_BIT(8)_DATETIMELTZ. This scenario is a failure.
+t_BIT_DATETIMELTZ. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -315,7 +315,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_DATETIMELTZ('DATETIMELTZ', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_DATETIMELTZ('DATETIMELTZ', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-03_param_to_variable_DATETIMETZ.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-03_param_to_variable_DATETIMETZ.answer
@@ -222,7 +222,7 @@ Stored procedure/function 't_FLOAT_DATETIMETZ' does not exist.
 null     
 
 
-t_NUMERIC(8,4)_DATETIMETZ. This scenario is a failure.
+t_NUMERIC_DATETIMETZ. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 2, column 5
@@ -302,7 +302,7 @@ Stored procedure/function 't_SHORT_DATETIMETZ' does not exist.
 null     
 
 
-t_BIT(8)_DATETIMETZ. This scenario is a failure.
+t_BIT_DATETIMETZ. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -315,7 +315,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_DATETIMETZ('DATETIMETZ', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_DATETIMETZ('DATETIMETZ', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-04_param_to_variable_DATE.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-04_param_to_variable_DATE.answer
@@ -223,7 +223,7 @@ Stored procedure/function 't_FLOAT_DATE' does not exist.
 null     
 
 
-t_NUMERIC(8,4)_DATE. This scenario is a failure.
+t_NUMERIC_DATE. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 2, column 13
@@ -303,7 +303,7 @@ Stored procedure/function 't_SHORT_DATE' does not exist.
 null     
 
 
-t_BIT(8)_DATE. This scenario is a failure.
+t_BIT_DATE. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -317,7 +317,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_DATE('DATE', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_DATE('DATE', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-05_param_to_variable_TIME.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-05_param_to_variable_TIME.answer
@@ -221,7 +221,7 @@ variables=>variables = 12:27:57 AM
 null     
 
 
-t_NUMERIC(8,4)_TIME. This scenario is a failure.
+t_NUMERIC_TIME. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 2, column 13
@@ -298,7 +298,7 @@ variables=>variables = 02:28:54 AM
 null     
 
 
-t_BIT(8)_TIME. This scenario is a failure.
+t_BIT_TIME. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -312,7 +312,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_TIME('TIME', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_TIME('TIME', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-06_param_to_variable_TIMESTAMP.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-06_param_to_variable_TIMESTAMP.answer
@@ -226,7 +226,7 @@ t_NUMERIC_TIMESTAMP. This scenario is a success.
 null     
 
 
-param_type = NUMERIC(8,4), variables_type = TIMESTAMP, param=>variables = 12:00:00 AM 00/00/0000
+param_type = NUMERIC, variables_type = TIMESTAMP, param=>variables = 12:00:00 AM 00/00/0000
 variables=>variables = 12:00:00 AM 00/00/0000
 ===================================================
 0
@@ -293,7 +293,7 @@ variables=>variables = 11:28:54 AM 01/01/1970
 null     
 
 
-t_BIT(8)_TIMESTAMP. This scenario is a failure.
+t_BIT_TIMESTAMP. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -306,7 +306,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_TIMESTAMP('TIMESTAMP', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_TIMESTAMP('TIMESTAMP', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-07_param_to_variable_TIMESTAMPLTZ.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-07_param_to_variable_TIMESTAMPLTZ.answer
@@ -222,7 +222,7 @@ Stored procedure/function 't_FLOAT_TIMESTAMPLTZ' does not exist.
 null     
 
 
-t_NUMERIC(8,4)_TIMESTAMPLTZ. This scenario is a failure.
+t_NUMERIC_TIMESTAMPLTZ. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 2, column 5
@@ -302,7 +302,7 @@ Stored procedure/function 't_SHORT_TIMESTAMPLTZ' does not exist.
 null     
 
 
-t_BIT(8)_TIMESTAMPLTZ. This scenario is a failure.
+t_BIT_TIMESTAMPLTZ. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -315,7 +315,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_TIMESTAMPLTZ('TIMESTAMPLTZ', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_TIMESTAMPLTZ('TIMESTAMPLTZ', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-08_param_to_variable_TIMESTAMPTZ.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-08_param_to_variable_TIMESTAMPTZ.answer
@@ -222,7 +222,7 @@ Stored procedure/function 't_FLOAT_TIMESTAMPTZ' does not exist.
 null     
 
 
-t_NUMERIC(8,4)_TIMESTAMPTZ. This scenario is a failure.
+t_NUMERIC_TIMESTAMPTZ. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 2, column 5
@@ -302,7 +302,7 @@ Stored procedure/function 't_SHORT_TIMESTAMPTZ' does not exist.
 null     
 
 
-t_BIT(8)_TIMESTAMPTZ. This scenario is a failure.
+t_BIT_TIMESTAMPTZ. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -315,7 +315,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_TIMESTAMPTZ('TIMESTAMPTZ', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_TIMESTAMPTZ('TIMESTAMPTZ', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-09_param_to_variable_INT.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-09_param_to_variable_INT.answer
@@ -233,7 +233,7 @@ t_NUMERIC_INT. This scenario is a success.
 null     
 
 
-param_type = NUMERIC(8,4), variables_type = INT, param=>variables = 0
+param_type = NUMERIC, variables_type = INT, param=>variables = 0
 variables=>variables = 0
 ===================================================
 0
@@ -300,7 +300,7 @@ variables=>variables = 8
 null     
 
 
-t_BIT(8)_INT. This scenario is a failure.
+t_BIT_INT. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -314,7 +314,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_INT('INT', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_INT('INT', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-10_param_to_variable_SHORT.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-10_param_to_variable_SHORT.answer
@@ -240,7 +240,7 @@ variables=>variables = 0
 null     
 
 
-param_type = NUMERIC(8,4), variables_type = SHORT, param=>variables = 0
+param_type = NUMERIC, variables_type = SHORT, param=>variables = 0
 variables=>variables = 0
 ===================================================
 0
@@ -307,7 +307,7 @@ variables=>variables = 0
 null     
 
 
-t_BIT(8)_SHORT. This scenario is a failure.
+t_BIT_SHORT. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -321,7 +321,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_SHORT('SHORT', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_SHORT('SHORT', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-11_param_to_variable_BIT.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-11_param_to_variable_BIT.answer
@@ -226,7 +226,7 @@ Stored procedure/function 't_FLOAT_BIT' does not exist.
 null     
 
 
-t_NUMERIC(8,4)_BIT. This scenario is a failure.
+t_NUMERIC_BIT. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 3, column 11
@@ -306,7 +306,7 @@ Stored procedure/function 't_SHORT_BIT' does not exist.
 null     
 
 
-t_BIT(8)_BIT. This scenario is a failure.
+t_BIT_BIT. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -320,7 +320,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_BIT('BIT', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_BIT('BIT', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-12_param_to_variable_BIT_VARYING.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-12_param_to_variable_BIT_VARYING.answer
@@ -222,7 +222,7 @@ Stored procedure/function 't_FLOAT_BITVARYING' does not exist.
 null     
 
 
-t_NUMERIC(8,4)_BIT VARYING. This scenario is a failure.
+t_NUMERIC_BIT VARYING. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 3, column 10
@@ -302,7 +302,7 @@ Stored procedure/function 't_SHORT_BITVARYING' does not exist.
 null     
 
 
-t_BIT(8)_BIT VARYING. This scenario is a failure.
+t_BIT_BIT VARYING. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -315,7 +315,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_BITVARYING('BIT VARYING', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_BITVARYING('BIT VARYING', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-13_param_to_variable_CHAR.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-13_param_to_variable_CHAR.answer
@@ -225,7 +225,7 @@ t_NUMERIC_CHAR. This scenario is a success.
 null     
 
 
-param_type = NUMERIC(8,4), variables_type = CHAR, param=>variables = 0.1235                        
+param_type = NUMERIC, variables_type = CHAR, param=>variables = 0.1235                        
 variables=>variables = 0.1235                        
 ===================================================
 0
@@ -292,7 +292,7 @@ variables=>variables = 8934
 null     
 
 
-t_BIT(8)_CHAR. This scenario is a failure.
+t_BIT_CHAR. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -305,7 +305,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_CHAR('CHAR', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_CHAR('CHAR', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-14_param_to_variable_VARCHAR.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-14_param_to_variable_VARCHAR.answer
@@ -225,7 +225,7 @@ t_NUMERIC_VARCHAR. This scenario is a success.
 null     
 
 
-param_type = NUMERIC(8,4), variables_type = VARCHAR, param=>variables = 0.1235
+param_type = NUMERIC, variables_type = VARCHAR, param=>variables = 0.1235
 variables=>variables = 0.1235
 ===================================================
 0
@@ -292,7 +292,7 @@ variables=>variables = 8934
 null     
 
 
-t_BIT(8)_VARCHAR. This scenario is a failure.
+t_BIT_VARCHAR. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -305,7 +305,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_VARCHAR('VARCHAR', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_VARCHAR('VARCHAR', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-15_param_to_variable_DOUBLE.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-15_param_to_variable_DOUBLE.answer
@@ -229,7 +229,7 @@ t_NUMERIC_DOUBLE. This scenario is a success.
 null     
 
 
-param_type = NUMERIC(8,4), variables_type = DOUBLE, param=>variables = 1.235000000000000e-01
+param_type = NUMERIC, variables_type = DOUBLE, param=>variables = 1.235000000000000e-01
 variables=>variables = 1.235000000000000e-01
 ===================================================
 0
@@ -296,7 +296,7 @@ variables=>variables = 8.934000000000000e+03
 null     
 
 
-t_BIT(8)_DOUBLE. This scenario is a failure.
+t_BIT_DOUBLE. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -309,7 +309,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_DOUBLE('DOUBLE', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_DOUBLE('DOUBLE', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-16_param_to_variable_FLOAT.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-16_param_to_variable_FLOAT.answer
@@ -233,7 +233,7 @@ t_NUMERIC_FLOAT. This scenario is a success.
 null     
 
 
-param_type = NUMERIC(8,4), variables_type = FLOAT, param=>variables = 1.235000e-01
+param_type = NUMERIC, variables_type = FLOAT, param=>variables = 1.235000e-01
 variables=>variables = 1.235000e-01
 ===================================================
 0
@@ -300,7 +300,7 @@ variables=>variables = 8.934000e+03
 null     
 
 
-t_BIT(8)_FLOAT. This scenario is a failure.
+t_BIT_FLOAT. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -314,7 +314,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_FLOAT('FLOAT', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_FLOAT('FLOAT', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-17_param_to_variable_NUMERIC.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-17_param_to_variable_NUMERIC.answer
@@ -232,8 +232,8 @@ variables=>variables = 0.123500000000000
 null     
 
 
-param_type = NUMERIC(8,4), variables_type = NUMERIC(38,15), param=>variables = 0.123500000000000
-variables=>variables = 0.123500000000000
+param_type = NUMERIC, variables_type = NUMERIC(38,15), param=>variables = 0.000000000000000
+variables=>variables = 0.000000000000000
 ===================================================
 0
 
@@ -299,7 +299,7 @@ variables=>variables = 8934.000000000000000
 null     
 
 
-t_BIT(8)_NUMERIC(38,15). This scenario is a failure.
+t_BIT_NUMERIC(38,15). This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -311,7 +311,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_NUMERIC('NUMERIC(38,15)', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_NUMERIC('NUMERIC(38,15)', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-18_param_to_variable_BIGINT.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-18_param_to_variable_BIGINT.answer
@@ -236,7 +236,7 @@ variables=>variables = 0
 null     
 
 
-param_type = NUMERIC(8,4), variables_type = BIGINT, param=>variables = 0
+param_type = NUMERIC, variables_type = BIGINT, param=>variables = 0
 variables=>variables = 0
 ===================================================
 0
@@ -303,7 +303,7 @@ variables=>variables = 8934
 null     
 
 
-t_BIT(8)_BIGINT. This scenario is a failure.
+t_BIT_BIGINT. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -316,7 +316,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_BIGINT('BIGINT', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_BIGINT('BIGINT', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-19_param_to_variable_SET.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-19_param_to_variable_SET.answer
@@ -226,7 +226,7 @@ Stored procedure/function 't_FLOAT_SET' does not exist.
 null     
 
 
-t_NUMERIC(8,4)_SET. This scenario is a failure.
+t_NUMERIC_SET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 2, column 5
@@ -306,7 +306,7 @@ Stored procedure/function 't_SHORT_SET' does not exist.
 null     
 
 
-t_BIT(8)_SET. This scenario is a failure.
+t_BIT_SET. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -320,7 +320,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_SET('SET', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_SET('SET', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-20_param_to_variable_MULTISET.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-20_param_to_variable_MULTISET.answer
@@ -222,7 +222,7 @@ Stored procedure/function 't_FLOAT_MULTISET' does not exist.
 null     
 
 
-t_NUMERIC(8,4)_MULTISET. This scenario is a failure.
+t_NUMERIC_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 2, column 5
@@ -302,7 +302,7 @@ Stored procedure/function 't_SHORT_MULTISET' does not exist.
 null     
 
 
-t_BIT(8)_MULTISET. This scenario is a failure.
+t_BIT_MULTISET. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -315,7 +315,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_MULTISET('MULTISET', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_MULTISET('MULTISET', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-21_param_to_variable_LIST.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-21_param_to_variable_LIST.answer
@@ -226,7 +226,7 @@ Stored procedure/function 't_FLOAT_LIST' does not exist.
 null     
 
 
-t_NUMERIC(8,4)_LIST. This scenario is a failure.
+t_NUMERIC_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 2, column 5
@@ -306,7 +306,7 @@ Stored procedure/function 't_SHORT_LIST' does not exist.
 null     
 
 
-t_BIT(8)_LIST. This scenario is a failure.
+t_BIT_LIST. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -320,7 +320,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_LIST('LIST', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_LIST('LIST', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-22_param_to_variable_ENUM.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-22_param_to_variable_ENUM.answer
@@ -226,7 +226,7 @@ Stored procedure/function 't_FLOAT_ENUM' does not exist.
 null     
 
 
-t_NUMERIC(8,4)_ENUM. This scenario is a failure.
+t_NUMERIC_ENUM. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 3, column 12
@@ -306,7 +306,7 @@ Stored procedure/function 't_SHORT_ENUM' does not exist.
 null     
 
 
-t_BIT(8)_ENUM. This scenario is a failure.
+t_BIT_ENUM. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -320,7 +320,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_ENUM('ENUM', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_ENUM('ENUM', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-23_param_to_variable_BLOB.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-23_param_to_variable_BLOB.answer
@@ -226,7 +226,7 @@ Stored procedure/function 't_FLOAT_BLOB' does not exist.
 null     
 
 
-t_NUMERIC(8,4)_BLOB. This scenario is a failure.
+t_NUMERIC_BLOB. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 3, column 12
@@ -306,7 +306,7 @@ Stored procedure/function 't_SHORT_BLOB' does not exist.
 null     
 
 
-t_BIT(8)_BLOB. This scenario is a failure.
+t_BIT_BLOB. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -320,7 +320,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_BLOB('BLOB', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_BLOB('BLOB', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-24_param_to_variable_CLOB.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-24_param_to_variable_CLOB.answer
@@ -226,7 +226,7 @@ Stored procedure/function 't_FLOAT_CLOB' does not exist.
 null     
 
 
-t_NUMERIC(8,4)_CLOB. This scenario is a failure.
+t_NUMERIC_CLOB. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 3, column 12
@@ -306,7 +306,7 @@ Stored procedure/function 't_SHORT_CLOB' does not exist.
 null     
 
 
-t_BIT(8)_CLOB. This scenario is a failure.
+t_BIT_CLOB. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -320,7 +320,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_CLOB('CLOB', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_CLOB('CLOB', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-25_param_to_variable_JSON.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-25_param_to_variable_JSON.answer
@@ -226,7 +226,7 @@ Stored procedure/function 't_FLOAT_JSON' does not exist.
 null     
 
 
-t_NUMERIC(8,4)_JSON. This scenario is a failure.
+t_NUMERIC_JSON. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 3, column 12
@@ -306,7 +306,7 @@ Stored procedure/function 't_SHORT_JSON' does not exist.
 null     
 
 
-t_BIT(8)_JSON. This scenario is a failure.
+t_BIT_JSON. This scenario is a failure.
 ===================================================
 Error:-494
 Semantic: before '  ) as
@@ -320,7 +320,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace proced
 ===================================================
 Error:-495
 Execute: before '  ; '
-Methods require an object as their target. call t_BIT_JSON('JSON', X'aa') on 'BIT(8)'
+Methods require an object as their target. call t_BIT_JSON('JSON', X'aa') on 'BIT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-01_param_to_variable_DATETIME.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-01_param_to_variable_DATETIME.sql
@@ -135,8 +135,8 @@ call t_FLOAT_DATETIME('FLOAT', 'DATETIME', cast( 1677.217 as float ) ) ;
 drop procedure t_FLOAT_DATETIME ;
 
 
-call print_message('t_NUMERIC(8,4)_DATETIME. This scenario is a failure.');
-create or replace procedure t_NUMERIC_DATETIME(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+call print_message('t_NUMERIC_DATETIME. This scenario is a failure.');
+create or replace procedure t_NUMERIC_DATETIME(param_type string, variables_type string, param NUMERIC ) as 
 VAR DATETIME := param ;
 VAR1 DATETIME  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_DATETIME('NUMERIC(8,4)', 'DATETIME', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_DATETIME('NUMERIC', 'DATETIME', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_DATETIME ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_DATETIME('BIGINT', 'DATETIME', decode('DATETIME', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_DATETIME('BIGINT', 'DATETIME', decode('DATETIME', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_DATETIME ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_DATETIME('INT', 'DATETIME', decode('DATETIME', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_DATETIME('INT', 'DATETIME', decode('DATETIME', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_DATETIME ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_DATETIME('SHORT', 'DATETIME', decode('DATETIME', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_DATETIME('SHORT', 'DATETIME', decode('DATETIME', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_DATETIME ;
 
 
-call print_message('t_BIT(8)_DATETIME. This scenario is a failure.');
-create or replace procedure t_BIT_DATETIME(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_DATETIME. This scenario is a failure.');
+create or replace procedure t_BIT_DATETIME(param_type string, variables_type string, param BIT ) as 
 VAR DATETIME := param ;
 VAR1 DATETIME  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_DATETIME('BIT(8)', 'DATETIME', 0xaa ) ;
+call t_BIT_DATETIME('BIT', 'DATETIME', 0xaa ) ;
 drop procedure t_BIT_DATETIME ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-02_param_to_variable_DATETIMELTZ.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-02_param_to_variable_DATETIMELTZ.sql
@@ -135,8 +135,8 @@ call t_FLOAT_DATETIMELTZ('FLOAT', 'DATETIMELTZ', cast( 1677.217 as float ) ) ;
 drop procedure t_FLOAT_DATETIMELTZ ;
 
 
-call print_message('t_NUMERIC(8,4)_DATETIMELTZ. This scenario is a failure.');
-create or replace procedure t_NUMERIC_DATETIMELTZ(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+call print_message('t_NUMERIC_DATETIMELTZ. This scenario is a failure.');
+create or replace procedure t_NUMERIC_DATETIMELTZ(param_type string, variables_type string, param NUMERIC ) as 
 VAR DATETIMELTZ := param ;
 VAR1 DATETIMELTZ  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_DATETIMELTZ('NUMERIC(8,4)', 'DATETIMELTZ', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_DATETIMELTZ('NUMERIC', 'DATETIMELTZ', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_DATETIMELTZ ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_DATETIMELTZ('BIGINT', 'DATETIMELTZ', decode('DATETIMELTZ', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_DATETIMELTZ('BIGINT', 'DATETIMELTZ', decode('DATETIMELTZ', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_DATETIMELTZ ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_DATETIMELTZ('INT', 'DATETIMELTZ', decode('DATETIMELTZ', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_DATETIMELTZ('INT', 'DATETIMELTZ', decode('DATETIMELTZ', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_DATETIMELTZ ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_DATETIMELTZ('SHORT', 'DATETIMELTZ', decode('DATETIMELTZ', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_DATETIMELTZ('SHORT', 'DATETIMELTZ', decode('DATETIMELTZ', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_DATETIMELTZ ;
 
 
-call print_message('t_BIT(8)_DATETIMELTZ. This scenario is a failure.');
-create or replace procedure t_BIT_DATETIMELTZ(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_DATETIMELTZ. This scenario is a failure.');
+create or replace procedure t_BIT_DATETIMELTZ(param_type string, variables_type string, param BIT ) as 
 VAR DATETIMELTZ := param ;
 VAR1 DATETIMELTZ  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_DATETIMELTZ('BIT(8)', 'DATETIMELTZ', 0xaa ) ;
+call t_BIT_DATETIMELTZ('BIT', 'DATETIMELTZ', 0xaa ) ;
 drop procedure t_BIT_DATETIMELTZ ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-03_param_to_variable_DATETIMETZ.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-03_param_to_variable_DATETIMETZ.sql
@@ -135,8 +135,8 @@ call t_FLOAT_DATETIMETZ('FLOAT', 'DATETIMETZ', cast( 1677.217 as float ) ) ;
 drop procedure t_FLOAT_DATETIMETZ ;
 
 
-call print_message('t_NUMERIC(8,4)_DATETIMETZ. This scenario is a failure.');
-create or replace procedure t_NUMERIC_DATETIMETZ(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+call print_message('t_NUMERIC_DATETIMETZ. This scenario is a failure.');
+create or replace procedure t_NUMERIC_DATETIMETZ(param_type string, variables_type string, param NUMERIC ) as 
 VAR DATETIMETZ := param ;
 VAR1 DATETIMETZ  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_DATETIMETZ('NUMERIC(8,4)', 'DATETIMETZ', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_DATETIMETZ('NUMERIC', 'DATETIMETZ', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_DATETIMETZ ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_DATETIMETZ('BIGINT', 'DATETIMETZ', decode('DATETIMETZ', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_DATETIMETZ('BIGINT', 'DATETIMETZ', decode('DATETIMETZ', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_DATETIMETZ ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_DATETIMETZ('INT', 'DATETIMETZ', decode('DATETIMETZ', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_DATETIMETZ('INT', 'DATETIMETZ', decode('DATETIMETZ', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_DATETIMETZ ;
 
 
@@ -183,7 +183,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_DATETIMETZ('SHORT', 'DATETIMETZ', decode('DATETIMETZ', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_DATETIMETZ('SHORT', 'DATETIMETZ', decode('DATETIMETZ', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_DATETIMETZ ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-03_param_to_variable_DATETIMETZ.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-03_param_to_variable_DATETIMETZ.sql
@@ -187,8 +187,8 @@ call t_SHORT_DATETIMETZ('SHORT', 'DATETIMETZ', decode('DATETIMETZ', 'INT',cast( 
 drop procedure t_SHORT_DATETIMETZ ;
 
 
-call print_message('t_BIT(8)_DATETIMETZ. This scenario is a failure.');
-create or replace procedure t_BIT_DATETIMETZ(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_DATETIMETZ. This scenario is a failure.');
+create or replace procedure t_BIT_DATETIMETZ(param_type string, variables_type string, param BIT ) as 
 VAR DATETIMETZ := param ;
 VAR1 DATETIMETZ  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_DATETIMETZ('BIT(8)', 'DATETIMETZ', 0xaa ) ;
+call t_BIT_DATETIMETZ('BIT', 'DATETIMETZ', 0xaa ) ;
 drop procedure t_BIT_DATETIMETZ ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-04_param_to_variable_DATE.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-04_param_to_variable_DATE.sql
@@ -135,8 +135,8 @@ call t_FLOAT_DATE('FLOAT', 'DATE', cast( 1677.217 as float ) ) ;
 drop procedure t_FLOAT_DATE ;
 
 
-call print_message('t_NUMERIC(8,4)_DATE. This scenario is a failure.');
-create or replace procedure t_NUMERIC_DATE(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+call print_message('t_NUMERIC_DATE. This scenario is a failure.');
+create or replace procedure t_NUMERIC_DATE(param_type string, variables_type string, param NUMERIC ) as 
 VAR DATE := param ;
 VAR1 DATE  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_DATE('NUMERIC(8,4)', 'DATE', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_DATE('NUMERIC', 'DATE', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_DATE ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_DATE('BIGINT', 'DATE', decode('DATE', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_DATE('BIGINT', 'DATE', decode('DATE', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_DATE ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_DATE('INT', 'DATE', decode('DATE', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_DATE('INT', 'DATE', decode('DATE', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_DATE ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_DATE('SHORT', 'DATE', decode('DATE', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_DATE('SHORT', 'DATE', decode('DATE', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_DATE ;
 
 
-call print_message('t_BIT(8)_DATE. This scenario is a failure.');
-create or replace procedure t_BIT_DATE(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_DATE. This scenario is a failure.');
+create or replace procedure t_BIT_DATE(param_type string, variables_type string, param BIT ) as 
 VAR DATE := param ;
 VAR1 DATE  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_DATE('BIT(8)', 'DATE', 0xaa ) ;
+call t_BIT_DATE('BIT', 'DATE', 0xaa ) ;
 drop procedure t_BIT_DATE ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-05_param_to_variable_TIME.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-05_param_to_variable_TIME.sql
@@ -135,8 +135,8 @@ call t_FLOAT_TIME('FLOAT', 'TIME', cast( 1677.217 as float ) ) ;
 drop procedure t_FLOAT_TIME ;
 
 
-call print_message('t_NUMERIC(8,4)_TIME. This scenario is a failure.');
-create or replace procedure t_NUMERIC_TIME(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+call print_message('t_NUMERIC_TIME. This scenario is a failure.');
+create or replace procedure t_NUMERIC_TIME(param_type string, variables_type string, param NUMERIC ) as 
 VAR TIME := param ;
 VAR1 TIME  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_TIME('NUMERIC(8,4)', 'TIME', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_TIME('NUMERIC', 'TIME', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_TIME ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_TIME('BIGINT', 'TIME', decode('TIME', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_TIME('BIGINT', 'TIME', decode('TIME', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_TIME ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_TIME('INT', 'TIME', decode('TIME', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_TIME('INT', 'TIME', decode('TIME', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_TIME ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_TIME('SHORT', 'TIME', decode('TIME', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_TIME('SHORT', 'TIME', decode('TIME', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_TIME ;
 
 
-call print_message('t_BIT(8)_TIME. This scenario is a failure.');
-create or replace procedure t_BIT_TIME(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_TIME. This scenario is a failure.');
+create or replace procedure t_BIT_TIME(param_type string, variables_type string, param BIT ) as 
 VAR TIME := param ;
 VAR1 TIME  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_TIME('BIT(8)', 'TIME', 0xaa ) ;
+call t_BIT_TIME('BIT', 'TIME', 0xaa ) ;
 drop procedure t_BIT_TIME ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-06_param_to_variable_TIMESTAMP.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-06_param_to_variable_TIMESTAMP.sql
@@ -136,7 +136,7 @@ drop procedure t_FLOAT_TIMESTAMP ;
 
 
 call print_message('t_NUMERIC_TIMESTAMP. This scenario is a success.');
-create or replace procedure t_NUMERIC_TIMESTAMP(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+create or replace procedure t_NUMERIC_TIMESTAMP(param_type string, variables_type string, param NUMERIC ) as 
 VAR TIMESTAMP := param ;
 VAR1 TIMESTAMP  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_TIMESTAMP('NUMERIC(8,4)', 'TIMESTAMP', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_TIMESTAMP('NUMERIC', 'TIMESTAMP', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_TIMESTAMP ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_TIMESTAMP('BIGINT', 'TIMESTAMP', decode('TIMESTAMP', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_TIMESTAMP('BIGINT', 'TIMESTAMP', decode('TIMESTAMP', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_TIMESTAMP ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_TIMESTAMP('INT', 'TIMESTAMP', decode('TIMESTAMP', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_TIMESTAMP('INT', 'TIMESTAMP', decode('TIMESTAMP', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_TIMESTAMP ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_TIMESTAMP('SHORT', 'TIMESTAMP', decode('TIMESTAMP', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_TIMESTAMP('SHORT', 'TIMESTAMP', decode('TIMESTAMP', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_TIMESTAMP ;
 
 
-call print_message('t_BIT(8)_TIMESTAMP. This scenario is a failure.');
-create or replace procedure t_BIT_TIMESTAMP(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_TIMESTAMP. This scenario is a failure.');
+create or replace procedure t_BIT_TIMESTAMP(param_type string, variables_type string, param BIT ) as 
 VAR TIMESTAMP := param ;
 VAR1 TIMESTAMP  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_TIMESTAMP('BIT(8)', 'TIMESTAMP', 0xaa ) ;
+call t_BIT_TIMESTAMP('BIT', 'TIMESTAMP', 0xaa ) ;
 drop procedure t_BIT_TIMESTAMP ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-07_param_to_variable_TIMESTAMPLTZ.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-07_param_to_variable_TIMESTAMPLTZ.sql
@@ -135,8 +135,8 @@ call t_FLOAT_TIMESTAMPLTZ('FLOAT', 'TIMESTAMPLTZ', cast( 1677.217 as float ) ) ;
 drop procedure t_FLOAT_TIMESTAMPLTZ ;
 
 
-call print_message('t_NUMERIC(8,4)_TIMESTAMPLTZ. This scenario is a failure.');
-create or replace procedure t_NUMERIC_TIMESTAMPLTZ(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+call print_message('t_NUMERIC_TIMESTAMPLTZ. This scenario is a failure.');
+create or replace procedure t_NUMERIC_TIMESTAMPLTZ(param_type string, variables_type string, param NUMERIC ) as 
 VAR TIMESTAMPLTZ := param ;
 VAR1 TIMESTAMPLTZ  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_TIMESTAMPLTZ('NUMERIC(8,4)', 'TIMESTAMPLTZ', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_TIMESTAMPLTZ('NUMERIC', 'TIMESTAMPLTZ', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_TIMESTAMPLTZ ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_TIMESTAMPLTZ('BIGINT', 'TIMESTAMPLTZ', decode('TIMESTAMPLTZ', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_TIMESTAMPLTZ('BIGINT', 'TIMESTAMPLTZ', decode('TIMESTAMPLTZ', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_TIMESTAMPLTZ ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_TIMESTAMPLTZ('INT', 'TIMESTAMPLTZ', decode('TIMESTAMPLTZ', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_TIMESTAMPLTZ('INT', 'TIMESTAMPLTZ', decode('TIMESTAMPLTZ', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_TIMESTAMPLTZ ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_TIMESTAMPLTZ('SHORT', 'TIMESTAMPLTZ', decode('TIMESTAMPLTZ', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_TIMESTAMPLTZ('SHORT', 'TIMESTAMPLTZ', decode('TIMESTAMPLTZ', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_TIMESTAMPLTZ ;
 
 
-call print_message('t_BIT(8)_TIMESTAMPLTZ. This scenario is a failure.');
-create or replace procedure t_BIT_TIMESTAMPLTZ(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_TIMESTAMPLTZ. This scenario is a failure.');
+create or replace procedure t_BIT_TIMESTAMPLTZ(param_type string, variables_type string, param BIT ) as 
 VAR TIMESTAMPLTZ := param ;
 VAR1 TIMESTAMPLTZ  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_TIMESTAMPLTZ('BIT(8)', 'TIMESTAMPLTZ', 0xaa ) ;
+call t_BIT_TIMESTAMPLTZ('BIT', 'TIMESTAMPLTZ', 0xaa ) ;
 drop procedure t_BIT_TIMESTAMPLTZ ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-08_param_to_variable_TIMESTAMPTZ.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-08_param_to_variable_TIMESTAMPTZ.sql
@@ -135,8 +135,8 @@ call t_FLOAT_TIMESTAMPTZ('FLOAT', 'TIMESTAMPTZ', cast( 1677.217 as float ) ) ;
 drop procedure t_FLOAT_TIMESTAMPTZ ;
 
 
-call print_message('t_NUMERIC(8,4)_TIMESTAMPTZ. This scenario is a failure.');
-create or replace procedure t_NUMERIC_TIMESTAMPTZ(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+call print_message('t_NUMERIC_TIMESTAMPTZ. This scenario is a failure.');
+create or replace procedure t_NUMERIC_TIMESTAMPTZ(param_type string, variables_type string, param NUMERIC ) as 
 VAR TIMESTAMPTZ := param ;
 VAR1 TIMESTAMPTZ  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_TIMESTAMPTZ('NUMERIC(8,4)', 'TIMESTAMPTZ', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_TIMESTAMPTZ('NUMERIC', 'TIMESTAMPTZ', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_TIMESTAMPTZ ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_TIMESTAMPTZ('BIGINT', 'TIMESTAMPTZ', decode('TIMESTAMPTZ', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_TIMESTAMPTZ('BIGINT', 'TIMESTAMPTZ', decode('TIMESTAMPTZ', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_TIMESTAMPTZ ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_TIMESTAMPTZ('INT', 'TIMESTAMPTZ', decode('TIMESTAMPTZ', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_TIMESTAMPTZ('INT', 'TIMESTAMPTZ', decode('TIMESTAMPTZ', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_TIMESTAMPTZ ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_TIMESTAMPTZ('SHORT', 'TIMESTAMPTZ', decode('TIMESTAMPTZ', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_TIMESTAMPTZ('SHORT', 'TIMESTAMPTZ', decode('TIMESTAMPTZ', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_TIMESTAMPTZ ;
 
 
-call print_message('t_BIT(8)_TIMESTAMPTZ. This scenario is a failure.');
-create or replace procedure t_BIT_TIMESTAMPTZ(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_TIMESTAMPTZ. This scenario is a failure.');
+create or replace procedure t_BIT_TIMESTAMPTZ(param_type string, variables_type string, param BIT ) as 
 VAR TIMESTAMPTZ := param ;
 VAR1 TIMESTAMPTZ  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_TIMESTAMPTZ('BIT(8)', 'TIMESTAMPTZ', 0xaa ) ;
+call t_BIT_TIMESTAMPTZ('BIT', 'TIMESTAMPTZ', 0xaa ) ;
 drop procedure t_BIT_TIMESTAMPTZ ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-09_param_to_variable_INT.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-09_param_to_variable_INT.sql
@@ -136,7 +136,7 @@ drop procedure t_FLOAT_INT ;
 
 
 call print_message('t_NUMERIC_INT. This scenario is a success.');
-create or replace procedure t_NUMERIC_INT(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+create or replace procedure t_NUMERIC_INT(param_type string, variables_type string, param NUMERIC ) as 
 VAR INT := param ;
 VAR1 INT  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_INT('NUMERIC(8,4)', 'INT', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_INT('NUMERIC', 'INT', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_INT ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_INT('BIGINT', 'INT', decode('INT', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_INT('BIGINT', 'INT', decode('INT', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_INT ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_INT('INT', 'INT', decode('INT', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_INT('INT', 'INT', decode('INT', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_INT ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_INT('SHORT', 'INT', decode('INT', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_INT('SHORT', 'INT', decode('INT', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_INT ;
 
 
-call print_message('t_BIT(8)_INT. This scenario is a failure.');
-create or replace procedure t_BIT_INT(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_INT. This scenario is a failure.');
+create or replace procedure t_BIT_INT(param_type string, variables_type string, param BIT ) as 
 VAR INT := param ;
 VAR1 INT  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_INT('BIT(8)', 'INT', 0xaa ) ;
+call t_BIT_INT('BIT', 'INT', 0xaa ) ;
 drop procedure t_BIT_INT ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-10_param_to_variable_SHORT.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-10_param_to_variable_SHORT.sql
@@ -136,7 +136,7 @@ drop procedure t_FLOAT_SHORT ;
 
 
 call print_message('t_NUMERIC_SHORT. This scenario is a success.');
-create or replace procedure t_NUMERIC_SHORT(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+create or replace procedure t_NUMERIC_SHORT(param_type string, variables_type string, param NUMERIC ) as 
 VAR SHORT := param ;
 VAR1 SHORT  ;
 begin
@@ -145,7 +145,7 @@ VAR1 := VAR ;
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
 call t_NUMERIC_SHORT('NUMERIC(4,4)', 'SHORT', cast( 0.123456789 as numeric(4,4) ) ) ;
-call t_NUMERIC_SHORT('NUMERIC(8,4)', 'SHORT', cast( 0.123456789 as numeric(8,4) ) ) ;
+call t_NUMERIC_SHORT('NUMERIC', 'SHORT', cast( 0.123456789 as NUMERIC ) ) ;
 drop procedure t_NUMERIC_SHORT ;
 
 
@@ -158,7 +158,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_SHORT('BIGINT', 'SHORT', decode('SHORT', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_SHORT('BIGINT', 'SHORT', decode('SHORT', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_SHORT ;
 
 
@@ -171,7 +171,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_SHORT('INT', 'SHORT', decode('SHORT', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_SHORT('INT', 'SHORT', decode('SHORT', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_SHORT ;
 
 
@@ -184,12 +184,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_SHORT('SHORT', 'SHORT', decode('SHORT', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_SHORT('SHORT', 'SHORT', decode('SHORT', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_SHORT ;
 
 
-call print_message('t_BIT(8)_SHORT. This scenario is a failure.');
-create or replace procedure t_BIT_SHORT(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_SHORT. This scenario is a failure.');
+create or replace procedure t_BIT_SHORT(param_type string, variables_type string, param BIT ) as 
 VAR SHORT := param ;
 VAR1 SHORT  ;
 begin
@@ -197,7 +197,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_SHORT('BIT(8)', 'SHORT', 0xaa ) ;
+call t_BIT_SHORT('BIT', 'SHORT', 0xaa ) ;
 drop procedure t_BIT_SHORT ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-11_param_to_variable_BIT.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-11_param_to_variable_BIT.sql
@@ -135,8 +135,8 @@ call t_FLOAT_BIT('FLOAT', 'BIT', cast( 1677.217 as float ) ) ;
 drop procedure t_FLOAT_BIT ;
 
 
-call print_message('t_NUMERIC(8,4)_BIT. This scenario is a failure.');
-create or replace procedure t_NUMERIC_BIT(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+call print_message('t_NUMERIC_BIT. This scenario is a failure.');
+create or replace procedure t_NUMERIC_BIT(param_type string, variables_type string, param NUMERIC ) as 
 VAR BIT := param ;
 VAR1 BIT  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_BIT('NUMERIC(8,4)', 'BIT', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_BIT('NUMERIC', 'BIT', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_BIT ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_BIT('BIGINT', 'BIT', decode('BIT', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_BIT('BIGINT', 'BIT', decode('BIT', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_BIT ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_BIT('INT', 'BIT', decode('BIT', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_BIT('INT', 'BIT', decode('BIT', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_BIT ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_BIT('SHORT', 'BIT', decode('BIT', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_BIT('SHORT', 'BIT', decode('BIT', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_BIT ;
 
 
-call print_message('t_BIT(8)_BIT. This scenario is a failure.');
-create or replace procedure t_BIT_BIT(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_BIT. This scenario is a failure.');
+create or replace procedure t_BIT_BIT(param_type string, variables_type string, param BIT ) as 
 VAR BIT := param ;
 VAR1 BIT  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_BIT('BIT(8)', 'BIT', 0xaa ) ;
+call t_BIT_BIT('BIT', 'BIT', 0xaa ) ;
 drop procedure t_BIT_BIT ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-12_param_to_variable_BIT_VARYING.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-12_param_to_variable_BIT_VARYING.sql
@@ -135,8 +135,8 @@ call t_FLOAT_BITVARYING('FLOAT', 'BIT VARYING', cast( 1677.217 as float ) ) ;
 drop procedure t_FLOAT_BITVARYING ;
 
 
-call print_message('t_NUMERIC(8,4)_BIT VARYING. This scenario is a failure.');
-create or replace procedure t_NUMERIC_BITVARYING(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+call print_message('t_NUMERIC_BIT VARYING. This scenario is a failure.');
+create or replace procedure t_NUMERIC_BITVARYING(param_type string, variables_type string, param NUMERIC ) as 
 VAR BIT VARYING := param ;
 VAR1 BIT VARYING  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_BITVARYING('NUMERIC(8,4)', 'BIT VARYING', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_BITVARYING('NUMERIC', 'BIT VARYING', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_BITVARYING ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_BITVARYING('BIGINT', 'BIT VARYING', decode('BIT VARYING', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_BITVARYING('BIGINT', 'BIT VARYING', decode('BIT VARYING', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_BITVARYING ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_BITVARYING('INT', 'BIT VARYING', decode('BIT VARYING', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_BITVARYING('INT', 'BIT VARYING', decode('BIT VARYING', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_BITVARYING ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_BITVARYING('SHORT', 'BIT VARYING', decode('BIT VARYING', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_BITVARYING('SHORT', 'BIT VARYING', decode('BIT VARYING', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_BITVARYING ;
 
 
-call print_message('t_BIT(8)_BIT VARYING. This scenario is a failure.');
-create or replace procedure t_BIT_BITVARYING(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_BIT VARYING. This scenario is a failure.');
+create or replace procedure t_BIT_BITVARYING(param_type string, variables_type string, param BIT ) as 
 VAR BIT VARYING := param ;
 VAR1 BIT VARYING  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_BITVARYING('BIT(8)', 'BIT VARYING', 0xaa ) ;
+call t_BIT_BITVARYING('BIT', 'BIT VARYING', 0xaa ) ;
 drop procedure t_BIT_BITVARYING ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-13_param_to_variable_CHAR.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-13_param_to_variable_CHAR.sql
@@ -136,7 +136,7 @@ drop procedure t_FLOAT_CHAR ;
 
 
 call print_message('t_NUMERIC_CHAR. This scenario is a success.');
-create or replace procedure t_NUMERIC_CHAR(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+create or replace procedure t_NUMERIC_CHAR(param_type string, variables_type string, param NUMERIC ) as 
 VAR CHAR(30) := param ;
 VAR1 CHAR(30)  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_CHAR('NUMERIC(8,4)', 'CHAR', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_CHAR('NUMERIC', 'CHAR', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_CHAR ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_CHAR('BIGINT', 'CHAR', decode('CHAR', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_CHAR('BIGINT', 'CHAR', decode('CHAR', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_CHAR ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_CHAR('INT', 'CHAR', decode('CHAR', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_CHAR('INT', 'CHAR', decode('CHAR', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_CHAR ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_CHAR('SHORT', 'CHAR', decode('CHAR', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_CHAR('SHORT', 'CHAR', decode('CHAR', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_CHAR ;
 
 
-call print_message('t_BIT(8)_CHAR. This scenario is a failure.');
-create or replace procedure t_BIT_CHAR(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_CHAR. This scenario is a failure.');
+create or replace procedure t_BIT_CHAR(param_type string, variables_type string, param BIT ) as 
 VAR CHAR(30) := param ;
 VAR1 CHAR(30)  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_CHAR('BIT(8)', 'CHAR', 0xaa ) ;
+call t_BIT_CHAR('BIT', 'CHAR', 0xaa ) ;
 drop procedure t_BIT_CHAR ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-14_param_to_variable_VARCHAR.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-14_param_to_variable_VARCHAR.sql
@@ -136,7 +136,7 @@ drop procedure t_FLOAT_VARCHAR ;
 
 
 call print_message('t_NUMERIC_VARCHAR. This scenario is a success.');
-create or replace procedure t_NUMERIC_VARCHAR(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+create or replace procedure t_NUMERIC_VARCHAR(param_type string, variables_type string, param NUMERIC ) as 
 VAR VARCHAR := param ;
 VAR1 VARCHAR  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_VARCHAR('NUMERIC(8,4)', 'VARCHAR', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_VARCHAR('NUMERIC', 'VARCHAR', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_VARCHAR ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_VARCHAR('BIGINT', 'VARCHAR', decode('VARCHAR', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_VARCHAR('BIGINT', 'VARCHAR', decode('VARCHAR', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_VARCHAR ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_VARCHAR('INT', 'VARCHAR', decode('VARCHAR', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_VARCHAR('INT', 'VARCHAR', decode('VARCHAR', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_VARCHAR ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_VARCHAR('SHORT', 'VARCHAR', decode('VARCHAR', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_VARCHAR('SHORT', 'VARCHAR', decode('VARCHAR', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_VARCHAR ;
 
 
-call print_message('t_BIT(8)_VARCHAR. This scenario is a failure.');
-create or replace procedure t_BIT_VARCHAR(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_VARCHAR. This scenario is a failure.');
+create or replace procedure t_BIT_VARCHAR(param_type string, variables_type string, param BIT ) as 
 VAR VARCHAR := param ;
 VAR1 VARCHAR  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_VARCHAR('BIT(8)', 'VARCHAR', 0xaa ) ;
+call t_BIT_VARCHAR('BIT', 'VARCHAR', 0xaa ) ;
 drop procedure t_BIT_VARCHAR ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-15_param_to_variable_DOUBLE.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-15_param_to_variable_DOUBLE.sql
@@ -136,7 +136,7 @@ drop procedure t_FLOAT_DOUBLE ;
 
 
 call print_message('t_NUMERIC_DOUBLE. This scenario is a success.');
-create or replace procedure t_NUMERIC_DOUBLE(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+create or replace procedure t_NUMERIC_DOUBLE(param_type string, variables_type string, param NUMERIC ) as 
 VAR DOUBLE := param ;
 VAR1 DOUBLE  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_DOUBLE('NUMERIC(8,4)', 'DOUBLE', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_DOUBLE('NUMERIC', 'DOUBLE', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_DOUBLE ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_DOUBLE('BIGINT', 'DOUBLE', decode('DOUBLE', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_DOUBLE('BIGINT', 'DOUBLE', decode('DOUBLE', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_DOUBLE ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_DOUBLE('INT', 'DOUBLE', decode('DOUBLE', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_DOUBLE('INT', 'DOUBLE', decode('DOUBLE', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_DOUBLE ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_DOUBLE('SHORT', 'DOUBLE', decode('DOUBLE', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_DOUBLE('SHORT', 'DOUBLE', decode('DOUBLE', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_DOUBLE ;
 
 
-call print_message('t_BIT(8)_DOUBLE. This scenario is a failure.');
-create or replace procedure t_BIT_DOUBLE(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_DOUBLE. This scenario is a failure.');
+create or replace procedure t_BIT_DOUBLE(param_type string, variables_type string, param BIT ) as 
 VAR DOUBLE := param ;
 VAR1 DOUBLE  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_DOUBLE('BIT(8)', 'DOUBLE', 0xaa ) ;
+call t_BIT_DOUBLE('BIT', 'DOUBLE', 0xaa ) ;
 drop procedure t_BIT_DOUBLE ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-16_param_to_variable_FLOAT.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-16_param_to_variable_FLOAT.sql
@@ -136,7 +136,7 @@ drop procedure t_FLOAT_FLOAT ;
 
 
 call print_message('t_NUMERIC_FLOAT. This scenario is a success.');
-create or replace procedure t_NUMERIC_FLOAT(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+create or replace procedure t_NUMERIC_FLOAT(param_type string, variables_type string, param NUMERIC ) as 
 VAR FLOAT := param ;
 VAR1 FLOAT  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_FLOAT('NUMERIC(8,4)', 'FLOAT', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_FLOAT('NUMERIC', 'FLOAT', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_FLOAT ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_FLOAT('BIGINT', 'FLOAT', decode('FLOAT', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_FLOAT('BIGINT', 'FLOAT', decode('FLOAT', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_FLOAT ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_FLOAT('INT', 'FLOAT', decode('FLOAT', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_FLOAT('INT', 'FLOAT', decode('FLOAT', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_FLOAT ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_FLOAT('SHORT', 'FLOAT', decode('FLOAT', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_FLOAT('SHORT', 'FLOAT', decode('FLOAT', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_FLOAT ;
 
 
-call print_message('t_BIT(8)_FLOAT. This scenario is a failure.');
-create or replace procedure t_BIT_FLOAT(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_FLOAT. This scenario is a failure.');
+create or replace procedure t_BIT_FLOAT(param_type string, variables_type string, param BIT ) as 
 VAR FLOAT := param ;
 VAR1 FLOAT  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_FLOAT('BIT(8)', 'FLOAT', 0xaa ) ;
+call t_BIT_FLOAT('BIT', 'FLOAT', 0xaa ) ;
 drop procedure t_BIT_FLOAT ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-17_param_to_variable_NUMERIC.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-17_param_to_variable_NUMERIC.sql
@@ -136,7 +136,7 @@ drop procedure t_FLOAT_NUMERIC ;
 
 
 call print_message('t_NUMERIC_NUMERIC. This scenario is a success.');
-create or replace procedure t_NUMERIC_NUMERIC(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+create or replace procedure t_NUMERIC_NUMERIC(param_type string, variables_type string, param NUMERIC ) as 
 VAR NUMERIC(38,15) := param ;
 VAR1 NUMERIC(38,15)  ;
 begin
@@ -145,7 +145,7 @@ VAR1 := VAR ;
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
 call t_NUMERIC_NUMERIC('NUMERIC(4,4)', 'NUMERIC(38,15)', cast( 0.123456789 as numeric(4,4) ) ) ;
-call t_NUMERIC_NUMERIC('NUMERIC(8,4)', 'NUMERIC(38,15)', cast( 0.123456789 as numeric(8,4) ) ) ;
+call t_NUMERIC_NUMERIC('NUMERIC', 'NUMERIC(38,15)', cast( 0.123456789 as NUMERIC ) ) ;
 drop procedure t_NUMERIC_NUMERIC ;
 
 
@@ -158,7 +158,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_NUMERIC('BIGINT', 'NUMERIC(38,15)', decode('NUMERIC(38,15)', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_NUMERIC('BIGINT', 'NUMERIC(38,15)', decode('NUMERIC(38,15)', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_NUMERIC ;
 
 
@@ -171,7 +171,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_NUMERIC('INT', 'NUMERIC(38,15)', decode('NUMERIC(38,15)', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_NUMERIC('INT', 'NUMERIC(38,15)', decode('NUMERIC(38,15)', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_NUMERIC ;
 
 
@@ -184,12 +184,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_NUMERIC('SHORT', 'NUMERIC(38,15)', decode('NUMERIC(38,15)', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_NUMERIC('SHORT', 'NUMERIC(38,15)', decode('NUMERIC(38,15)', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_NUMERIC ;
 
 
-call print_message('t_BIT(8)_NUMERIC(38,15). This scenario is a failure.');
-create or replace procedure t_BIT_NUMERIC(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_NUMERIC(38,15). This scenario is a failure.');
+create or replace procedure t_BIT_NUMERIC(param_type string, variables_type string, param BIT ) as 
 VAR NUMERIC(38,15) := param ;
 VAR1 NUMERIC(38,15)  ;
 begin
@@ -197,7 +197,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_NUMERIC('BIT(8)', 'NUMERIC(38,15)', 0xaa ) ;
+call t_BIT_NUMERIC('BIT', 'NUMERIC(38,15)', 0xaa ) ;
 drop procedure t_BIT_NUMERIC ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-18_param_to_variable_BIGINT.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-18_param_to_variable_BIGINT.sql
@@ -136,7 +136,7 @@ drop procedure t_FLOAT_BIGINT ;
 
 
 call print_message('t_NUMERIC_BIGINT. This scenario is a success.');
-create or replace procedure t_NUMERIC_BIGINT(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+create or replace procedure t_NUMERIC_BIGINT(param_type string, variables_type string, param NUMERIC ) as 
 VAR BIGINT := param ;
 VAR1 BIGINT  ;
 begin
@@ -145,7 +145,7 @@ VAR1 := VAR ;
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
 call t_NUMERIC_BIGINT('NUMERIC(4,4)', 'BIGINT', cast( 0.123456789 as numeric(4,4) ) ) ;
-call t_NUMERIC_BIGINT('NUMERIC(8,4)', 'BIGINT', cast( 0.123456789 as numeric(8,4) ) ) ;
+call t_NUMERIC_BIGINT('NUMERIC', 'BIGINT', cast( 0.123456789 as NUMERIC ) ) ;
 drop procedure t_NUMERIC_BIGINT ;
 
 
@@ -158,7 +158,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_BIGINT('BIGINT', 'BIGINT', decode('BIGINT', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_BIGINT('BIGINT', 'BIGINT', decode('BIGINT', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_BIGINT ;
 
 
@@ -171,7 +171,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_BIGINT('INT', 'BIGINT', decode('BIGINT', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_BIGINT('INT', 'BIGINT', decode('BIGINT', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_BIGINT ;
 
 
@@ -184,12 +184,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_BIGINT('SHORT', 'BIGINT', decode('BIGINT', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_BIGINT('SHORT', 'BIGINT', decode('BIGINT', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_BIGINT ;
 
 
-call print_message('t_BIT(8)_BIGINT. This scenario is a failure.');
-create or replace procedure t_BIT_BIGINT(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_BIGINT. This scenario is a failure.');
+create or replace procedure t_BIT_BIGINT(param_type string, variables_type string, param BIT ) as 
 VAR BIGINT := param ;
 VAR1 BIGINT  ;
 begin
@@ -197,7 +197,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_BIGINT('BIT(8)', 'BIGINT', 0xaa ) ;
+call t_BIT_BIGINT('BIT', 'BIGINT', 0xaa ) ;
 drop procedure t_BIT_BIGINT ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-19_param_to_variable_SET.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-19_param_to_variable_SET.sql
@@ -135,8 +135,8 @@ call t_FLOAT_SET('FLOAT', 'SET', cast( 1677.217 as float ) ) ;
 drop procedure t_FLOAT_SET ;
 
 
-call print_message('t_NUMERIC(8,4)_SET. This scenario is a failure.');
-create or replace procedure t_NUMERIC_SET(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+call print_message('t_NUMERIC_SET. This scenario is a failure.');
+create or replace procedure t_NUMERIC_SET(param_type string, variables_type string, param NUMERIC ) as 
 VAR SET := param ;
 VAR1 SET  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_SET('NUMERIC(8,4)', 'SET', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_SET('NUMERIC', 'SET', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_SET ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_SET('BIGINT', 'SET', decode('SET', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_SET('BIGINT', 'SET', decode('SET', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_SET ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_SET('INT', 'SET', decode('SET', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_SET('INT', 'SET', decode('SET', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_SET ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_SET('SHORT', 'SET', decode('SET', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_SET('SHORT', 'SET', decode('SET', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_SET ;
 
 
-call print_message('t_BIT(8)_SET. This scenario is a failure.');
-create or replace procedure t_BIT_SET(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_SET. This scenario is a failure.');
+create or replace procedure t_BIT_SET(param_type string, variables_type string, param BIT ) as 
 VAR SET := param ;
 VAR1 SET  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_SET('BIT(8)', 'SET', 0xaa ) ;
+call t_BIT_SET('BIT', 'SET', 0xaa ) ;
 drop procedure t_BIT_SET ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-20_param_to_variable_MULTISET.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-20_param_to_variable_MULTISET.sql
@@ -135,8 +135,8 @@ call t_FLOAT_MULTISET('FLOAT', 'MULTISET', cast( 1677.217 as float ) ) ;
 drop procedure t_FLOAT_MULTISET ;
 
 
-call print_message('t_NUMERIC(8,4)_MULTISET. This scenario is a failure.');
-create or replace procedure t_NUMERIC_MULTISET(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+call print_message('t_NUMERIC_MULTISET. This scenario is a failure.');
+create or replace procedure t_NUMERIC_MULTISET(param_type string, variables_type string, param NUMERIC ) as 
 VAR MULTISET := param ;
 VAR1 MULTISET  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_MULTISET('NUMERIC(8,4)', 'MULTISET', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_MULTISET('NUMERIC', 'MULTISET', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_MULTISET ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_MULTISET('BIGINT', 'MULTISET', decode('MULTISET', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_MULTISET('BIGINT', 'MULTISET', decode('MULTISET', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_MULTISET ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_MULTISET('INT', 'MULTISET', decode('MULTISET', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_MULTISET('INT', 'MULTISET', decode('MULTISET', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_MULTISET ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_MULTISET('SHORT', 'MULTISET', decode('MULTISET', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_MULTISET('SHORT', 'MULTISET', decode('MULTISET', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_MULTISET ;
 
 
-call print_message('t_BIT(8)_MULTISET. This scenario is a failure.');
-create or replace procedure t_BIT_MULTISET(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_MULTISET. This scenario is a failure.');
+create or replace procedure t_BIT_MULTISET(param_type string, variables_type string, param BIT ) as 
 VAR MULTISET := param ;
 VAR1 MULTISET  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_MULTISET('BIT(8)', 'MULTISET', 0xaa ) ;
+call t_BIT_MULTISET('BIT', 'MULTISET', 0xaa ) ;
 drop procedure t_BIT_MULTISET ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-21_param_to_variable_LIST.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-21_param_to_variable_LIST.sql
@@ -135,8 +135,8 @@ call t_FLOAT_LIST('FLOAT', 'LIST', cast( 1677.217 as float ) ) ;
 drop procedure t_FLOAT_LIST ;
 
 
-call print_message('t_NUMERIC(8,4)_LIST. This scenario is a failure.');
-create or replace procedure t_NUMERIC_LIST(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+call print_message('t_NUMERIC_LIST. This scenario is a failure.');
+create or replace procedure t_NUMERIC_LIST(param_type string, variables_type string, param NUMERIC ) as 
 VAR LIST := param ;
 VAR1 LIST  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_LIST('NUMERIC(8,4)', 'LIST', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_LIST('NUMERIC', 'LIST', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_LIST ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_LIST('BIGINT', 'LIST', decode('LIST', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_LIST('BIGINT', 'LIST', decode('LIST', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_LIST ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_LIST('INT', 'LIST', decode('LIST', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_LIST('INT', 'LIST', decode('LIST', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_LIST ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_LIST('SHORT', 'LIST', decode('LIST', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_LIST('SHORT', 'LIST', decode('LIST', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_LIST ;
 
 
-call print_message('t_BIT(8)_LIST. This scenario is a failure.');
-create or replace procedure t_BIT_LIST(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_LIST. This scenario is a failure.');
+create or replace procedure t_BIT_LIST(param_type string, variables_type string, param BIT ) as 
 VAR LIST := param ;
 VAR1 LIST  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_LIST('BIT(8)', 'LIST', 0xaa ) ;
+call t_BIT_LIST('BIT', 'LIST', 0xaa ) ;
 drop procedure t_BIT_LIST ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-22_param_to_variable_ENUM.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-22_param_to_variable_ENUM.sql
@@ -135,8 +135,8 @@ call t_FLOAT_ENUM('FLOAT', 'ENUM', cast( 1677.217 as float ) ) ;
 drop procedure t_FLOAT_ENUM ;
 
 
-call print_message('t_NUMERIC(8,4)_ENUM. This scenario is a failure.');
-create or replace procedure t_NUMERIC_ENUM(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+call print_message('t_NUMERIC_ENUM. This scenario is a failure.');
+create or replace procedure t_NUMERIC_ENUM(param_type string, variables_type string, param NUMERIC ) as 
 VAR ENUM := param ;
 VAR1 ENUM  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_ENUM('NUMERIC(8,4)', 'ENUM', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_ENUM('NUMERIC', 'ENUM', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_ENUM ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_ENUM('BIGINT', 'ENUM', decode('ENUM', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_ENUM('BIGINT', 'ENUM', decode('ENUM', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_ENUM ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_ENUM('INT', 'ENUM', decode('ENUM', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_ENUM('INT', 'ENUM', decode('ENUM', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_ENUM ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_ENUM('SHORT', 'ENUM', decode('ENUM', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_ENUM('SHORT', 'ENUM', decode('ENUM', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_ENUM ;
 
 
-call print_message('t_BIT(8)_ENUM. This scenario is a failure.');
-create or replace procedure t_BIT_ENUM(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_ENUM. This scenario is a failure.');
+create or replace procedure t_BIT_ENUM(param_type string, variables_type string, param BIT ) as 
 VAR ENUM := param ;
 VAR1 ENUM  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_ENUM('BIT(8)', 'ENUM', 0xaa ) ;
+call t_BIT_ENUM('BIT', 'ENUM', 0xaa ) ;
 drop procedure t_BIT_ENUM ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-23_param_to_variable_BLOB.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-23_param_to_variable_BLOB.sql
@@ -135,8 +135,8 @@ call t_FLOAT_BLOB('FLOAT', 'BLOB', cast( 1677.217 as float ) ) ;
 drop procedure t_FLOAT_BLOB ;
 
 
-call print_message('t_NUMERIC(8,4)_BLOB. This scenario is a failure.');
-create or replace procedure t_NUMERIC_BLOB(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+call print_message('t_NUMERIC_BLOB. This scenario is a failure.');
+create or replace procedure t_NUMERIC_BLOB(param_type string, variables_type string, param NUMERIC ) as 
 VAR BLOB := param ;
 VAR1 BLOB  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_BLOB('NUMERIC(8,4)', 'BLOB', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_BLOB('NUMERIC', 'BLOB', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_BLOB ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_BLOB('BIGINT', 'BLOB', decode('BLOB', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_BLOB('BIGINT', 'BLOB', decode('BLOB', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_BLOB ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_BLOB('INT', 'BLOB', decode('BLOB', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_BLOB('INT', 'BLOB', decode('BLOB', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_BLOB ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_BLOB('SHORT', 'BLOB', decode('BLOB', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_BLOB('SHORT', 'BLOB', decode('BLOB', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_BLOB ;
 
 
-call print_message('t_BIT(8)_BLOB. This scenario is a failure.');
-create or replace procedure t_BIT_BLOB(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_BLOB. This scenario is a failure.');
+create or replace procedure t_BIT_BLOB(param_type string, variables_type string, param BIT ) as 
 VAR BLOB := param ;
 VAR1 BLOB  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_BLOB('BIT(8)', 'BLOB', 0xaa ) ;
+call t_BIT_BLOB('BIT', 'BLOB', 0xaa ) ;
 drop procedure t_BIT_BLOB ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-24_param_to_variable_CLOB.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-24_param_to_variable_CLOB.sql
@@ -135,8 +135,8 @@ call t_FLOAT_CLOB('FLOAT', 'CLOB', cast( 1677.217 as float ) ) ;
 drop procedure t_FLOAT_CLOB ;
 
 
-call print_message('t_NUMERIC(8,4)_CLOB. This scenario is a failure.');
-create or replace procedure t_NUMERIC_CLOB(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+call print_message('t_NUMERIC_CLOB. This scenario is a failure.');
+create or replace procedure t_NUMERIC_CLOB(param_type string, variables_type string, param NUMERIC ) as 
 VAR CLOB := param ;
 VAR1 CLOB  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_CLOB('NUMERIC(8,4)', 'CLOB', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_CLOB('NUMERIC', 'CLOB', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_CLOB ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_CLOB('BIGINT', 'CLOB', decode('CLOB', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_CLOB('BIGINT', 'CLOB', decode('CLOB', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_CLOB ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_CLOB('INT', 'CLOB', decode('CLOB', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_CLOB('INT', 'CLOB', decode('CLOB', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_CLOB ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_CLOB('SHORT', 'CLOB', decode('CLOB', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_CLOB('SHORT', 'CLOB', decode('CLOB', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_CLOB ;
 
 
-call print_message('t_BIT(8)_CLOB. This scenario is a failure.');
-create or replace procedure t_BIT_CLOB(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_CLOB. This scenario is a failure.');
+create or replace procedure t_BIT_CLOB(param_type string, variables_type string, param BIT ) as 
 VAR CLOB := param ;
 VAR1 CLOB  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_CLOB('BIT(8)', 'CLOB', 0xaa ) ;
+call t_BIT_CLOB('BIT', 'CLOB', 0xaa ) ;
 drop procedure t_BIT_CLOB ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-25_param_to_variable_JSON.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/cases/02_02_04-25_param_to_variable_JSON.sql
@@ -135,8 +135,8 @@ call t_FLOAT_JSON('FLOAT', 'JSON', cast( 1677.217 as float ) ) ;
 drop procedure t_FLOAT_JSON ;
 
 
-call print_message('t_NUMERIC(8,4)_JSON. This scenario is a failure.');
-create or replace procedure t_NUMERIC_JSON(param_type string, variables_type string, param NUMERIC(8,4) ) as 
+call print_message('t_NUMERIC_JSON. This scenario is a failure.');
+create or replace procedure t_NUMERIC_JSON(param_type string, variables_type string, param NUMERIC ) as 
 VAR JSON := param ;
 VAR1 JSON  ;
 begin
@@ -144,7 +144,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_NUMERIC_JSON('NUMERIC(8,4)', 'JSON', cast( 0.123456789 as numeric(4,4) ) ) ;
+call t_NUMERIC_JSON('NUMERIC', 'JSON', cast( 0.123456789 as numeric(4,4) ) ) ;
 drop procedure t_NUMERIC_JSON ;
 
 
@@ -157,7 +157,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIGINT_JSON('BIGINT', 'JSON', decode('JSON', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC(8,4)', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
+call t_BIGINT_JSON('BIGINT', 'JSON', decode('JSON', 'INT',cast( 34589012 as bigint ) /1000, 'SHORT', cast( 34589012 as bigint ) /10000, 'NUMERIC', cast( 34589012 as bigint ) /10000, cast( 34589012 as bigint ) )  ) ;
 drop procedure t_BIGINT_JSON ;
 
 
@@ -170,7 +170,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_INT_JSON('INT', 'JSON', decode('JSON', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC(8,4)', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
+call t_INT_JSON('INT', 'JSON', decode('JSON', 'INT',cast( 782346 as int ) /1000, 'SHORT', cast( 782346 as int ) /10000, 'NUMERIC', cast( 782346 as int ) /10000, cast( 782346 as int ) )  ) ;
 drop procedure t_INT_JSON ;
 
 
@@ -183,12 +183,12 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_SHORT_JSON('SHORT', 'JSON', decode('JSON', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC(8,4)', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
+call t_SHORT_JSON('SHORT', 'JSON', decode('JSON', 'INT',cast( 8934 as short ) /1000, 'SHORT', cast( 8934 as short ) /10000, 'NUMERIC', cast( 8934 as short ) /10000, cast( 8934 as short ) )  ) ;
 drop procedure t_SHORT_JSON ;
 
 
-call print_message('t_BIT(8)_JSON. This scenario is a failure.');
-create or replace procedure t_BIT_JSON(param_type string, variables_type string, param BIT(8) ) as 
+call print_message('t_BIT_JSON. This scenario is a failure.');
+create or replace procedure t_BIT_JSON(param_type string, variables_type string, param BIT ) as 
 VAR JSON := param ;
 VAR1 JSON  ;
 begin
@@ -196,7 +196,7 @@ VAR1 := VAR ;
     dbms_output.put_line('param_type = ' ||param_type ||', variables_type = '||variables_type||', param=>variables = '|| VAR ); 
     dbms_output.put_line('variables=>variables = ' || VAR1  ); 
 end;
-call t_BIT_JSON('BIT(8)', 'JSON', 0xaa ) ;
+call t_BIT_JSON('BIT', 'JSON', 0xaa ) ;
 drop procedure t_BIT_JSON ;
 
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/cases/31_bugfix_percent_type.sql
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/cases/31_bugfix_percent_type.sql
@@ -25,7 +25,7 @@ drop function test_percent_type_in_sig;
 create or replace procedure test_percent_typed_arg_to_out_param as
     c dual.dummy%type;
 
-    procedure poo(c out char(1)) as
+    procedure poo(c out char) as
     begin
         dbms_output.put_line('Call OK');
     end;
@@ -39,7 +39,7 @@ drop procedure test_percent_typed_arg_to_out_param;
 
 create or replace procedure test_percent_typed_arg_to_in_param() as
     c dual.dummy%type :='z' ;
-    procedure poo(in_param in char(1)) as
+    procedure poo(in_param in char) as
     begin
         dbms_output.put_line('print in value: ' + in_param);
     end;

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-03_error_into_unupdatable_2.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-03_error_into_unupdatable_2.sql
@@ -2,7 +2,7 @@
 
 -- error: identifiers in the into clause of static sql select statements must be updatable
 
-create or replace procedure t(c varchar(1)) as
+create or replace procedure t(c varchar) as
 begin
     select dummy into c from dual;
 end;

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-04_error_into_length_mismatch.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-04_error_into_length_mismatch.sql
@@ -2,7 +2,7 @@
 
 -- error: the lengths of into clause and the select list must match
 
-create or replace procedure t(c out varchar(1)) as
+create or replace procedure t(c out varchar) as
     d varchar(1);
 begin
     select dummy into c, d from dual;

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_01_open/cases/03_03_01-01_normal_with_param.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_01_open/cases/03_03_01-01_normal_with_param.sql
@@ -4,7 +4,7 @@
 
 
 create or replace procedure t(i int) as
-    cursor c(cs varchar(32), bbb int) is
+    cursor c(cs varchar, bbb int) is
         select charset_name from db_charset where charset_name = cs and charset_id > bbb;
     r varchar(32);
 begin

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_01_open/cases/03_03_01-05_error_arg_len_mismatch.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_01_open/cases/03_03_01-05_error_arg_len_mismatch.sql
@@ -3,7 +3,7 @@
 -- error: argument length does not match that in the definition of the cursor
 
 create or replace procedure t(i int) as
-    cursor c(cs varchar(32), b int) is select coll_name from db_collation where charset_name = cs and coll_id > b;
+    cursor c(cs varchar, b int) is select coll_name from db_collation where charset_name = cs and coll_id > b;
 begin
     open c('utf8');
 end;

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_01_open/cases/03_03_01-06_error_arg_type_mismatch.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_01_open/cases/03_03_01-06_error_arg_type_mismatch.sql
@@ -3,7 +3,7 @@
 -- error: argument type does not match that in the definition of the cursor
 
 create or replace procedure t(i int) as
-    cursor c(cs varchar(32), b int) is select coll_name from db_collation where charset_name = cs and coll_id > b;
+    cursor c(cs varchar, b int) is select coll_name from db_collation where charset_name = cs and coll_id > b;
 begin
     open c('utf8', true);
 end;

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_02_fetch/cases/03_03_02-03_error_into_unupdatable.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_02_fetch/cases/03_03_02-03_error_into_unupdatable.sql
@@ -2,7 +2,7 @@
 
 -- error: fetching a value into an unupdatable
 
-create or replace procedure t(r varchar(1)) as
+create or replace procedure t(r varchar) as
     cursor c is select dummy from dual;
 begin
     open c;

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_02_fetch/cases/03_03_02-04_error_into_len_mismatch.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_02_fetch/cases/03_03_02-04_error_into_len_mismatch.sql
@@ -3,7 +3,7 @@
 -- error: into clause length mismatch
 
 create or replace procedure t(i int) as
-    cursor c(cs varchar(32), b int) is select coll_name from db_collation where charset_name = cs and coll_id > b;
+    cursor c(cs varchar, b int) is select coll_name from db_collation where charset_name = cs and coll_id > b;
     r varchar(32);
     rr varchar(32);
 begin

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_02_fetch/cases/03_03_02-05_error_into_incompatible.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_02_fetch/cases/03_03_02-05_error_into_incompatible.sql
@@ -3,7 +3,7 @@
 -- error: into clause type mismatch
 
 create or replace procedure t(i int) as
-    cursor c(cs varchar(32), b int) is select coll_name from db_collation where charset_name = cs and coll_id > b;
+    cursor c(cs varchar, b int) is select coll_name from db_collation where charset_name = cs and coll_id > b;
     b boolean;
 begin
     open c('utf8', 3);

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_02_fetch/cases/03_03_02-06_normal_fetching_unopen.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_02_fetch/cases/03_03_02-06_normal_fetching_unopen.sql
@@ -5,7 +5,7 @@
 
 
 create or replace procedure t(i int) as
-    cursor c(cs varchar(32), b int) is select coll_name from db_collation where charset_name = cs and coll_id > b;
+    cursor c(cs varchar, b int) is select coll_name from db_collation where charset_name = cs and coll_id > b;
     r varchar(1);
 begin
     fetch c into r;

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_03_close/cases/03_03_03-03_normal_close_unopen.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_03_close/cases/03_03_03-03_normal_close_unopen.sql
@@ -4,7 +4,7 @@
 -- Verified for CBRD-24951
 
 create or replace procedure t(i int) as
-    cursor c(cs varchar(32), b int) is select coll_name from db_collation where charset_name = cs and coll_id > b;
+    cursor c(cs varchar, b int) is select coll_name from db_collation where charset_name = cs and coll_id > b;
 begin
     close c;
     dbms_output.put_line('unreachable');

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_01_into_clause/cases/03_04_01-02_error_into_unupdatable.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_01_into_clause/cases/03_04_01-02_error_into_unupdatable.sql
@@ -2,7 +2,7 @@
 
 -- error: into unupdatable identifiers
 
-create or replace procedure t(charset varchar(32)) as
+create or replace procedure t(charset varchar) as
 begin
     execute immediate 'select charset_name from db_collation where coll_name = ''utf8_en_cs''' into charset;
 end;

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-13_variable_to_return_CHAR.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-13_variable_to_return_CHAR.answer
@@ -28,10 +28,10 @@ null
 t_DATETIMELTZ_CHAR. This scenario is a failure.
 ===================================================
 Error:-494
-Semantic: before '  ) RETURN CHAR(40) IS
+Semantic: before '  ) RETURN CHAR IS
 VAR DATETIMELTZ  ;
 begin
-VAR := param_v...'
+VAR := param_value...'
 Unsupported argument type 'datetimeltz' of the stored procedure create or replace function t_DATETIMELTZ_CHAR(variables_type...
 
 ===================================================
@@ -52,10 +52,10 @@ null
 t_DATETIMETZ_CHAR. This scenario is a failure.
 ===================================================
 Error:-494
-Semantic: before '  ) RETURN CHAR(40) IS
+Semantic: before '  ) RETURN CHAR IS
 VAR DATETIMETZ  ;
 begin
-VAR := param_va...'
+VAR := param_value ...'
 Unsupported argument type 'datetimetz' of the stored procedure create or replace function t_DATETIMETZ_CHAR(variables_type ...
 
 ===================================================
@@ -133,10 +133,10 @@ null
 t_TIMESTAMPLTZ_CHAR. This scenario is a failure.
 ===================================================
 Error:-494
-Semantic: before '  ) RETURN CHAR(40) IS
+Semantic: before '  ) RETURN CHAR IS
 VAR TIMESTAMPLTZ  ;
 begin
-VAR := param_...'
+VAR := param_valu...'
 Unsupported argument type 'timestampltz' of the stored procedure create or replace function t_TIMESTAMPLTZ_CHAR(variables_typ...
 
 ===================================================
@@ -157,10 +157,10 @@ null
 t_TIMESTAMPTZ_CHAR. This scenario is a failure.
 ===================================================
 Error:-494
-Semantic: before '  ) RETURN CHAR(40) IS
+Semantic: before '  ) RETURN CHAR IS
 VAR TIMESTAMPTZ  ;
 begin
-VAR := param_v...'
+VAR := param_value...'
 Unsupported argument type 'timestamptz' of the stored procedure create or replace function t_TIMESTAMPTZ_CHAR(variables_type...
 
 ===================================================
@@ -295,10 +295,11 @@ null
 t_BIT(8)_CHAR. This scenario is a failure.
 ===================================================
 Error:-494
-Semantic: before '  ) RETURN CHAR(40) IS
+Semantic: before '  ) RETURN CHAR IS
 VAR BIT(8)  ;
 begin
-VAR := param_value ...'
+VAR := param_value ;
+db...'
 Unsupported argument type 'bit' of the stored procedure create or replace function t_BIT_CHAR(variables_type  varcha...
 
 ===================================================
@@ -319,10 +320,10 @@ null
 t_BIT VARYING_CHAR. This scenario is a failure.
 ===================================================
 Error:-494
-Semantic: before '  ) RETURN CHAR(40) IS
+Semantic: before '  ) RETURN CHAR IS
 VAR BIT VARYING  ;
 begin
-VAR := param_v...'
+VAR := param_value...'
 dba.BITVARYING is not defined. create or replace function t_BITVARYING_CHAR(variables_type ...
 
 ===================================================
@@ -463,11 +464,11 @@ null
 t_BLOB_CHAR. This scenario is a failure.
 ===================================================
 Error:-494
-Semantic: before '  ) RETURN CHAR(40) IS
+Semantic: before '  ) RETURN CHAR IS
 VAR BLOB  ;
 begin
 VAR := param_value ;
-...'
+dbms...'
 Unsupported argument type 'blob' of the stored procedure create or replace function t_BLOB_CHAR(variables_type  varch...
 
 ===================================================
@@ -488,11 +489,11 @@ null
 t_CLOB_CHAR. This scenario is a failure.
 ===================================================
 Error:-494
-Semantic: before '  ) RETURN CHAR(40) IS
+Semantic: before '  ) RETURN CHAR IS
 VAR CLOB  ;
 begin
 VAR := param_value ;
-...'
+dbms...'
 Unsupported argument type 'clob' of the stored procedure create or replace function t_CLOB_CHAR(variables_type  varch...
 
 ===================================================
@@ -513,11 +514,11 @@ null
 t_JSON_CHAR. This scenario is a failure.
 ===================================================
 Error:-494
-Semantic: before '  ) RETURN CHAR(40) IS
+Semantic: before '  ) RETURN CHAR IS
 VAR JSON  ;
 begin
 VAR := param_value ;
-...'
+dbms...'
 Unsupported argument type 'json' of the stored procedure create or replace function t_JSON_CHAR(variables_type  varch...
 
 ===================================================

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/cases/03_10_03-13_variable_to_return_CHAR.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/cases/03_10_03-13_variable_to_return_CHAR.sql
@@ -6,7 +6,7 @@ end;
 
 
 call print_message('t_DATETIME_CHAR. This scenario is a success.');
-create or replace function t_DATETIME_CHAR(variables_type string, return_type string, param_value DATETIME ) RETURN CHAR(40) IS 
+create or replace function t_DATETIME_CHAR(variables_type string, return_type string, param_value DATETIME ) RETURN CHAR IS 
    VAR DATETIME  ;
 begin
    VAR := param_value ;
@@ -21,7 +21,7 @@ drop function t_DATETIME_CHAR ;
 
 
 call print_message('t_DATETIMELTZ_CHAR. This scenario is a failure.');
-create or replace function t_DATETIMELTZ_CHAR(variables_type string, return_type string, param_value DATETIMELTZ ) RETURN CHAR(40) IS 
+create or replace function t_DATETIMELTZ_CHAR(variables_type string, return_type string, param_value DATETIMELTZ ) RETURN CHAR IS 
    VAR DATETIMELTZ  ;
 begin
    VAR := param_value ;
@@ -36,7 +36,7 @@ drop function t_DATETIMELTZ_CHAR ;
 
 
 call print_message('t_DATETIMETZ_CHAR. This scenario is a failure.');
-create or replace function t_DATETIMETZ_CHAR(variables_type string, return_type string, param_value DATETIMETZ ) RETURN CHAR(40) IS 
+create or replace function t_DATETIMETZ_CHAR(variables_type string, return_type string, param_value DATETIMETZ ) RETURN CHAR IS 
    VAR DATETIMETZ  ;
 begin
    VAR := param_value ;
@@ -51,7 +51,7 @@ drop function t_DATETIMETZ_CHAR ;
 
 
 call print_message('t_DATE_CHAR. This scenario is a success.');
-create or replace function t_DATE_CHAR(variables_type string, return_type string, param_value DATE ) RETURN CHAR(40) IS 
+create or replace function t_DATE_CHAR(variables_type string, return_type string, param_value DATE ) RETURN CHAR IS 
    VAR DATE  ;
 begin
    VAR := param_value ;
@@ -66,7 +66,7 @@ drop function t_DATE_CHAR ;
 
 
 call print_message('t_TIME_CHAR. This scenario is a success.');
-create or replace function t_TIME_CHAR(variables_type string, return_type string, param_value TIME ) RETURN CHAR(40) IS 
+create or replace function t_TIME_CHAR(variables_type string, return_type string, param_value TIME ) RETURN CHAR IS 
    VAR TIME  ;
 begin
    VAR := param_value ;
@@ -81,7 +81,7 @@ drop function t_TIME_CHAR ;
 
 
 call print_message('t_TIMESTAMP_CHAR. This scenario is a success.');
-create or replace function t_TIMESTAMP_CHAR(variables_type string, return_type string, param_value TIMESTAMP ) RETURN CHAR(40) IS 
+create or replace function t_TIMESTAMP_CHAR(variables_type string, return_type string, param_value TIMESTAMP ) RETURN CHAR IS 
    VAR TIMESTAMP  ;
 begin
    VAR := param_value ;
@@ -96,7 +96,7 @@ drop function t_TIMESTAMP_CHAR ;
 
 
 call print_message('t_TIMESTAMPLTZ_CHAR. This scenario is a failure.');
-create or replace function t_TIMESTAMPLTZ_CHAR(variables_type string, return_type string, param_value TIMESTAMPLTZ ) RETURN CHAR(40) IS 
+create or replace function t_TIMESTAMPLTZ_CHAR(variables_type string, return_type string, param_value TIMESTAMPLTZ ) RETURN CHAR IS 
    VAR TIMESTAMPLTZ  ;
 begin
    VAR := param_value ;
@@ -111,7 +111,7 @@ drop function t_TIMESTAMPLTZ_CHAR ;
 
 
 call print_message('t_TIMESTAMPTZ_CHAR. This scenario is a failure.');
-create or replace function t_TIMESTAMPTZ_CHAR(variables_type string, return_type string, param_value TIMESTAMPTZ ) RETURN CHAR(40) IS 
+create or replace function t_TIMESTAMPTZ_CHAR(variables_type string, return_type string, param_value TIMESTAMPTZ ) RETURN CHAR IS 
    VAR TIMESTAMPTZ  ;
 begin
    VAR := param_value ;
@@ -126,7 +126,7 @@ drop function t_TIMESTAMPTZ_CHAR ;
 
 
 call print_message('t_DOUBLE_CHAR. This scenario is a success.');
-create or replace function t_DOUBLE_CHAR(variables_type string, return_type string, param_value DOUBLE ) RETURN CHAR(40) IS 
+create or replace function t_DOUBLE_CHAR(variables_type string, return_type string, param_value DOUBLE ) RETURN CHAR IS 
    VAR DOUBLE  ;
 begin
    VAR := param_value ;
@@ -141,7 +141,7 @@ drop function t_DOUBLE_CHAR ;
 
 
 call print_message('t_FLOAT_CHAR. This scenario is a success.');
-create or replace function t_FLOAT_CHAR(variables_type string, return_type string, param_value FLOAT ) RETURN CHAR(40) IS 
+create or replace function t_FLOAT_CHAR(variables_type string, return_type string, param_value FLOAT ) RETURN CHAR IS 
    VAR FLOAT  ;
 begin
    VAR := param_value ;
@@ -156,7 +156,7 @@ drop function t_FLOAT_CHAR ;
 
 
 call print_message('t_NUMERIC_CHAR. This scenario is a success.');
-create or replace function t_NUMERIC_CHAR(variables_type string, return_type string, param_value NUMERIC ) RETURN CHAR(40) IS 
+create or replace function t_NUMERIC_CHAR(variables_type string, return_type string, param_value NUMERIC ) RETURN CHAR IS 
    VAR NUMERIC(8,4)  ;
 begin
    VAR := param_value ;
@@ -171,7 +171,7 @@ drop function t_NUMERIC_CHAR ;
 
 
 call print_message('t_BIGINT_CHAR. This scenario is a success.');
-create or replace function t_BIGINT_CHAR(variables_type string, return_type string, param_value BIGINT ) RETURN CHAR(40) IS 
+create or replace function t_BIGINT_CHAR(variables_type string, return_type string, param_value BIGINT ) RETURN CHAR IS 
    VAR BIGINT  ;
 begin
    VAR := param_value ;
@@ -186,7 +186,7 @@ drop function t_BIGINT_CHAR ;
 
 
 call print_message('t_INT_CHAR. This scenario is a success.');
-create or replace function t_INT_CHAR(variables_type string, return_type string, param_value INT ) RETURN CHAR(40) IS 
+create or replace function t_INT_CHAR(variables_type string, return_type string, param_value INT ) RETURN CHAR IS 
    VAR INT  ;
 begin
    VAR := param_value ;
@@ -201,7 +201,7 @@ drop function t_INT_CHAR ;
 
 
 call print_message('t_SHORT_CHAR. This scenario is a success.');
-create or replace function t_SHORT_CHAR(variables_type string, return_type string, param_value SHORT ) RETURN CHAR(40) IS 
+create or replace function t_SHORT_CHAR(variables_type string, return_type string, param_value SHORT ) RETURN CHAR IS 
    VAR SHORT  ;
 begin
    VAR := param_value ;
@@ -216,7 +216,7 @@ drop function t_SHORT_CHAR ;
 
 
 call print_message('t_BIT(8)_CHAR. This scenario is a failure.');
-create or replace function t_BIT_CHAR(variables_type string, return_type string, param_value BIT ) RETURN CHAR(40) IS 
+create or replace function t_BIT_CHAR(variables_type string, return_type string, param_value BIT ) RETURN CHAR IS 
    VAR BIT(8)  ;
 begin
    VAR := param_value ;
@@ -231,7 +231,7 @@ drop function t_BIT_CHAR ;
 
 
 call print_message('t_BIT VARYING_CHAR. This scenario is a failure.');
-create or replace function t_BITVARYING_CHAR(variables_type string, return_type string, param_value BITVARYING ) RETURN CHAR(40) IS 
+create or replace function t_BITVARYING_CHAR(variables_type string, return_type string, param_value BITVARYING ) RETURN CHAR IS 
    VAR BIT VARYING  ;
 begin
    VAR := param_value ;
@@ -246,7 +246,7 @@ drop function t_BITVARYING_CHAR ;
 
 
 call print_message('t_CHAR_CHAR. This scenario is a success.');
-create or replace function t_CHAR_CHAR(variables_type string, return_type string, param_value CHAR ) RETURN CHAR(40) IS 
+create or replace function t_CHAR_CHAR(variables_type string, return_type string, param_value CHAR ) RETURN CHAR IS 
    VAR CHAR  ;
 begin
    VAR := param_value ;
@@ -261,7 +261,7 @@ drop function t_CHAR_CHAR ;
 
 
 call print_message('t_VARCHAR_CHAR. This scenario is a success.');
-create or replace function t_VARCHAR_CHAR(variables_type string, return_type string, param_value VARCHAR ) RETURN CHAR(40) IS 
+create or replace function t_VARCHAR_CHAR(variables_type string, return_type string, param_value VARCHAR ) RETURN CHAR IS 
    VAR VARCHAR  ;
 begin
    VAR := param_value ;
@@ -276,7 +276,7 @@ drop function t_VARCHAR_CHAR ;
 
 
 call print_message('t_SET_CHAR. This scenario is a failure.');
-create or replace function t_SET_CHAR(variables_type string, return_type string, param_value SET ) RETURN CHAR(40) IS 
+create or replace function t_SET_CHAR(variables_type string, return_type string, param_value SET ) RETURN CHAR IS 
    VAR SET  ;
 begin
    VAR := param_value ;
@@ -291,7 +291,7 @@ drop function t_SET_CHAR ;
 
 
 call print_message('t_MULTISET_CHAR. This scenario is a failure.');
-create or replace function t_MULTISET_CHAR(variables_type string, return_type string, param_value MULTISET ) RETURN CHAR(40) IS 
+create or replace function t_MULTISET_CHAR(variables_type string, return_type string, param_value MULTISET ) RETURN CHAR IS 
    VAR MULTISET  ;
 begin
    VAR := param_value ;
@@ -306,7 +306,7 @@ drop function t_MULTISET_CHAR ;
 
 
 call print_message('t_LIST_CHAR. This scenario is a failure.');
-create or replace function t_LIST_CHAR(variables_type string, return_type string, param_value LIST ) RETURN CHAR(40) IS 
+create or replace function t_LIST_CHAR(variables_type string, return_type string, param_value LIST ) RETURN CHAR IS 
    VAR LIST  ;
 begin
    VAR := param_value ;
@@ -321,7 +321,7 @@ drop function t_LIST_CHAR ;
 
 
 call print_message('t_ENUM_CHAR. This scenario is a failure.');
-create or replace function t_ENUM_CHAR(variables_type string, return_type string, param_value ENUM ) RETURN CHAR(40) IS 
+create or replace function t_ENUM_CHAR(variables_type string, return_type string, param_value ENUM ) RETURN CHAR IS 
    VAR ENUM  ;
 begin
    VAR := param_value ;
@@ -336,7 +336,7 @@ drop function t_ENUM_CHAR ;
 
 
 call print_message('t_BLOB_CHAR. This scenario is a failure.');
-create or replace function t_BLOB_CHAR(variables_type string, return_type string, param_value BLOB ) RETURN CHAR(40) IS 
+create or replace function t_BLOB_CHAR(variables_type string, return_type string, param_value BLOB ) RETURN CHAR IS 
    VAR BLOB  ;
 begin
    VAR := param_value ;
@@ -351,7 +351,7 @@ drop function t_BLOB_CHAR ;
 
 
 call print_message('t_CLOB_CHAR. This scenario is a failure.');
-create or replace function t_CLOB_CHAR(variables_type string, return_type string, param_value CLOB ) RETURN CHAR(40) IS 
+create or replace function t_CLOB_CHAR(variables_type string, return_type string, param_value CLOB ) RETURN CHAR IS 
    VAR CLOB  ;
 begin
    VAR := param_value ;
@@ -366,7 +366,7 @@ drop function t_CLOB_CHAR ;
 
 
 call print_message('t_JSON_CHAR. This scenario is a failure.');
-create or replace function t_JSON_CHAR(variables_type string, return_type string, param_value JSON ) RETURN CHAR(40) IS 
+create or replace function t_JSON_CHAR(variables_type string, return_type string, param_value JSON ) RETURN CHAR IS 
    VAR JSON  ;
 begin
    VAR := param_value ;

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/cases/03_10_03-17_variable_to_return_NUMERIC.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/cases/03_10_03-17_variable_to_return_NUMERIC.sql
@@ -126,7 +126,7 @@ drop function t_TIMESTAMPTZ_NUMERIC ;
 
 --BUG( normal : 1234.567890000000000, BUG : 1235) - CBRD-25529
 call print_message('t_DOUBLE_NUMERIC. This scenario is a success.');
-create or replace function t_DOUBLE_NUMERIC(variables_type string, return_type string, param_value DOUBLE ) RETURN NUMERIC(38,5) IS 
+create or replace function t_DOUBLE_NUMERIC(variables_type string, return_type string, param_value DOUBLE ) RETURN NUMERIC IS 
    VAR DOUBLE  ;
 begin
    VAR := param_value ;

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_14_like/_01_basic/cases/04_14_01-02_cbrd_25150.sql
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_14_like/_01_basic/cases/04_14_01-02_cbrd_25150.sql
@@ -1,7 +1,7 @@
 --+ server-message on
 -- Verified for CBRD-25150
 
-create or replace procedure poo(s varchar(10), w varchar(10)) as
+create or replace procedure poo(s varchar, w varchar) as
     b boolean;
     result_b varchar(10);
 begin


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25477

SP 인자타입과 리턴타입에 precision, scale 지정을 하지 못하도록 막음에 따라 TC를 업데이트 했습니다. 