### PR TITLE
[CBRD-25416] Add temporary exclusion case to Ha_repl test

### DIFF
--- a/sql/config/daily_regression_test_exclude_list_ha_repl.conf
+++ b/sql/config/daily_regression_test_exclude_list_ha_repl.conf
@@ -305,3 +305,6 @@ sql/_27_banana_qa/issue_8909_unquoted_keywords/cases/_004_update.test
 
 #[PERMANENT] don't support 'call' on HA.
 sql/_33_elderberry/cbrd_23845/cases/_02_permission_check.test
+
+#[temporary] CBRD-25416 , If the problem is resolved, this case should be removed from this exclude file.
+sql/_08_javasp/cases/case_cte_01.test


### PR DESCRIPTION
CBRD-24658 이슈가 해결되어 Ha_repl 테스트에 제외시켰던 TC를 복귀시켰으나, ha_repl_debug 테스트에 발생하는 core는 해결이 되지 않았습니다.
CBRD-24658에 연결되어 있는 CBRD-25416 이슈가 머지된 후 다시 살펴봐야 할 것 같다는 개발자의 의견입니다.
CBRD-24516이슈는 SP나 method에 대해 plan을 generic function과 동일하게 생성할 수 있도록 하는 Refactoring 이슈입니다. 

매번 regression test에 core가 발생하기 때문에 임시적으로 테스트에서 제외합니다.