### PR TITLE
fix an unstable TC by adding an ORDER BY clause

### DIFF
--- a/sql/_34_fig/cbrd_24252/answers/cbrd_24252_6.answer
+++ b/sql/_34_fig/cbrd_24252/answers/cbrd_24252_6.answer
@@ -1,92 +1,78 @@
-===================================================
-0
-===================================================
-0
-===================================================
-0
-===================================================
-1000
-===================================================
-0
-===================================================
-0
-===================================================
-0
-===================================================
-0
-===================================================
-0
-===================================================
-0
-0
-===================================================
-0
-1000
-===================================================
-1000
-===================================================
-1000
-===================================================
-1000
-===================================================
-1000
-===================================================
-1000
-===================================================
-1000
-===================================================
-0
-===================================================
-0
-===================================================
-0
-===================================================
-col_a    col_b    
-1     -1     
-1001     -1     
-2001     -1     
-3001     -1     
+set trace on;
 
-===================================================
-trace    
+/* dummy data */
+drop table if exists dummy;
+create table dummy (col_a int);
+insert into dummy
+select rownum from
+table ({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
+table ({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
+table ({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
 
-Query Plan:
-  TABLE SCAN (c)
+/* ----------------------------------------
+ *
+ * test case 6
+ *   - child c (parent_col_a:not_null)
+ *   - parent p (super_parent_col_a:not null) (c:parent_col_a->p:col_a)
+ *   - super parent s (p:super_parent_col_a->s:col_a)
+ *
+ * ---------------------------------------- */
 
-  rewritten query: select c.col_a, c.col_b from [dba.t_child] c where c.col_b= ?:? 
+drop table if exists t_child;
+drop table if exists t_parent;
+drop table if exists t_super_parent;
+create table t_super_parent (col_a int primary key, col_b int);
+create table t_parent (col_a int primary key auto_increment, col_b int);
+alter table t_parent add column super_parent_col_a int not null references t_super_parent (col_a); /* not_null */
+create table t_child (col_a int auto_increment primary key, col_b int);
+alter table t_child add column parent_col_a int not null references t_parent (col_a); /* not_null */
+insert into t_super_parent select col_a, col_a from dummy;
+insert into t_parent select null, (col_a * -1), col_a from dummy;
+insert into t_parent select null, (col_a * -1), col_a from dummy;
+insert into t_child select null, (col_a * -1), col_a from dummy;
+insert into t_child select null, (col_a * -1), col_a from dummy;
+insert into t_child select null, (col_a * -1), col_a from dummy;
+insert into t_child select null, (col_a * -1), col_a from dummy;
 
-Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.t_child), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-     
+update statistics on t_child with fullscan;
+update statistics on t_parent with fullscan;
+update statistics on t_super_parent with fullscan;
 
-===================================================
-col_a    col_b    
-1     -1     
-1001     -1     
-2001     -1     
-3001     -1     
+/* ansi‑style */
+select /*+ recompile */
+    c.col_a,
+    c.col_b
+from
+    t_child as c
+    inner join t_parent as p on c.parent_col_a = p.col_a
+    inner join t_super_parent as s on p.super_parent_col_a = s.col_a
+where
+    c.col_b = -1
+order by
+    c.col_a;
+show trace;
 
-===================================================
-trace    
+select /*+ recompile */
+    c.col_a,
+    c.col_b
+from
+    t_child as c,
+    t_parent as p,
+    t_super_parent as s
+where
+    c.parent_col_a = p.col_a
+    and p.super_parent_col_a = s.col_a
+    and c.col_b = -1
+order by
+    c.col_a;
+show trace;
 
-Query Plan:
-  TABLE SCAN (c)
 
-  rewritten query: select c.col_a, c.col_b from [dba.t_child] c where c.col_b= ?:? 
+drop table if exists t_child;
+drop table if exists t_parent;
+drop table if exists t_super_parent;
 
-Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.t_child), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-     
 
-===================================================
-0
-===================================================
-0
-===================================================
-0
-===================================================
-0
-===================================================
-0
+drop table if exists dummy;
+
+set trace off;

--- a/sql/_34_fig/cbrd_24252/answers/cbrd_24252_6.answer
+++ b/sql/_34_fig/cbrd_24252/answers/cbrd_24252_6.answer
@@ -1,78 +1,96 @@
-set trace on;
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+1000
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+0
+===================================================
+0
+1000
+===================================================
+1000
+===================================================
+1000
+===================================================
+1000
+===================================================
+1000
+===================================================
+1000
+===================================================
+1000
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+col_a    col_b    
+1     -1     
+1001     -1     
+2001     -1     
+3001     -1     
 
-/* dummy data */
-drop table if exists dummy;
-create table dummy (col_a int);
-insert into dummy
-select rownum from
-table ({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
-table ({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
-table ({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+===================================================
+trace    
 
-/* ----------------------------------------
- *
- * test case 6
- *   - child c (parent_col_a:not_null)
- *   - parent p (super_parent_col_a:not null) (c:parent_col_a->p:col_a)
- *   - super parent s (p:super_parent_col_a->s:col_a)
- *
- * ---------------------------------------- */
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (c)
 
-drop table if exists t_child;
-drop table if exists t_parent;
-drop table if exists t_super_parent;
-create table t_super_parent (col_a int primary key, col_b int);
-create table t_parent (col_a int primary key auto_increment, col_b int);
-alter table t_parent add column super_parent_col_a int not null references t_super_parent (col_a); /* not_null */
-create table t_child (col_a int auto_increment primary key, col_b int);
-alter table t_child add column parent_col_a int not null references t_parent (col_a); /* not_null */
-insert into t_super_parent select col_a, col_a from dummy;
-insert into t_parent select null, (col_a * -1), col_a from dummy;
-insert into t_parent select null, (col_a * -1), col_a from dummy;
-insert into t_child select null, (col_a * -1), col_a from dummy;
-insert into t_child select null, (col_a * -1), col_a from dummy;
-insert into t_child select null, (col_a * -1), col_a from dummy;
-insert into t_child select null, (col_a * -1), col_a from dummy;
+  rewritten query: select c.col_a, c.col_b from [dba.t_child] c where c.col_b= ?:?  order by ?
 
-update statistics on t_child with fullscan;
-update statistics on t_parent with fullscan;
-update statistics on t_super_parent with fullscan;
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.t_child), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
 
-/* ansi‑style */
-select /*+ recompile */
-    c.col_a,
-    c.col_b
-from
-    t_child as c
-    inner join t_parent as p on c.parent_col_a = p.col_a
-    inner join t_super_parent as s on p.super_parent_col_a = s.col_a
-where
-    c.col_b = -1
-order by
-    c.col_a;
-show trace;
+===================================================
+col_a    col_b    
+1     -1     
+1001     -1     
+2001     -1     
+3001     -1     
 
-select /*+ recompile */
-    c.col_a,
-    c.col_b
-from
-    t_child as c,
-    t_parent as p,
-    t_super_parent as s
-where
-    c.parent_col_a = p.col_a
-    and p.super_parent_col_a = s.col_a
-    and c.col_b = -1
-order by
-    c.col_a;
-show trace;
+===================================================
+trace    
 
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (c)
 
-drop table if exists t_child;
-drop table if exists t_parent;
-drop table if exists t_super_parent;
+  rewritten query: select c.col_a, c.col_b from [dba.t_child] c where c.col_b= ?:?  order by ?
 
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.t_child), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
 
-drop table if exists dummy;
-
-set trace off;
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0

--- a/sql/_34_fig/cbrd_24252/cases/cbrd_24252_6.sql
+++ b/sql/_34_fig/cbrd_24252/cases/cbrd_24252_6.sql
@@ -47,7 +47,9 @@ from
     inner join t_parent as p on c.parent_col_a = p.col_a
     inner join t_super_parent as s on p.super_parent_col_a = s.col_a
 where
-    c.col_b = -1;
+    c.col_b = -1
+order by
+    col_a;
 show trace;
 
 select /*+ recompile */
@@ -60,7 +62,9 @@ from
 where
     c.parent_col_a = p.col_a
     and p.super_parent_col_a = s.col_a
-    and c.col_b = -1;
+    and c.col_b = -1
+order by
+    col_a;
 show trace;
 
 

--- a/sql/_34_fig/cbrd_24252/cases/cbrd_24252_6.sql
+++ b/sql/_34_fig/cbrd_24252/cases/cbrd_24252_6.sql
@@ -49,7 +49,7 @@ from
 where
     c.col_b = -1
 order by
-    col_a;
+    c.col_a;
 show trace;
 
 select /*+ recompile */
@@ -64,7 +64,7 @@ where
     and p.super_parent_col_a = s.col_a
     and c.col_b = -1
 order by
-    col_a;
+    c.col_a;
 show trace;
 
 


### PR DESCRIPTION
특정 이슈와 관계 없이 
TC sql/_34_fig/cbrd_24252/cases/cbrd_24252_6.sql 안의 select 문 결과의 순서가 임의로 바뀌는 것을 막기 위해 
ORDER BY 절을 추가한 것입니다. 

엔진 PR https://github.com/CUBRID/cubrid/pull/5566 의 머지를 막고 있습니다. 