### PR TITLE
[CBRD-25673] Fixed an issue where an error message was displayed differently when selecting a non-existent stored procedure that includes [user_schema], and modified the related test cases.

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-01_param_to_variable_DATETIME.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-01_param_to_variable_DATETIME.answer
@@ -57,7 +57,7 @@ VAR DATETIME := param ;
 VAR1 DATETIME  ;
 begin
 VAR1 := ...'
-Unsupported argument type 'datetimetz' of the stored procedure create or replace procedure [dba.t_datetimetz_datetime](para...
+Unsupported argument type 'datetimetz' of the stored procedure create or replace procedure [dba.t_DATETIMETZ_DATETIME](para...
 
 ===================================================
 Error:-495

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-01_variable_to_return_DATETIME.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-01_variable_to_return_DATETIME.answer
@@ -38,7 +38,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_DATETIME('DATETIMELTZ', 'DATETIME', d...'
-Function t_DATETIMELTZ_DATETIME is undefined or given wrong number of parameter. select t_DATETIMELTZ_DATETIME('DATETIMELTZ', 'DATETIME', dat...
+Function t_datetimeltz_datetime is undefined or given wrong number of parameter. select t_DATETIMELTZ_DATETIME('DATETIMELTZ', 'DATETIME', dat...
 
 ===================================================
 Error:-894
@@ -56,13 +56,13 @@ Semantic: before '  ) RETURN DATETIME IS
 VAR DATETIMETZ  ;
 begin
 VAR := param_va...'
-Unsupported argument type 'datetimetz' of the stored procedure create or replace function [dba.t_datetimetz_datetime](varia...
+Unsupported argument type 'datetimetz' of the stored procedure create or replace function [dba.t_DATETIMETZ_DATETIME](varia...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_DATETIME('DATETIMETZ', 'DATETIME', dat...'
-Function t_DATETIMETZ_DATETIME is undefined or given wrong number of parameter. select t_DATETIMETZ_DATETIME('DATETIMETZ', 'DATETIME', datet...
+Function t_datetimetz_datetime is undefined or given wrong number of parameter. select t_DATETIMETZ_DATETIME('DATETIMETZ', 'DATETIME', datet...
 
 ===================================================
 Error:-894
@@ -102,7 +102,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_DATETIME('TIME', 'DATETIME', TIME'13:15:45' ...'
-Function t_TIME_DATETIME is undefined or given wrong number of parameter. select t_TIME_DATETIME('TIME', 'DATETIME', time '13:15:45'),...
+Function t_time_datetime is undefined or given wrong number of parameter. select t_TIME_DATETIME('TIME', 'DATETIME', time '13:15:45'),...
 
 ===================================================
 Error:-894
@@ -145,7 +145,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_DATETIME('TIMESTAMPLTZ', 'DATETIME',...'
-Function t_TIMESTAMPLTZ_DATETIME is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_DATETIME('TIMESTAMPLTZ', 'DATETIME', t...
+Function t_timestampltz_datetime is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_DATETIME('TIMESTAMPLTZ', 'DATETIME', t...
 
 ===================================================
 Error:-894
@@ -169,7 +169,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_DATETIME('TIMESTAMPTZ', 'DATETIME', t...'
-Function t_TIMESTAMPTZ_DATETIME is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_DATETIME('TIMESTAMPTZ', 'DATETIME', tim...
+Function t_timestamptz_datetime is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_DATETIME('TIMESTAMPTZ', 'DATETIME', tim...
 
 ===================================================
 Error:-894
@@ -190,7 +190,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DOUBLE_DATETIME('DOUBLE', 'DATETIME', cast( 1234....'
-Function t_DOUBLE_DATETIME is undefined or given wrong number of parameter. select t_DOUBLE_DATETIME('DOUBLE', 'DATETIME',  cast(1234.56...
+Function t_double_datetime is undefined or given wrong number of parameter. select t_DOUBLE_DATETIME('DOUBLE', 'DATETIME',  cast(1234.56...
 
 ===================================================
 Error:-894
@@ -211,7 +211,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_FLOAT_DATETIME('FLOAT', 'DATETIME', cast( 16777.2...'
-Function t_FLOAT_DATETIME is undefined or given wrong number of parameter. select t_FLOAT_DATETIME('FLOAT', 'DATETIME',  cast(16777.217...
+Function t_float_datetime is undefined or given wrong number of parameter. select t_FLOAT_DATETIME('FLOAT', 'DATETIME',  cast(16777.217...
 
 ===================================================
 Error:-894
@@ -232,7 +232,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_NUMERIC_DATETIME('NUMERIC(8,4)', 'DATETIME', cast...'
-Function t_NUMERIC_DATETIME is undefined or given wrong number of parameter. select t_NUMERIC_DATETIME('NUMERIC(8,4)', 'DATETIME',  cast(...
+Function t_numeric_datetime is undefined or given wrong number of parameter. select t_NUMERIC_DATETIME('NUMERIC(8,4)', 'DATETIME',  cast(...
 
 ===================================================
 Error:-894
@@ -253,7 +253,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_BIGINT_DATETIME('BIGINT', 'DATETIME', cast( 34589...'
-Function t_BIGINT_DATETIME is undefined or given wrong number of parameter. select t_BIGINT_DATETIME('BIGINT', 'DATETIME',  cast(3458901...
+Function t_bigint_datetime is undefined or given wrong number of parameter. select t_BIGINT_DATETIME('BIGINT', 'DATETIME',  cast(3458901...
 
 ===================================================
 Error:-894
@@ -274,7 +274,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_INT_DATETIME('INT', 'DATETIME', cast( 782346 as i...'
-Function t_INT_DATETIME is undefined or given wrong number of parameter. select t_INT_DATETIME('INT', 'DATETIME',  cast(782346 as int...
+Function t_int_datetime is undefined or given wrong number of parameter. select t_INT_DATETIME('INT', 'DATETIME',  cast(782346 as int...
 
 ===================================================
 Error:-894
@@ -295,7 +295,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_SHORT_DATETIME('SHORT', 'DATETIME', cast( 8934 as...'
-Function t_SHORT_DATETIME is undefined or given wrong number of parameter. select t_SHORT_DATETIME('SHORT', 'DATETIME',  cast(8934 as s...
+Function t_short_datetime is undefined or given wrong number of parameter. select t_SHORT_DATETIME('SHORT', 'DATETIME',  cast(8934 as s...
 
 ===================================================
 Error:-894
@@ -319,7 +319,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_DATETIME('BIT(8)', 'DATETIME', 0xaa ) ) ; '
-Function t_BIT_DATETIME is undefined or given wrong number of parameter. select t_BIT_DATETIME('BIT(8)', 'DATETIME', X'aa'),  typeof(...
+Function t_bit_datetime is undefined or given wrong number of parameter. select t_BIT_DATETIME('BIT(8)', 'DATETIME', X'aa'),  typeof(...
 
 ===================================================
 Error:-894
@@ -343,7 +343,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_DATE
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_DATETIME('BIT VARYING', 'DATETIME', 0x...'
-Function t_BITVARYING_DATETIME is undefined or given wrong number of parameter. select t_BITVARYING_DATETIME('BIT VARYING', 'DATETIME', X'aa...
+Function t_bitvarying_datetime is undefined or given wrong number of parameter. select t_BITVARYING_DATETIME('BIT VARYING', 'DATETIME', X'aa...
 
 ===================================================
 Error:-894
@@ -402,7 +402,7 @@ Stored procedure compile error: no viable alternative at input 'VAR SET'
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_DATETIME('SET', 'DATETIME', {'c','c','c','b',...'
-Function t_SET_DATETIME is undefined or given wrong number of parameter. select t_SET_DATETIME('SET', 'DATETIME'),  typeof(t_SET_DATE...
+Function t_set_datetime is undefined or given wrong number of parameter. select t_SET_DATETIME('SET', 'DATETIME'),  typeof(t_SET_DATE...
 
 ===================================================
 Error:-894
@@ -423,7 +423,7 @@ Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_DATETIME('MULTISET', 'DATETIME', {'c','c...'
-Function t_MULTISET_DATETIME is undefined or given wrong number of parameter. select t_MULTISET_DATETIME('MULTISET', 'DATETIME'),  typeof(...
+Function t_multiset_datetime is undefined or given wrong number of parameter. select t_MULTISET_DATETIME('MULTISET', 'DATETIME'),  typeof(...
 
 ===================================================
 Error:-894
@@ -444,7 +444,7 @@ Stored procedure compile error: no viable alternative at input 'VAR LIST'
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_DATETIME('LIST', 'DATETIME', {'c','c','c','b...'
-Function t_LIST_DATETIME is undefined or given wrong number of parameter. select t_LIST_DATETIME('LIST', 'DATETIME'),  typeof(t_LIST_D...
+Function t_list_datetime is undefined or given wrong number of parameter. select t_LIST_DATETIME('LIST', 'DATETIME'),  typeof(t_LIST_D...
 
 ===================================================
 Error:-894
@@ -465,7 +465,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_DATETIME('ENUM', 'DATETIME', 'yellow' ) ) ; '
-Function t_ENUM_DATETIME is undefined or given wrong number of parameter. select t_ENUM_DATETIME('ENUM', 'DATETIME', 'yellow'),  typeo...
+Function t_enum_datetime is undefined or given wrong number of parameter. select t_ENUM_DATETIME('ENUM', 'DATETIME', 'yellow'),  typeo...
 
 ===================================================
 Error:-894
@@ -490,7 +490,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_DATETIME('BLOB', 'DATETIME', BIT_TO_BLOB(X'0...'
-Function t_BLOB_DATETIME is undefined or given wrong number of parameter. select t_BLOB_DATETIME('BLOB', 'DATETIME',  bit_to_blob(X'00...
+Function t_blob_datetime is undefined or given wrong number of parameter. select t_BLOB_DATETIME('BLOB', 'DATETIME',  bit_to_blob(X'00...
 
 ===================================================
 Error:-894
@@ -515,7 +515,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_DATETIME('CLOB', 'DATETIME', CHAR_TO_CLOB('T...'
-Function t_CLOB_DATETIME is undefined or given wrong number of parameter. select t_CLOB_DATETIME('CLOB', 'DATETIME',  char_to_clob('Th...
+Function t_clob_datetime is undefined or given wrong number of parameter. select t_CLOB_DATETIME('CLOB', 'DATETIME',  char_to_clob('Th...
 
 ===================================================
 Error:-894
@@ -540,7 +540,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_DATETIME('JSON', 'DATETIME', '{"a":1}' ) ) ; '
-Function t_JSON_DATETIME is undefined or given wrong number of parameter. select t_JSON_DATETIME('JSON', 'DATETIME', '{"a":1}'),  type...
+Function t_json_datetime is undefined or given wrong number of parameter. select t_JSON_DATETIME('JSON', 'DATETIME', '{"a":1}'),  type...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-02_variable_to_return_DATETIMELTZ.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-02_variable_to_return_DATETIMELTZ.answer
@@ -15,7 +15,7 @@ Semantic: Unsupported return type 'datetimeltz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_DATETIMELTZ('DATETIME', 'DATETIMELTZ', D...'
-Function t_DATETIME_DATETIMELTZ is undefined or given wrong number of parameter. select t_DATETIME_DATETIMELTZ('DATETIME', 'DATETIMELTZ', dat...
+Function t_datetime_datetimeltz is undefined or given wrong number of parameter. select t_DATETIME_DATETIMELTZ('DATETIME', 'DATETIMELTZ', dat...
 
 ===================================================
 Error:-894
@@ -39,7 +39,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_DATETIMELTZ('DATETIMELTZ', 'DATETIMEL...'
-Function t_DATETIMELTZ_DATETIMELTZ is undefined or given wrong number of parameter. select t_DATETIMELTZ_DATETIMELTZ('DATETIMELTZ', 'DATETIMELTZ...
+Function t_datetimeltz_datetimeltz is undefined or given wrong number of parameter. select t_DATETIMELTZ_DATETIMELTZ('DATETIMELTZ', 'DATETIMELTZ...
 
 ===================================================
 Error:-894
@@ -63,7 +63,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_DATETIMELTZ('DATETIMETZ', 'DATETIMELTZ...'
-Function t_DATETIMETZ_DATETIMELTZ is undefined or given wrong number of parameter. select t_DATETIMETZ_DATETIMELTZ('DATETIMETZ', 'DATETIMELTZ',...
+Function t_datetimetz_datetimeltz is undefined or given wrong number of parameter. select t_DATETIMETZ_DATETIMELTZ('DATETIMETZ', 'DATETIMELTZ',...
 
 ===================================================
 Error:-894
@@ -83,7 +83,7 @@ Semantic: Unsupported return type 'datetimeltz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_DATETIMELTZ('DATE', 'DATETIMELTZ', DATE'2008...'
-Function t_DATE_DATETIMELTZ is undefined or given wrong number of parameter. select t_DATE_DATETIMELTZ('DATE', 'DATETIMELTZ', date '2008-...
+Function t_date_datetimeltz is undefined or given wrong number of parameter. select t_DATE_DATETIMELTZ('DATE', 'DATETIMELTZ', date '2008-...
 
 ===================================================
 Error:-894
@@ -103,7 +103,7 @@ Semantic: Unsupported return type 'datetimeltz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_DATETIMELTZ('TIME', 'DATETIMELTZ', TIME'13:1...'
-Function t_TIME_DATETIMELTZ is undefined or given wrong number of parameter. select t_TIME_DATETIMELTZ('TIME', 'DATETIMELTZ', time '13:15...
+Function t_time_datetimeltz is undefined or given wrong number of parameter. select t_TIME_DATETIMELTZ('TIME', 'DATETIMELTZ', time '13:15...
 
 ===================================================
 Error:-894
@@ -123,7 +123,7 @@ Semantic: Unsupported return type 'datetimeltz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_DATETIMELTZ('TIMESTAMP', 'DATETIMELTZ',...'
-Function t_TIMESTAMP_DATETIMELTZ is undefined or given wrong number of parameter. select t_TIMESTAMP_DATETIMELTZ('TIMESTAMP', 'DATETIMELTZ', t...
+Function t_timestamp_datetimeltz is undefined or given wrong number of parameter. select t_TIMESTAMP_DATETIMELTZ('TIMESTAMP', 'DATETIMELTZ', t...
 
 ===================================================
 Error:-894
@@ -147,7 +147,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_DATETIMELTZ('TIMESTAMPLTZ', 'DATETIM...'
-Function t_TIMESTAMPLTZ_DATETIMELTZ is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_DATETIMELTZ('TIMESTAMPLTZ', 'DATETIMEL...
+Function t_timestampltz_datetimeltz is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_DATETIMELTZ('TIMESTAMPLTZ', 'DATETIMEL...
 
 ===================================================
 Error:-894
@@ -171,7 +171,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_DATETIMELTZ('TIMESTAMPTZ', 'DATETIMEL...'
-Function t_TIMESTAMPTZ_DATETIMELTZ is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_DATETIMELTZ('TIMESTAMPTZ', 'DATETIMELTZ...
+Function t_timestamptz_datetimeltz is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_DATETIMELTZ('TIMESTAMPTZ', 'DATETIMELTZ...
 
 ===================================================
 Error:-894
@@ -191,7 +191,7 @@ Semantic: Unsupported return type 'datetimeltz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_DOUBLE_DATETIMELTZ('DOUBLE', 'DATETIMELTZ', cast(...'
-Function t_DOUBLE_DATETIMELTZ is undefined or given wrong number of parameter. select t_DOUBLE_DATETIMELTZ('DOUBLE', 'DATETIMELTZ',  cast(1...
+Function t_double_datetimeltz is undefined or given wrong number of parameter. select t_DOUBLE_DATETIMELTZ('DOUBLE', 'DATETIMELTZ',  cast(1...
 
 ===================================================
 Error:-894
@@ -211,7 +211,7 @@ Semantic: Unsupported return type 'datetimeltz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_FLOAT_DATETIMELTZ('FLOAT', 'DATETIMELTZ', cast( 1...'
-Function t_FLOAT_DATETIMELTZ is undefined or given wrong number of parameter. select t_FLOAT_DATETIMELTZ('FLOAT', 'DATETIMELTZ',  cast(167...
+Function t_float_datetimeltz is undefined or given wrong number of parameter. select t_FLOAT_DATETIMELTZ('FLOAT', 'DATETIMELTZ',  cast(167...
 
 ===================================================
 Error:-894
@@ -231,7 +231,7 @@ Semantic: Unsupported return type 'datetimeltz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_NUMERIC_DATETIMELTZ('NUMERIC(8,4)', 'DATETIMELTZ'...'
-Function t_NUMERIC_DATETIMELTZ is undefined or given wrong number of parameter. select t_NUMERIC_DATETIMELTZ('NUMERIC(8,4)', 'DATETIMELTZ', ...
+Function t_numeric_datetimeltz is undefined or given wrong number of parameter. select t_NUMERIC_DATETIMELTZ('NUMERIC(8,4)', 'DATETIMELTZ', ...
 
 ===================================================
 Error:-894
@@ -251,7 +251,7 @@ Semantic: Unsupported return type 'datetimeltz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_BIGINT_DATETIMELTZ('BIGINT', 'DATETIMELTZ', cast(...'
-Function t_BIGINT_DATETIMELTZ is undefined or given wrong number of parameter. select t_BIGINT_DATETIMELTZ('BIGINT', 'DATETIMELTZ',  cast(3...
+Function t_bigint_datetimeltz is undefined or given wrong number of parameter. select t_BIGINT_DATETIMELTZ('BIGINT', 'DATETIMELTZ',  cast(3...
 
 ===================================================
 Error:-894
@@ -271,7 +271,7 @@ Semantic: Unsupported return type 'datetimeltz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_INT_DATETIMELTZ('INT', 'DATETIMELTZ', cast( 78234...'
-Function t_INT_DATETIMELTZ is undefined or given wrong number of parameter. select t_INT_DATETIMELTZ('INT', 'DATETIMELTZ',  cast(782346 ...
+Function t_int_datetimeltz is undefined or given wrong number of parameter. select t_INT_DATETIMELTZ('INT', 'DATETIMELTZ',  cast(782346 ...
 
 ===================================================
 Error:-894
@@ -291,7 +291,7 @@ Semantic: Unsupported return type 'datetimeltz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_SHORT_DATETIMELTZ('SHORT', 'DATETIMELTZ', cast( 8...'
-Function t_SHORT_DATETIMELTZ is undefined or given wrong number of parameter. select t_SHORT_DATETIMELTZ('SHORT', 'DATETIMELTZ',  cast(893...
+Function t_short_datetimeltz is undefined or given wrong number of parameter. select t_SHORT_DATETIMELTZ('SHORT', 'DATETIMELTZ',  cast(893...
 
 ===================================================
 Error:-894
@@ -315,7 +315,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_DATETIMELTZ('BIT(8)', 'DATETIMELTZ', 0xaa ) ) ; '
-Function t_BIT_DATETIMELTZ is undefined or given wrong number of parameter. select t_BIT_DATETIMELTZ('BIT(8)', 'DATETIMELTZ', X'aa'),  t...
+Function t_bit_datetimeltz is undefined or given wrong number of parameter. select t_BIT_DATETIMELTZ('BIT(8)', 'DATETIMELTZ', X'aa'),  t...
 
 ===================================================
 Error:-894
@@ -339,7 +339,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_DATE
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_DATETIMELTZ('BIT VARYING', 'DATETIMELT...'
-Function t_BITVARYING_DATETIMELTZ is undefined or given wrong number of parameter. select t_BITVARYING_DATETIMELTZ('BIT VARYING', 'DATETIMELTZ'...
+Function t_bitvarying_datetimeltz is undefined or given wrong number of parameter. select t_BITVARYING_DATETIMELTZ('BIT VARYING', 'DATETIMELTZ'...
 
 ===================================================
 Error:-894
@@ -359,7 +359,7 @@ Semantic: Unsupported return type 'datetimeltz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_CHAR_DATETIMELTZ('CHAR', 'DATETIMELTZ', cast( '09...'
-Function t_CHAR_DATETIMELTZ is undefined or given wrong number of parameter. select t_CHAR_DATETIMELTZ('CHAR', 'DATETIMELTZ',  cast('09/0...
+Function t_char_datetimeltz is undefined or given wrong number of parameter. select t_CHAR_DATETIMELTZ('CHAR', 'DATETIMELTZ',  cast('09/0...
 
 ===================================================
 Error:-894
@@ -379,7 +379,7 @@ Semantic: Unsupported return type 'datetimeltz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_VARCHAR_DATETIMELTZ('VARCHAR', 'DATETIMELTZ', cas...'
-Function t_VARCHAR_DATETIMELTZ is undefined or given wrong number of parameter. select t_VARCHAR_DATETIMELTZ('VARCHAR', 'DATETIMELTZ',  cast...
+Function t_varchar_datetimeltz is undefined or given wrong number of parameter. select t_VARCHAR_DATETIMELTZ('VARCHAR', 'DATETIMELTZ',  cast...
 
 ===================================================
 Error:-894
@@ -399,7 +399,7 @@ Semantic: Unsupported return type 'datetimeltz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_DATETIMELTZ('SET', 'DATETIMELTZ', {'c','c','c...'
-Function t_SET_DATETIMELTZ is undefined or given wrong number of parameter. select t_SET_DATETIMELTZ('SET', 'DATETIMELTZ'),  typeof(t_SE...
+Function t_set_datetimeltz is undefined or given wrong number of parameter. select t_SET_DATETIMELTZ('SET', 'DATETIMELTZ'),  typeof(t_SE...
 
 ===================================================
 Error:-894
@@ -419,7 +419,7 @@ Semantic: Unsupported return type 'datetimeltz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_DATETIMELTZ('MULTISET', 'DATETIMELTZ', {...'
-Function t_MULTISET_DATETIMELTZ is undefined or given wrong number of parameter. select t_MULTISET_DATETIMELTZ('MULTISET', 'DATETIMELTZ'),  t...
+Function t_multiset_datetimeltz is undefined or given wrong number of parameter. select t_MULTISET_DATETIMELTZ('MULTISET', 'DATETIMELTZ'),  t...
 
 ===================================================
 Error:-894
@@ -439,7 +439,7 @@ Semantic: Unsupported return type 'datetimeltz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_DATETIMELTZ('LIST', 'DATETIMELTZ', {'c','c',...'
-Function t_LIST_DATETIMELTZ is undefined or given wrong number of parameter. select t_LIST_DATETIMELTZ('LIST', 'DATETIMELTZ'),  typeof(t_...
+Function t_list_datetimeltz is undefined or given wrong number of parameter. select t_LIST_DATETIMELTZ('LIST', 'DATETIMELTZ'),  typeof(t_...
 
 ===================================================
 Error:-894
@@ -460,7 +460,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_DATETIMELTZ('ENUM', 'DATETIMELTZ', 'yellow' ...'
-Function t_ENUM_DATETIMELTZ is undefined or given wrong number of parameter. select t_ENUM_DATETIMELTZ('ENUM', 'DATETIMELTZ', 'yellow'), ...
+Function t_enum_datetimeltz is undefined or given wrong number of parameter. select t_ENUM_DATETIMELTZ('ENUM', 'DATETIMELTZ', 'yellow'), ...
 
 ===================================================
 Error:-894
@@ -484,7 +484,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_DATETIMELTZ('BLOB', 'DATETIMELTZ', BIT_TO_BL...'
-Function t_BLOB_DATETIMELTZ is undefined or given wrong number of parameter. select t_BLOB_DATETIMELTZ('BLOB', 'DATETIMELTZ',  bit_to_blo...
+Function t_blob_datetimeltz is undefined or given wrong number of parameter. select t_BLOB_DATETIMELTZ('BLOB', 'DATETIMELTZ',  bit_to_blo...
 
 ===================================================
 Error:-894
@@ -508,7 +508,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_DATETIMELTZ('CLOB', 'DATETIMELTZ', CHAR_TO_C...'
-Function t_CLOB_DATETIMELTZ is undefined or given wrong number of parameter. select t_CLOB_DATETIMELTZ('CLOB', 'DATETIMELTZ',  char_to_cl...
+Function t_clob_datetimeltz is undefined or given wrong number of parameter. select t_CLOB_DATETIMELTZ('CLOB', 'DATETIMELTZ',  char_to_cl...
 
 ===================================================
 Error:-894
@@ -532,7 +532,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_DATETIMELTZ('JSON', 'DATETIMELTZ', '{"a":1}'...'
-Function t_JSON_DATETIMELTZ is undefined or given wrong number of parameter. select t_JSON_DATETIMELTZ('JSON', 'DATETIMELTZ', '{"a":1}'),...
+Function t_json_datetimeltz is undefined or given wrong number of parameter. select t_JSON_DATETIMELTZ('JSON', 'DATETIMELTZ', '{"a":1}'),...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-03_variable_to_return_DATETIMETZ.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-03_variable_to_return_DATETIMETZ.answer
@@ -15,7 +15,7 @@ Semantic: Unsupported return type 'datetimetz' of the stored procedure create or
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_DATETIMETZ('DATETIME', 'DATETIMETZ', DAT...'
-Function t_DATETIME_DATETIMETZ is undefined or given wrong number of parameter. select t_DATETIME_DATETIMETZ('DATETIME', 'DATETIMETZ', datet...
+Function t_datetime_datetimetz is undefined or given wrong number of parameter. select t_DATETIME_DATETIMETZ('DATETIME', 'DATETIMETZ', datet...
 
 ===================================================
 Error:-894
@@ -39,7 +39,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_DATETIMETZ('DATETIMELTZ', 'DATETIMETZ...'
-Function t_DATETIMELTZ_DATETIMETZ is undefined or given wrong number of parameter. select t_DATETIMELTZ_DATETIMETZ('DATETIMELTZ', 'DATETIMETZ',...
+Function t_datetimeltz_datetimetz is undefined or given wrong number of parameter. select t_DATETIMELTZ_DATETIMETZ('DATETIMELTZ', 'DATETIMETZ',...
 
 ===================================================
 Error:-894
@@ -63,7 +63,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_DATETIMETZ('DATETIMETZ', 'DATETIMETZ',...'
-Function t_DATETIMETZ_DATETIMETZ is undefined or given wrong number of parameter. select t_DATETIMETZ_DATETIMETZ('DATETIMETZ', 'DATETIMETZ', d...
+Function t_datetimetz_datetimetz is undefined or given wrong number of parameter. select t_DATETIMETZ_DATETIMETZ('DATETIMETZ', 'DATETIMETZ', d...
 
 ===================================================
 Error:-894
@@ -83,7 +83,7 @@ Semantic: Unsupported return type 'datetimetz' of the stored procedure create or
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_DATETIMETZ('DATE', 'DATETIMETZ', DATE'2008-1...'
-Function t_DATE_DATETIMETZ is undefined or given wrong number of parameter. select t_DATE_DATETIMETZ('DATE', 'DATETIMETZ', date '2008-10...
+Function t_date_datetimetz is undefined or given wrong number of parameter. select t_DATE_DATETIMETZ('DATE', 'DATETIMETZ', date '2008-10...
 
 ===================================================
 Error:-894
@@ -103,7 +103,7 @@ Semantic: Unsupported return type 'datetimetz' of the stored procedure create or
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_DATETIMETZ('TIME', 'DATETIMETZ', TIME'13:15:...'
-Function t_TIME_DATETIMETZ is undefined or given wrong number of parameter. select t_TIME_DATETIMETZ('TIME', 'DATETIMETZ', time '13:15:4...
+Function t_time_datetimetz is undefined or given wrong number of parameter. select t_TIME_DATETIMETZ('TIME', 'DATETIMETZ', time '13:15:4...
 
 ===================================================
 Error:-894
@@ -123,7 +123,7 @@ Semantic: Unsupported return type 'datetimetz' of the stored procedure create or
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_DATETIMETZ('TIMESTAMP', 'DATETIMETZ', T...'
-Function t_TIMESTAMP_DATETIMETZ is undefined or given wrong number of parameter. select t_TIMESTAMP_DATETIMETZ('TIMESTAMP', 'DATETIMETZ', tim...
+Function t_timestamp_datetimetz is undefined or given wrong number of parameter. select t_TIMESTAMP_DATETIMETZ('TIMESTAMP', 'DATETIMETZ', tim...
 
 ===================================================
 Error:-894
@@ -147,7 +147,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_DATETIMETZ('TIMESTAMPLTZ', 'DATETIME...'
-Function t_TIMESTAMPLTZ_DATETIMETZ is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_DATETIMETZ('TIMESTAMPLTZ', 'DATETIMETZ...
+Function t_timestampltz_datetimetz is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_DATETIMETZ('TIMESTAMPLTZ', 'DATETIMETZ...
 
 ===================================================
 Error:-894
@@ -171,7 +171,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_DATETIMETZ('TIMESTAMPTZ', 'DATETIMETZ...'
-Function t_TIMESTAMPTZ_DATETIMETZ is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_DATETIMETZ('TIMESTAMPTZ', 'DATETIMETZ',...
+Function t_timestamptz_datetimetz is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_DATETIMETZ('TIMESTAMPTZ', 'DATETIMETZ',...
 
 ===================================================
 Error:-894
@@ -191,7 +191,7 @@ Semantic: Unsupported return type 'datetimetz' of the stored procedure create or
 Error:-494
 Semantic: before ' ,
 typeof( t_DOUBLE_DATETIMETZ('DOUBLE', 'DATETIMETZ', cast( 1...'
-Function t_DOUBLE_DATETIMETZ is undefined or given wrong number of parameter. select t_DOUBLE_DATETIMETZ('DOUBLE', 'DATETIMETZ',  cast(123...
+Function t_double_datetimetz is undefined or given wrong number of parameter. select t_DOUBLE_DATETIMETZ('DOUBLE', 'DATETIMETZ',  cast(123...
 
 ===================================================
 Error:-894
@@ -211,7 +211,7 @@ Semantic: Unsupported return type 'datetimetz' of the stored procedure create or
 Error:-494
 Semantic: before ' ,
 typeof( t_FLOAT_DATETIMETZ('FLOAT', 'DATETIMETZ', cast( 167...'
-Function t_FLOAT_DATETIMETZ is undefined or given wrong number of parameter. select t_FLOAT_DATETIMETZ('FLOAT', 'DATETIMETZ',  cast(16777...
+Function t_float_datetimetz is undefined or given wrong number of parameter. select t_FLOAT_DATETIMETZ('FLOAT', 'DATETIMETZ',  cast(16777...
 
 ===================================================
 Error:-894
@@ -231,7 +231,7 @@ Semantic: Unsupported return type 'datetimetz' of the stored procedure create or
 Error:-494
 Semantic: before ' ,
 typeof( t_NUMERIC_DATETIMETZ('NUMERIC(8,4)', 'DATETIMETZ', ...'
-Function t_NUMERIC_DATETIMETZ is undefined or given wrong number of parameter. select t_NUMERIC_DATETIMETZ('NUMERIC(8,4)', 'DATETIMETZ',  c...
+Function t_numeric_datetimetz is undefined or given wrong number of parameter. select t_NUMERIC_DATETIMETZ('NUMERIC(8,4)', 'DATETIMETZ',  c...
 
 ===================================================
 Error:-894
@@ -251,7 +251,7 @@ Semantic: Unsupported return type 'datetimetz' of the stored procedure create or
 Error:-494
 Semantic: before ' ,
 typeof( t_BIGINT_DATETIMETZ('BIGINT', 'DATETIMETZ', cast( 3...'
-Function t_BIGINT_DATETIMETZ is undefined or given wrong number of parameter. select t_BIGINT_DATETIMETZ('BIGINT', 'DATETIMETZ',  cast(345...
+Function t_bigint_datetimetz is undefined or given wrong number of parameter. select t_BIGINT_DATETIMETZ('BIGINT', 'DATETIMETZ',  cast(345...
 
 ===================================================
 Error:-894
@@ -271,7 +271,7 @@ Semantic: Unsupported return type 'datetimetz' of the stored procedure create or
 Error:-494
 Semantic: before ' ,
 typeof( t_INT_DATETIMETZ('INT', 'DATETIMETZ', cast( 782346 ...'
-Function t_INT_DATETIMETZ is undefined or given wrong number of parameter. select t_INT_DATETIMETZ('INT', 'DATETIMETZ',  cast(782346 as...
+Function t_int_datetimetz is undefined or given wrong number of parameter. select t_INT_DATETIMETZ('INT', 'DATETIMETZ',  cast(782346 as...
 
 ===================================================
 Error:-894
@@ -291,7 +291,7 @@ Semantic: Unsupported return type 'datetimetz' of the stored procedure create or
 Error:-494
 Semantic: before ' ,
 typeof( t_SHORT_DATETIMETZ('SHORT', 'DATETIMETZ', cast( 893...'
-Function t_SHORT_DATETIMETZ is undefined or given wrong number of parameter. select t_SHORT_DATETIMETZ('SHORT', 'DATETIMETZ',  cast(8934 ...
+Function t_short_datetimetz is undefined or given wrong number of parameter. select t_SHORT_DATETIMETZ('SHORT', 'DATETIMETZ',  cast(8934 ...
 
 ===================================================
 Error:-894
@@ -315,7 +315,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_DATETIMETZ('BIT(8)', 'DATETIMETZ', 0xaa ) ) ; '
-Function t_BIT_DATETIMETZ is undefined or given wrong number of parameter. select t_BIT_DATETIMETZ('BIT(8)', 'DATETIMETZ', X'aa'),  typ...
+Function t_bit_datetimetz is undefined or given wrong number of parameter. select t_BIT_DATETIMETZ('BIT(8)', 'DATETIMETZ', X'aa'),  typ...
 
 ===================================================
 Error:-894
@@ -339,7 +339,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_DATE
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_DATETIMETZ('BIT VARYING', 'DATETIMETZ'...'
-Function t_BITVARYING_DATETIMETZ is undefined or given wrong number of parameter. select t_BITVARYING_DATETIMETZ('BIT VARYING', 'DATETIMETZ', ...
+Function t_bitvarying_datetimetz is undefined or given wrong number of parameter. select t_BITVARYING_DATETIMETZ('BIT VARYING', 'DATETIMETZ', ...
 
 ===================================================
 Error:-894
@@ -359,7 +359,7 @@ Semantic: Unsupported return type 'datetimetz' of the stored procedure create or
 Error:-494
 Semantic: before ' ,
 typeof( t_CHAR_DATETIMETZ('CHAR', 'DATETIMETZ', cast( '09/0...'
-Function t_CHAR_DATETIMETZ is undefined or given wrong number of parameter. select t_CHAR_DATETIMETZ('CHAR', 'DATETIMETZ',  cast('09/01/...
+Function t_char_datetimetz is undefined or given wrong number of parameter. select t_CHAR_DATETIMETZ('CHAR', 'DATETIMETZ',  cast('09/01/...
 
 ===================================================
 Error:-894
@@ -379,7 +379,7 @@ Semantic: Unsupported return type 'datetimetz' of the stored procedure create or
 Error:-494
 Semantic: before ' ,
 typeof( t_VARCHAR_DATETIMETZ('VARCHAR', 'DATETIMETZ', cast(...'
-Function t_VARCHAR_DATETIMETZ is undefined or given wrong number of parameter. select t_VARCHAR_DATETIMETZ('VARCHAR', 'DATETIMETZ',  cast('...
+Function t_varchar_datetimetz is undefined or given wrong number of parameter. select t_VARCHAR_DATETIMETZ('VARCHAR', 'DATETIMETZ',  cast('...
 
 ===================================================
 Error:-894
@@ -399,7 +399,7 @@ Semantic: Unsupported return type 'datetimetz' of the stored procedure create or
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_DATETIMETZ('SET', 'DATETIMETZ', {'c','c','c',...'
-Function t_SET_DATETIMETZ is undefined or given wrong number of parameter. select t_SET_DATETIMETZ('SET', 'DATETIMETZ'),  typeof(t_SET_...
+Function t_set_datetimetz is undefined or given wrong number of parameter. select t_SET_DATETIMETZ('SET', 'DATETIMETZ'),  typeof(t_SET_...
 
 ===================================================
 Error:-894
@@ -419,7 +419,7 @@ Semantic: Unsupported return type 'datetimetz' of the stored procedure create or
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_DATETIMETZ('MULTISET', 'DATETIMETZ', {'c...'
-Function t_MULTISET_DATETIMETZ is undefined or given wrong number of parameter. select t_MULTISET_DATETIMETZ('MULTISET', 'DATETIMETZ'),  typ...
+Function t_multiset_datetimetz is undefined or given wrong number of parameter. select t_MULTISET_DATETIMETZ('MULTISET', 'DATETIMETZ'),  typ...
 
 ===================================================
 Error:-894
@@ -439,7 +439,7 @@ Semantic: Unsupported return type 'datetimetz' of the stored procedure create or
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_DATETIMETZ('LIST', 'DATETIMETZ', {'c','c','c...'
-Function t_LIST_DATETIMETZ is undefined or given wrong number of parameter. select t_LIST_DATETIMETZ('LIST', 'DATETIMETZ'),  typeof(t_LI...
+Function t_list_datetimetz is undefined or given wrong number of parameter. select t_LIST_DATETIMETZ('LIST', 'DATETIMETZ'),  typeof(t_LI...
 
 ===================================================
 Error:-894
@@ -460,7 +460,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_DATETIMETZ('ENUM', 'DATETIMETZ', 'yellow' ) ...'
-Function t_ENUM_DATETIMETZ is undefined or given wrong number of parameter. select t_ENUM_DATETIMETZ('ENUM', 'DATETIMETZ', 'yellow'),  t...
+Function t_enum_datetimetz is undefined or given wrong number of parameter. select t_ENUM_DATETIMETZ('ENUM', 'DATETIMETZ', 'yellow'),  t...
 
 ===================================================
 Error:-894
@@ -484,7 +484,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_DATETIMETZ('BLOB', 'DATETIMETZ', BIT_TO_BLOB...'
-Function t_BLOB_DATETIMETZ is undefined or given wrong number of parameter. select t_BLOB_DATETIMETZ('BLOB', 'DATETIMETZ',  bit_to_blob(...
+Function t_blob_datetimetz is undefined or given wrong number of parameter. select t_BLOB_DATETIMETZ('BLOB', 'DATETIMETZ',  bit_to_blob(...
 
 ===================================================
 Error:-894
@@ -508,7 +508,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_DATETIMETZ('CLOB', 'DATETIMETZ', CHAR_TO_CLO...'
-Function t_CLOB_DATETIMETZ is undefined or given wrong number of parameter. select t_CLOB_DATETIMETZ('CLOB', 'DATETIMETZ',  char_to_clob...
+Function t_clob_datetimetz is undefined or given wrong number of parameter. select t_CLOB_DATETIMETZ('CLOB', 'DATETIMETZ',  char_to_clob...
 
 ===================================================
 Error:-894
@@ -532,7 +532,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_DATETIMETZ('JSON', 'DATETIMETZ', '{"a":1}' )...'
-Function t_JSON_DATETIMETZ is undefined or given wrong number of parameter. select t_JSON_DATETIMETZ('JSON', 'DATETIMETZ', '{"a":1}'),  ...
+Function t_json_datetimetz is undefined or given wrong number of parameter. select t_JSON_DATETIMETZ('JSON', 'DATETIMETZ', '{"a":1}'),  ...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-04_variable_to_return_DATE.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-04_variable_to_return_DATE.answer
@@ -38,7 +38,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_DATE('DATETIMELTZ', 'DATE', datetimel...'
-Function t_DATETIMELTZ_DATE is undefined or given wrong number of parameter. select t_DATETIMELTZ_DATE('DATETIMELTZ', 'DATE', datetimeltz...
+Function t_datetimeltz_date is undefined or given wrong number of parameter. select t_DATETIMELTZ_DATE('DATETIMELTZ', 'DATE', datetimeltz...
 
 ===================================================
 Error:-894
@@ -62,7 +62,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_DATE('DATETIMETZ', 'DATE', datetimetz ...'
-Function t_DATETIMETZ_DATE is undefined or given wrong number of parameter. select t_DATETIMETZ_DATE('DATETIMETZ', 'DATE', datetimetz '0...
+Function t_datetimetz_date is undefined or given wrong number of parameter. select t_DATETIMETZ_DATE('DATETIMETZ', 'DATE', datetimetz '0...
 
 ===================================================
 Error:-894
@@ -102,7 +102,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_DATE('TIME', 'DATE', TIME'13:15:45' ) ) ; '
-Function t_TIME_DATE is undefined or given wrong number of parameter. select t_TIME_DATE('TIME', 'DATE', time '13:15:45'),  typeof...
+Function t_time_date is undefined or given wrong number of parameter. select t_TIME_DATE('TIME', 'DATE', time '13:15:45'),  typeof...
 
 ===================================================
 Error:-894
@@ -145,7 +145,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_DATE('TIMESTAMPLTZ', 'DATE', timesta...'
-Function t_TIMESTAMPLTZ_DATE is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_DATE('TIMESTAMPLTZ', 'DATE', timestamp...
+Function t_timestampltz_date is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_DATE('TIMESTAMPLTZ', 'DATE', timestamp...
 
 ===================================================
 Error:-894
@@ -169,7 +169,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_DATE('TIMESTAMPTZ', 'DATE', timestamp...'
-Function t_TIMESTAMPTZ_DATE is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_DATE('TIMESTAMPTZ', 'DATE', timestamptz...
+Function t_timestamptz_date is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_DATE('TIMESTAMPTZ', 'DATE', timestamptz...
 
 ===================================================
 Error:-894
@@ -190,7 +190,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DOUBLE_DATE('DOUBLE', 'DATE', cast( 1234.56789 as...'
-Function t_DOUBLE_DATE is undefined or given wrong number of parameter. select t_DOUBLE_DATE('DOUBLE', 'DATE',  cast(1234.56789 as d...
+Function t_double_date is undefined or given wrong number of parameter. select t_DOUBLE_DATE('DOUBLE', 'DATE',  cast(1234.56789 as d...
 
 ===================================================
 Error:-894
@@ -211,7 +211,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_FLOAT_DATE('FLOAT', 'DATE', cast( 16777.217 as fl...'
-Function t_FLOAT_DATE is undefined or given wrong number of parameter. select t_FLOAT_DATE('FLOAT', 'DATE',  cast(16777.217 as floa...
+Function t_float_date is undefined or given wrong number of parameter. select t_FLOAT_DATE('FLOAT', 'DATE',  cast(16777.217 as floa...
 
 ===================================================
 Error:-894
@@ -232,7 +232,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_NUMERIC_DATE('NUMERIC(8,4)', 'DATE', cast( 0.1234...'
-Function t_NUMERIC_DATE is undefined or given wrong number of parameter. select t_NUMERIC_DATE('NUMERIC(8,4)', 'DATE',  cast(0.123456...
+Function t_numeric_date is undefined or given wrong number of parameter. select t_NUMERIC_DATE('NUMERIC(8,4)', 'DATE',  cast(0.123456...
 
 ===================================================
 Error:-894
@@ -253,7 +253,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_BIGINT_DATE('BIGINT', 'DATE', cast( 34589012 as b...'
-Function t_BIGINT_DATE is undefined or given wrong number of parameter. select t_BIGINT_DATE('BIGINT', 'DATE',  cast(34589012 as big...
+Function t_bigint_date is undefined or given wrong number of parameter. select t_BIGINT_DATE('BIGINT', 'DATE',  cast(34589012 as big...
 
 ===================================================
 Error:-894
@@ -274,7 +274,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_INT_DATE('INT', 'DATE', cast( 782346 as int ) ) ) ; '
-Function t_INT_DATE is undefined or given wrong number of parameter. select t_INT_DATE('INT', 'DATE',  cast(782346 as integer)), ...
+Function t_int_date is undefined or given wrong number of parameter. select t_INT_DATE('INT', 'DATE',  cast(782346 as integer)), ...
 
 ===================================================
 Error:-894
@@ -295,7 +295,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_SHORT_DATE('SHORT', 'DATE', cast( 8934 as short )...'
-Function t_SHORT_DATE is undefined or given wrong number of parameter. select t_SHORT_DATE('SHORT', 'DATE',  cast(8934 as smallint)...
+Function t_short_date is undefined or given wrong number of parameter. select t_SHORT_DATE('SHORT', 'DATE',  cast(8934 as smallint)...
 
 ===================================================
 Error:-894
@@ -320,7 +320,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_DATE('BIT(8)', 'DATE', 0xaa ) ) ; '
-Function t_BIT_DATE is undefined or given wrong number of parameter. select t_BIT_DATE('BIT(8)', 'DATE', X'aa'),  typeof(t_BIT_DA...
+Function t_bit_date is undefined or given wrong number of parameter. select t_BIT_DATE('BIT(8)', 'DATE', X'aa'),  typeof(t_BIT_DA...
 
 ===================================================
 Error:-894
@@ -344,7 +344,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_DATE
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_DATE('BIT VARYING', 'DATE', 0xaa ) ) ; '
-Function t_BITVARYING_DATE is undefined or given wrong number of parameter. select t_BITVARYING_DATE('BIT VARYING', 'DATE', X'aa'),  typ...
+Function t_bitvarying_date is undefined or given wrong number of parameter. select t_BITVARYING_DATE('BIT VARYING', 'DATE', X'aa'),  typ...
 
 ===================================================
 Error:-894
@@ -401,7 +401,7 @@ Stored procedure compile error: no viable alternative at input 'VAR SET'
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_DATE('SET', 'DATE', {'c','c','c','b','b','a'}...'
-Function t_SET_DATE is undefined or given wrong number of parameter. select t_SET_DATE('SET', 'DATE'),  typeof(t_SET_DATE('SET', ...
+Function t_set_date is undefined or given wrong number of parameter. select t_SET_DATE('SET', 'DATE'),  typeof(t_SET_DATE('SET', ...
 
 ===================================================
 Error:-894
@@ -422,7 +422,7 @@ Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_DATE('MULTISET', 'DATE', {'c','c','c','b...'
-Function t_MULTISET_DATE is undefined or given wrong number of parameter. select t_MULTISET_DATE('MULTISET', 'DATE'),  typeof(t_MULTIS...
+Function t_multiset_date is undefined or given wrong number of parameter. select t_MULTISET_DATE('MULTISET', 'DATE'),  typeof(t_MULTIS...
 
 ===================================================
 Error:-894
@@ -443,7 +443,7 @@ Stored procedure compile error: no viable alternative at input 'VAR LIST'
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_DATE('LIST', 'DATE', {'c','c','c','b','b', '...'
-Function t_LIST_DATE is undefined or given wrong number of parameter. select t_LIST_DATE('LIST', 'DATE'),  typeof(t_LIST_DATE('LIS...
+Function t_list_date is undefined or given wrong number of parameter. select t_LIST_DATE('LIST', 'DATE'),  typeof(t_LIST_DATE('LIS...
 
 ===================================================
 Error:-894
@@ -464,7 +464,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_DATE('ENUM', 'DATE', 'yellow' ) ) ; '
-Function t_ENUM_DATE is undefined or given wrong number of parameter. select t_ENUM_DATE('ENUM', 'DATE', 'yellow'),  typeof(t_ENUM...
+Function t_enum_date is undefined or given wrong number of parameter. select t_ENUM_DATE('ENUM', 'DATE', 'yellow'),  typeof(t_ENUM...
 
 ===================================================
 Error:-894
@@ -489,7 +489,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_DATE('BLOB', 'DATE', BIT_TO_BLOB(X'000010') ...'
-Function t_BLOB_DATE is undefined or given wrong number of parameter. select t_BLOB_DATE('BLOB', 'DATE',  bit_to_blob(X'000010')),...
+Function t_blob_date is undefined or given wrong number of parameter. select t_BLOB_DATE('BLOB', 'DATE',  bit_to_blob(X'000010')),...
 
 ===================================================
 Error:-894
@@ -514,7 +514,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_DATE('CLOB', 'DATE', CHAR_TO_CLOB('This is a...'
-Function t_CLOB_DATE is undefined or given wrong number of parameter. select t_CLOB_DATE('CLOB', 'DATE',  char_to_clob('This is a ...
+Function t_clob_date is undefined or given wrong number of parameter. select t_CLOB_DATE('CLOB', 'DATE',  char_to_clob('This is a ...
 
 ===================================================
 Error:-894
@@ -539,7 +539,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_DATE('JSON', 'DATE', '{"a":1}' ) ) ; '
-Function t_JSON_DATE is undefined or given wrong number of parameter. select t_JSON_DATE('JSON', 'DATE', '{"a":1}'),  typeof(t_JSO...
+Function t_json_date is undefined or given wrong number of parameter. select t_JSON_DATE('JSON', 'DATE', '{"a":1}'),  typeof(t_JSO...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-05_variable_to_return_TIME.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-05_variable_to_return_TIME.answer
@@ -38,7 +38,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_TIME('DATETIMELTZ', 'TIME', datetimel...'
-Function t_DATETIMELTZ_TIME is undefined or given wrong number of parameter. select t_DATETIMELTZ_TIME('DATETIMELTZ', 'TIME', datetimeltz...
+Function t_datetimeltz_time is undefined or given wrong number of parameter. select t_DATETIMELTZ_TIME('DATETIMELTZ', 'TIME', datetimeltz...
 
 ===================================================
 Error:-894
@@ -62,7 +62,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_TIME('DATETIMETZ', 'TIME', datetimetz ...'
-Function t_DATETIMETZ_TIME is undefined or given wrong number of parameter. select t_DATETIMETZ_TIME('DATETIMETZ', 'TIME', datetimetz '0...
+Function t_datetimetz_time is undefined or given wrong number of parameter. select t_DATETIMETZ_TIME('DATETIMETZ', 'TIME', datetimetz '0...
 
 ===================================================
 Error:-894
@@ -83,7 +83,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_TIME('DATE', 'TIME', DATE'2008-10-31' ) ) ; '
-Function t_DATE_TIME is undefined or given wrong number of parameter. select t_DATE_TIME('DATE', 'TIME', date '2008-10-31'),  type...
+Function t_date_time is undefined or given wrong number of parameter. select t_DATE_TIME('DATE', 'TIME', date '2008-10-31'),  type...
 
 ===================================================
 Error:-894
@@ -145,7 +145,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_TIME('TIMESTAMPLTZ', 'TIME', timesta...'
-Function t_TIMESTAMPLTZ_TIME is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_TIME('TIMESTAMPLTZ', 'TIME', timestamp...
+Function t_timestampltz_time is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_TIME('TIMESTAMPLTZ', 'TIME', timestamp...
 
 ===================================================
 Error:-894
@@ -169,7 +169,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_TIME('TIMESTAMPTZ', 'TIME', timestamp...'
-Function t_TIMESTAMPTZ_TIME is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_TIME('TIMESTAMPTZ', 'TIME', timestamptz...
+Function t_timestamptz_time is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_TIME('TIMESTAMPTZ', 'TIME', timestamptz...
 
 ===================================================
 Error:-894
@@ -228,7 +228,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_NUMERIC_TIME('NUMERIC(8,4)', 'TIME', cast( 0.1234...'
-Function t_NUMERIC_TIME is undefined or given wrong number of parameter. select t_NUMERIC_TIME('NUMERIC(8,4)', 'TIME',  cast(0.123456...
+Function t_numeric_time is undefined or given wrong number of parameter. select t_NUMERIC_TIME('NUMERIC(8,4)', 'TIME',  cast(0.123456...
 
 ===================================================
 Error:-894
@@ -310,7 +310,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_TIME('BIT(8)', 'TIME', 0xaa ) ) ; '
-Function t_BIT_TIME is undefined or given wrong number of parameter. select t_BIT_TIME('BIT(8)', 'TIME', X'aa'),  typeof(t_BIT_TI...
+Function t_bit_time is undefined or given wrong number of parameter. select t_BIT_TIME('BIT(8)', 'TIME', X'aa'),  typeof(t_BIT_TI...
 
 ===================================================
 Error:-894
@@ -334,7 +334,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_TIME
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_TIME('BIT VARYING', 'TIME', 0xaa ) ) ; '
-Function t_BITVARYING_TIME is undefined or given wrong number of parameter. select t_BITVARYING_TIME('BIT VARYING', 'TIME', X'aa'),  typ...
+Function t_bitvarying_time is undefined or given wrong number of parameter. select t_BITVARYING_TIME('BIT VARYING', 'TIME', X'aa'),  typ...
 
 ===================================================
 Error:-894
@@ -391,7 +391,7 @@ Stored procedure compile error: no viable alternative at input 'VAR SET'
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_TIME('SET', 'TIME', {'c','c','c','b','b','a'}...'
-Function t_SET_TIME is undefined or given wrong number of parameter. select t_SET_TIME('SET', 'TIME'),  typeof(t_SET_TIME('SET', ...
+Function t_set_time is undefined or given wrong number of parameter. select t_SET_TIME('SET', 'TIME'),  typeof(t_SET_TIME('SET', ...
 
 ===================================================
 Error:-894
@@ -412,7 +412,7 @@ Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_TIME('MULTISET', 'TIME', {'c','c','c','b...'
-Function t_MULTISET_TIME is undefined or given wrong number of parameter. select t_MULTISET_TIME('MULTISET', 'TIME'),  typeof(t_MULTIS...
+Function t_multiset_time is undefined or given wrong number of parameter. select t_MULTISET_TIME('MULTISET', 'TIME'),  typeof(t_MULTIS...
 
 ===================================================
 Error:-894
@@ -433,7 +433,7 @@ Stored procedure compile error: no viable alternative at input 'VAR LIST'
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_TIME('LIST', 'TIME', {'c','c','c','b','b', '...'
-Function t_LIST_TIME is undefined or given wrong number of parameter. select t_LIST_TIME('LIST', 'TIME'),  typeof(t_LIST_TIME('LIS...
+Function t_list_time is undefined or given wrong number of parameter. select t_LIST_TIME('LIST', 'TIME'),  typeof(t_LIST_TIME('LIS...
 
 ===================================================
 Error:-894
@@ -454,7 +454,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_TIME('ENUM', 'TIME', 'yellow' ) ) ; '
-Function t_ENUM_TIME is undefined or given wrong number of parameter. select t_ENUM_TIME('ENUM', 'TIME', 'yellow'),  typeof(t_ENUM...
+Function t_enum_time is undefined or given wrong number of parameter. select t_ENUM_TIME('ENUM', 'TIME', 'yellow'),  typeof(t_ENUM...
 
 ===================================================
 Error:-894
@@ -479,7 +479,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_TIME('BLOB', 'TIME', BIT_TO_BLOB(X'000010') ...'
-Function t_BLOB_TIME is undefined or given wrong number of parameter. select t_BLOB_TIME('BLOB', 'TIME',  bit_to_blob(X'000010')),...
+Function t_blob_time is undefined or given wrong number of parameter. select t_BLOB_TIME('BLOB', 'TIME',  bit_to_blob(X'000010')),...
 
 ===================================================
 Error:-894
@@ -504,7 +504,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_TIME('CLOB', 'TIME', CHAR_TO_CLOB('This is a...'
-Function t_CLOB_TIME is undefined or given wrong number of parameter. select t_CLOB_TIME('CLOB', 'TIME',  char_to_clob('This is a ...
+Function t_clob_time is undefined or given wrong number of parameter. select t_CLOB_TIME('CLOB', 'TIME',  char_to_clob('This is a ...
 
 ===================================================
 Error:-894
@@ -529,7 +529,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_TIME('JSON', 'TIME', '{"a":1}' ) ) ; '
-Function t_JSON_TIME is undefined or given wrong number of parameter. select t_JSON_TIME('JSON', 'TIME', '{"a":1}'),  typeof(t_JSO...
+Function t_json_time is undefined or given wrong number of parameter. select t_JSON_TIME('JSON', 'TIME', '{"a":1}'),  typeof(t_JSO...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-06_variable_to_return_TIMESTAMP.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-06_variable_to_return_TIMESTAMP.answer
@@ -38,7 +38,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_TIMESTAMP('DATETIMELTZ', 'TIMESTAMP',...'
-Function t_DATETIMELTZ_TIMESTAMP is undefined or given wrong number of parameter. select t_DATETIMELTZ_TIMESTAMP('DATETIMELTZ', 'TIMESTAMP', d...
+Function t_datetimeltz_timestamp is undefined or given wrong number of parameter. select t_DATETIMELTZ_TIMESTAMP('DATETIMELTZ', 'TIMESTAMP', d...
 
 ===================================================
 Error:-894
@@ -62,7 +62,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_TIMESTAMP('DATETIMETZ', 'TIMESTAMP', d...'
-Function t_DATETIMETZ_TIMESTAMP is undefined or given wrong number of parameter. select t_DATETIMETZ_TIMESTAMP('DATETIMETZ', 'TIMESTAMP', dat...
+Function t_datetimetz_timestamp is undefined or given wrong number of parameter. select t_DATETIMETZ_TIMESTAMP('DATETIMETZ', 'TIMESTAMP', dat...
 
 ===================================================
 Error:-894
@@ -102,7 +102,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_TIMESTAMP('TIME', 'TIMESTAMP', TIME'13:15:45...'
-Function t_TIME_TIMESTAMP is undefined or given wrong number of parameter. select t_TIME_TIMESTAMP('TIME', 'TIMESTAMP', time '13:15:45'...
+Function t_time_timestamp is undefined or given wrong number of parameter. select t_TIME_TIMESTAMP('TIME', 'TIMESTAMP', time '13:15:45'...
 
 ===================================================
 Error:-894
@@ -145,7 +145,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_TIMESTAMP('TIMESTAMPLTZ', 'TIMESTAMP...'
-Function t_TIMESTAMPLTZ_TIMESTAMP is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_TIMESTAMP('TIMESTAMPLTZ', 'TIMESTAMP',...
+Function t_timestampltz_timestamp is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_TIMESTAMP('TIMESTAMPLTZ', 'TIMESTAMP',...
 
 ===================================================
 Error:-894
@@ -169,7 +169,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_TIMESTAMP('TIMESTAMPTZ', 'TIMESTAMP',...'
-Function t_TIMESTAMPTZ_TIMESTAMP is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_TIMESTAMP('TIMESTAMPTZ', 'TIMESTAMP', t...
+Function t_timestamptz_timestamp is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_TIMESTAMP('TIMESTAMPTZ', 'TIMESTAMP', t...
 
 ===================================================
 Error:-894
@@ -306,7 +306,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_TIMESTAMP('BIT(8)', 'TIMESTAMP', 0xaa ) ) ; '
-Function t_BIT_TIMESTAMP is undefined or given wrong number of parameter. select t_BIT_TIMESTAMP('BIT(8)', 'TIMESTAMP', X'aa'),  typeo...
+Function t_bit_timestamp is undefined or given wrong number of parameter. select t_BIT_TIMESTAMP('BIT(8)', 'TIMESTAMP', X'aa'),  typeo...
 
 ===================================================
 Error:-894
@@ -330,7 +330,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_TIME
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_TIMESTAMP('BIT VARYING', 'TIMESTAMP', ...'
-Function t_BITVARYING_TIMESTAMP is undefined or given wrong number of parameter. select t_BITVARYING_TIMESTAMP('BIT VARYING', 'TIMESTAMP', X'...
+Function t_bitvarying_timestamp is undefined or given wrong number of parameter. select t_BITVARYING_TIMESTAMP('BIT VARYING', 'TIMESTAMP', X'...
 
 ===================================================
 Error:-894
@@ -389,7 +389,7 @@ Stored procedure compile error: no viable alternative at input 'VAR SET'
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_TIMESTAMP('SET', 'TIMESTAMP', {'c','c','c','b...'
-Function t_SET_TIMESTAMP is undefined or given wrong number of parameter. select t_SET_TIMESTAMP('SET', 'TIMESTAMP'),  typeof(t_SET_TI...
+Function t_set_timestamp is undefined or given wrong number of parameter. select t_SET_TIMESTAMP('SET', 'TIMESTAMP'),  typeof(t_SET_TI...
 
 ===================================================
 Error:-894
@@ -410,7 +410,7 @@ Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_TIMESTAMP('MULTISET', 'TIMESTAMP', {'c',...'
-Function t_MULTISET_TIMESTAMP is undefined or given wrong number of parameter. select t_MULTISET_TIMESTAMP('MULTISET', 'TIMESTAMP'),  typeo...
+Function t_multiset_timestamp is undefined or given wrong number of parameter. select t_MULTISET_TIMESTAMP('MULTISET', 'TIMESTAMP'),  typeo...
 
 ===================================================
 Error:-894
@@ -431,7 +431,7 @@ Stored procedure compile error: no viable alternative at input 'VAR LIST'
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_TIMESTAMP('LIST', 'TIMESTAMP', {'c','c','c',...'
-Function t_LIST_TIMESTAMP is undefined or given wrong number of parameter. select t_LIST_TIMESTAMP('LIST', 'TIMESTAMP'),  typeof(t_LIST...
+Function t_list_timestamp is undefined or given wrong number of parameter. select t_LIST_TIMESTAMP('LIST', 'TIMESTAMP'),  typeof(t_LIST...
 
 ===================================================
 Error:-894
@@ -452,7 +452,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_TIMESTAMP('ENUM', 'TIMESTAMP', 'yellow' ) ) ; '
-Function t_ENUM_TIMESTAMP is undefined or given wrong number of parameter. select t_ENUM_TIMESTAMP('ENUM', 'TIMESTAMP', 'yellow'),  typ...
+Function t_enum_timestamp is undefined or given wrong number of parameter. select t_ENUM_TIMESTAMP('ENUM', 'TIMESTAMP', 'yellow'),  typ...
 
 ===================================================
 Error:-894
@@ -476,7 +476,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_TIMESTAMP('BLOB', 'TIMESTAMP', BIT_TO_BLOB(X...'
-Function t_BLOB_TIMESTAMP is undefined or given wrong number of parameter. select t_BLOB_TIMESTAMP('BLOB', 'TIMESTAMP',  bit_to_blob(X'...
+Function t_blob_timestamp is undefined or given wrong number of parameter. select t_BLOB_TIMESTAMP('BLOB', 'TIMESTAMP',  bit_to_blob(X'...
 
 ===================================================
 Error:-894
@@ -500,7 +500,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_TIMESTAMP('CLOB', 'TIMESTAMP', CHAR_TO_CLOB(...'
-Function t_CLOB_TIMESTAMP is undefined or given wrong number of parameter. select t_CLOB_TIMESTAMP('CLOB', 'TIMESTAMP',  char_to_clob('...
+Function t_clob_timestamp is undefined or given wrong number of parameter. select t_CLOB_TIMESTAMP('CLOB', 'TIMESTAMP',  char_to_clob('...
 
 ===================================================
 Error:-894
@@ -524,7 +524,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_TIMESTAMP('JSON', 'TIMESTAMP', '{"a":1}' ) ) ; '
-Function t_JSON_TIMESTAMP is undefined or given wrong number of parameter. select t_JSON_TIMESTAMP('JSON', 'TIMESTAMP', '{"a":1}'),  ty...
+Function t_json_timestamp is undefined or given wrong number of parameter. select t_JSON_TIMESTAMP('JSON', 'TIMESTAMP', '{"a":1}'),  ty...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-06_variable_to_return_TIMESTAMP.answer_cci
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-06_variable_to_return_TIMESTAMP.answer_cci
@@ -32,17 +32,17 @@ Semantic: before '  ) RETURN TIMESTAMP IS
 VAR DATETIMELTZ  ;
 begin
 VAR := param_...'
-Unsupported argument type 'datetimeltz' of the stored procedure create or replace function t_DATETIMELTZ_TIMESTAMP(variables...
+Unsupported argument type 'datetimeltz' of the stored procedure create or replace function [dba.t_DATETIMELTZ_TIMESTAMP](var...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_TIMESTAMP('DATETIMELTZ', 'TIMESTAMP',...'
-Function t_DATETIMELTZ_TIMESTAMP is undefined or given wrong number of parameter. select t_DATETIMELTZ_TIMESTAMP('DATETIMELTZ', 'TIMESTAMP', d...
+Function t_datetimeltz_timestamp is undefined or given wrong number of parameter. select t_DATETIMELTZ_TIMESTAMP('DATETIMELTZ', 'TIMESTAMP', d...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_DATETIMELTZ_TIMESTAMP' does not exist.
+Stored procedure/function 'dba.t_datetimeltz_timestamp' does not exist.
 
 ===================================================
     
@@ -56,17 +56,17 @@ Semantic: before '  ) RETURN TIMESTAMP IS
 VAR DATETIMETZ  ;
 begin
 VAR := param_v...'
-Unsupported argument type 'datetimetz' of the stored procedure create or replace function t_DATETIMETZ_TIMESTAMP(variables_...
+Unsupported argument type 'datetimetz' of the stored procedure create or replace function [dba.t_DATETIMETZ_TIMESTAMP](vari...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_TIMESTAMP('DATETIMETZ', 'TIMESTAMP', d...'
-Function t_DATETIMETZ_TIMESTAMP is undefined or given wrong number of parameter. select t_DATETIMETZ_TIMESTAMP('DATETIMETZ', 'TIMESTAMP', dat...
+Function t_datetimetz_timestamp is undefined or given wrong number of parameter. select t_DATETIMETZ_TIMESTAMP('DATETIMETZ', 'TIMESTAMP', dat...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_DATETIMETZ_TIMESTAMP' does not exist.
+Stored procedure/function 'dba.t_datetimetz_timestamp' does not exist.
 
 ===================================================
     
@@ -102,11 +102,11 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_TIMESTAMP('TIME', 'TIMESTAMP', TIME'13:15:45...'
-Function t_TIME_TIMESTAMP is undefined or given wrong number of parameter. select t_TIME_TIMESTAMP('TIME', 'TIMESTAMP', time '13:15:45'...
+Function t_time_timestamp is undefined or given wrong number of parameter. select t_TIME_TIMESTAMP('TIME', 'TIMESTAMP', time '13:15:45'...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_TIME_TIMESTAMP' does not exist.
+Stored procedure/function 'dba.t_time_timestamp' does not exist.
 
 ===================================================
     
@@ -139,17 +139,17 @@ Semantic: before '  ) RETURN TIMESTAMP IS
 VAR TIMESTAMPLTZ  ;
 begin
 VAR := param...'
-Unsupported argument type 'timestampltz' of the stored procedure create or replace function t_TIMESTAMPLTZ_TIMESTAMP(variable...
+Unsupported argument type 'timestampltz' of the stored procedure create or replace function [dba.t_TIMESTAMPLTZ_TIMESTAMP](va...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_TIMESTAMP('TIMESTAMPLTZ', 'TIMESTAMP...'
-Function t_TIMESTAMPLTZ_TIMESTAMP is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_TIMESTAMP('TIMESTAMPLTZ', 'TIMESTAMP',...
+Function t_timestampltz_timestamp is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_TIMESTAMP('TIMESTAMPLTZ', 'TIMESTAMP',...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_TIMESTAMPLTZ_TIMESTAMP' does not exist.
+Stored procedure/function 'dba.t_timestampltz_timestamp' does not exist.
 
 ===================================================
     
@@ -163,17 +163,17 @@ Semantic: before '  ) RETURN TIMESTAMP IS
 VAR TIMESTAMPTZ  ;
 begin
 VAR := param_...'
-Unsupported argument type 'timestamptz' of the stored procedure create or replace function t_TIMESTAMPTZ_TIMESTAMP(variables...
+Unsupported argument type 'timestamptz' of the stored procedure create or replace function [dba.t_TIMESTAMPTZ_TIMESTAMP](var...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_TIMESTAMP('TIMESTAMPTZ', 'TIMESTAMP',...'
-Function t_TIMESTAMPTZ_TIMESTAMP is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_TIMESTAMP('TIMESTAMPTZ', 'TIMESTAMP', t...
+Function t_timestamptz_timestamp is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_TIMESTAMP('TIMESTAMPTZ', 'TIMESTAMP', t...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_TIMESTAMPTZ_TIMESTAMP' does not exist.
+Stored procedure/function 'dba.t_timestamptz_timestamp' does not exist.
 
 ===================================================
     
@@ -301,17 +301,17 @@ Semantic: before '  ) RETURN TIMESTAMP IS
 VAR BIT(8)  ;
 begin
 VAR := param_value...'
-Unsupported argument type 'bit' of the stored procedure create or replace function t_BIT_TIMESTAMP(variables_type  v...
+Unsupported argument type 'bit' of the stored procedure create or replace function [dba.t_BIT_TIMESTAMP](variables_t...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_TIMESTAMP('BIT(8)', 'TIMESTAMP', 0xaa ) ) ; '
-Function t_BIT_TIMESTAMP is undefined or given wrong number of parameter. select t_BIT_TIMESTAMP('BIT(8)', 'TIMESTAMP', X'aa'),  typeo...
+Function t_bit_timestamp is undefined or given wrong number of parameter. select t_BIT_TIMESTAMP('BIT(8)', 'TIMESTAMP', X'aa'),  typeo...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_BIT_TIMESTAMP' does not exist.
+Stored procedure/function 'dba.t_bit_timestamp' does not exist.
 
 ===================================================
     
@@ -325,17 +325,17 @@ Semantic: before '  ) RETURN TIMESTAMP IS
 VAR BIT VARYING  ;
 begin
 VAR := param_...'
-dba.BITVARYING is not defined. create or replace function t_BITVARYING_TIMESTAMP(variables_...
+dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_TIMESTAMP](vari...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_TIMESTAMP('BIT VARYING', 'TIMESTAMP', ...'
-Function t_BITVARYING_TIMESTAMP is undefined or given wrong number of parameter. select t_BITVARYING_TIMESTAMP('BIT VARYING', 'TIMESTAMP', X'...
+Function t_bitvarying_timestamp is undefined or given wrong number of parameter. select t_BITVARYING_TIMESTAMP('BIT VARYING', 'TIMESTAMP', X'...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_BITVARYING_TIMESTAMP' does not exist.
+Stored procedure/function 'dba.t_bitvarying_timestamp' does not exist.
 
 ===================================================
     
@@ -390,11 +390,11 @@ Stored procedure compile error: no viable alternative at input 'VAR SET'
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_TIMESTAMP('SET', 'TIMESTAMP', {'c','c','c','b...'
-Function t_SET_TIMESTAMP is undefined or given wrong number of parameter. select t_SET_TIMESTAMP('SET', 'TIMESTAMP'),  typeof(t_SET_TI...
+Function t_set_timestamp is undefined or given wrong number of parameter. select t_SET_TIMESTAMP('SET', 'TIMESTAMP'),  typeof(t_SET_TI...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_SET_TIMESTAMP' does not exist.
+Stored procedure/function 'dba.t_set_timestamp' does not exist.
 
 ===================================================
     
@@ -411,11 +411,11 @@ Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_TIMESTAMP('MULTISET', 'TIMESTAMP', {'c',...'
-Function t_MULTISET_TIMESTAMP is undefined or given wrong number of parameter. select t_MULTISET_TIMESTAMP('MULTISET', 'TIMESTAMP'),  typeo...
+Function t_multiset_timestamp is undefined or given wrong number of parameter. select t_MULTISET_TIMESTAMP('MULTISET', 'TIMESTAMP'),  typeo...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_MULTISET_TIMESTAMP' does not exist.
+Stored procedure/function 'dba.t_multiset_timestamp' does not exist.
 
 ===================================================
     
@@ -432,11 +432,11 @@ Stored procedure compile error: no viable alternative at input 'VAR LIST'
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_TIMESTAMP('LIST', 'TIMESTAMP', {'c','c','c',...'
-Function t_LIST_TIMESTAMP is undefined or given wrong number of parameter. select t_LIST_TIMESTAMP('LIST', 'TIMESTAMP'),  typeof(t_LIST...
+Function t_list_timestamp is undefined or given wrong number of parameter. select t_LIST_TIMESTAMP('LIST', 'TIMESTAMP'),  typeof(t_LIST...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_LIST_TIMESTAMP' does not exist.
+Stored procedure/function 'dba.t_list_timestamp' does not exist.
 
 ===================================================
     
@@ -453,11 +453,11 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_TIMESTAMP('ENUM', 'TIMESTAMP', 'yellow' ) ) ; '
-Function t_ENUM_TIMESTAMP is undefined or given wrong number of parameter. select t_ENUM_TIMESTAMP('ENUM', 'TIMESTAMP', 'yellow'),  typ...
+Function t_enum_timestamp is undefined or given wrong number of parameter. select t_ENUM_TIMESTAMP('ENUM', 'TIMESTAMP', 'yellow'),  typ...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_ENUM_TIMESTAMP' does not exist.
+Stored procedure/function 'dba.t_enum_timestamp' does not exist.
 
 ===================================================
     
@@ -471,17 +471,17 @@ Semantic: before '  ) RETURN TIMESTAMP IS
 VAR BLOB  ;
 begin
 VAR := param_value ;...'
-Unsupported argument type 'blob' of the stored procedure create or replace function t_BLOB_TIMESTAMP(variables_type  ...
+Unsupported argument type 'blob' of the stored procedure create or replace function [dba.t_BLOB_TIMESTAMP](variables_...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_TIMESTAMP('BLOB', 'TIMESTAMP', BIT_TO_BLOB(X...'
-Function t_BLOB_TIMESTAMP is undefined or given wrong number of parameter. select t_BLOB_TIMESTAMP('BLOB', 'TIMESTAMP',  bit_to_blob(X'...
+Function t_blob_timestamp is undefined or given wrong number of parameter. select t_BLOB_TIMESTAMP('BLOB', 'TIMESTAMP',  bit_to_blob(X'...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_BLOB_TIMESTAMP' does not exist.
+Stored procedure/function 'dba.t_blob_timestamp' does not exist.
 
 ===================================================
     
@@ -495,17 +495,17 @@ Semantic: before '  ) RETURN TIMESTAMP IS
 VAR CLOB  ;
 begin
 VAR := param_value ;...'
-Unsupported argument type 'clob' of the stored procedure create or replace function t_CLOB_TIMESTAMP(variables_type  ...
+Unsupported argument type 'clob' of the stored procedure create or replace function [dba.t_CLOB_TIMESTAMP](variables_...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_TIMESTAMP('CLOB', 'TIMESTAMP', CHAR_TO_CLOB(...'
-Function t_CLOB_TIMESTAMP is undefined or given wrong number of parameter. select t_CLOB_TIMESTAMP('CLOB', 'TIMESTAMP',  char_to_clob('...
+Function t_clob_timestamp is undefined or given wrong number of parameter. select t_CLOB_TIMESTAMP('CLOB', 'TIMESTAMP',  char_to_clob('...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_CLOB_TIMESTAMP' does not exist.
+Stored procedure/function 'dba.t_clob_timestamp' does not exist.
 
 ===================================================
     
@@ -519,17 +519,17 @@ Semantic: before '  ) RETURN TIMESTAMP IS
 VAR JSON  ;
 begin
 VAR := param_value ;...'
-Unsupported argument type 'json' of the stored procedure create or replace function t_JSON_TIMESTAMP(variables_type  ...
+Unsupported argument type 'json' of the stored procedure create or replace function [dba.t_JSON_TIMESTAMP](variables_...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_TIMESTAMP('JSON', 'TIMESTAMP', '{"a":1}' ) ) ; '
-Function t_JSON_TIMESTAMP is undefined or given wrong number of parameter. select t_JSON_TIMESTAMP('JSON', 'TIMESTAMP', '{"a":1}'),  ty...
+Function t_json_timestamp is undefined or given wrong number of parameter. select t_JSON_TIMESTAMP('JSON', 'TIMESTAMP', '{"a":1}'),  ty...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_JSON_TIMESTAMP' does not exist.
+Stored procedure/function 'dba.t_json_timestamp' does not exist.
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-07_variable_to_return_TIMESTAMPLTZ.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-07_variable_to_return_TIMESTAMPLTZ.answer
@@ -15,7 +15,7 @@ Semantic: Unsupported return type 'timestampltz' of the stored procedure create 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_TIMESTAMPLTZ('DATETIME', 'TIMESTAMPLTZ',...'
-Function t_DATETIME_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_DATETIME_TIMESTAMPLTZ('DATETIME', 'TIMESTAMPLTZ', d...
+Function t_datetime_timestampltz is undefined or given wrong number of parameter. select t_DATETIME_TIMESTAMPLTZ('DATETIME', 'TIMESTAMPLTZ', d...
 
 ===================================================
 Error:-894
@@ -39,7 +39,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_TIMESTAMPLTZ('DATETIMELTZ', 'TIMESTAM...'
-Function t_DATETIMELTZ_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_DATETIMELTZ_TIMESTAMPLTZ('DATETIMELTZ', 'TIMESTAMPL...
+Function t_datetimeltz_timestampltz is undefined or given wrong number of parameter. select t_DATETIMELTZ_TIMESTAMPLTZ('DATETIMELTZ', 'TIMESTAMPL...
 
 ===================================================
 Error:-894
@@ -63,7 +63,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_TIMESTAMPLTZ('DATETIMETZ', 'TIMESTAMPL...'
-Function t_DATETIMETZ_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_DATETIMETZ_TIMESTAMPLTZ('DATETIMETZ', 'TIMESTAMPLTZ...
+Function t_datetimetz_timestampltz is undefined or given wrong number of parameter. select t_DATETIMETZ_TIMESTAMPLTZ('DATETIMETZ', 'TIMESTAMPLTZ...
 
 ===================================================
 Error:-894
@@ -83,7 +83,7 @@ Semantic: Unsupported return type 'timestampltz' of the stored procedure create 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_TIMESTAMPLTZ('DATE', 'TIMESTAMPLTZ', DATE'20...'
-Function t_DATE_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_DATE_TIMESTAMPLTZ('DATE', 'TIMESTAMPLTZ', date '200...
+Function t_date_timestampltz is undefined or given wrong number of parameter. select t_DATE_TIMESTAMPLTZ('DATE', 'TIMESTAMPLTZ', date '200...
 
 ===================================================
 Error:-894
@@ -103,7 +103,7 @@ Semantic: Unsupported return type 'timestampltz' of the stored procedure create 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_TIMESTAMPLTZ('TIME', 'TIMESTAMPLTZ', TIME'13...'
-Function t_TIME_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_TIME_TIMESTAMPLTZ('TIME', 'TIMESTAMPLTZ', time '13:...
+Function t_time_timestampltz is undefined or given wrong number of parameter. select t_TIME_TIMESTAMPLTZ('TIME', 'TIMESTAMPLTZ', time '13:...
 
 ===================================================
 Error:-894
@@ -123,7 +123,7 @@ Semantic: Unsupported return type 'timestampltz' of the stored procedure create 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_TIMESTAMPLTZ('TIMESTAMP', 'TIMESTAMPLTZ...'
-Function t_TIMESTAMP_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_TIMESTAMP_TIMESTAMPLTZ('TIMESTAMP', 'TIMESTAMPLTZ',...
+Function t_timestamp_timestampltz is undefined or given wrong number of parameter. select t_TIMESTAMP_TIMESTAMPLTZ('TIMESTAMP', 'TIMESTAMPLTZ',...
 
 ===================================================
 Error:-894
@@ -147,7 +147,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_TIMESTAMPLTZ('TIMESTAMPLTZ', 'TIMEST...'
-Function t_TIMESTAMPLTZ_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_TIMESTAMPLTZ('TIMESTAMPLTZ', 'TIMESTAM...
+Function t_timestampltz_timestampltz is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_TIMESTAMPLTZ('TIMESTAMPLTZ', 'TIMESTAM...
 
 ===================================================
 Error:-894
@@ -171,7 +171,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_TIMESTAMPLTZ('TIMESTAMPTZ', 'TIMESTAM...'
-Function t_TIMESTAMPTZ_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_TIMESTAMPLTZ('TIMESTAMPTZ', 'TIMESTAMPL...
+Function t_timestamptz_timestampltz is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_TIMESTAMPLTZ('TIMESTAMPTZ', 'TIMESTAMPL...
 
 ===================================================
 Error:-894
@@ -191,7 +191,7 @@ Semantic: Unsupported return type 'timestampltz' of the stored procedure create 
 Error:-494
 Semantic: before ' ,
 typeof( t_DOUBLE_TIMESTAMPLTZ('DOUBLE', 'TIMESTAMPLTZ', cas...'
-Function t_DOUBLE_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_DOUBLE_TIMESTAMPLTZ('DOUBLE', 'TIMESTAMPLTZ',  cast...
+Function t_double_timestampltz is undefined or given wrong number of parameter. select t_DOUBLE_TIMESTAMPLTZ('DOUBLE', 'TIMESTAMPLTZ',  cast...
 
 ===================================================
 Error:-894
@@ -211,7 +211,7 @@ Semantic: Unsupported return type 'timestampltz' of the stored procedure create 
 Error:-494
 Semantic: before ' ,
 typeof( t_FLOAT_TIMESTAMPLTZ('FLOAT', 'TIMESTAMPLTZ', cast(...'
-Function t_FLOAT_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_FLOAT_TIMESTAMPLTZ('FLOAT', 'TIMESTAMPLTZ',  cast(1...
+Function t_float_timestampltz is undefined or given wrong number of parameter. select t_FLOAT_TIMESTAMPLTZ('FLOAT', 'TIMESTAMPLTZ',  cast(1...
 
 ===================================================
 Error:-894
@@ -231,7 +231,7 @@ Semantic: Unsupported return type 'timestampltz' of the stored procedure create 
 Error:-494
 Semantic: before ' ,
 typeof( t_NUMERIC_TIMESTAMPLTZ('NUMERIC(8,4)', 'TIMESTAMPLT...'
-Function t_NUMERIC_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_NUMERIC_TIMESTAMPLTZ('NUMERIC(8,4)', 'TIMESTAMPLTZ'...
+Function t_numeric_timestampltz is undefined or given wrong number of parameter. select t_NUMERIC_TIMESTAMPLTZ('NUMERIC(8,4)', 'TIMESTAMPLTZ'...
 
 ===================================================
 Error:-894
@@ -251,7 +251,7 @@ Semantic: Unsupported return type 'timestampltz' of the stored procedure create 
 Error:-494
 Semantic: before ' ,
 typeof( t_BIGINT_TIMESTAMPLTZ('BIGINT', 'TIMESTAMPLTZ', cas...'
-Function t_BIGINT_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_BIGINT_TIMESTAMPLTZ('BIGINT', 'TIMESTAMPLTZ',  cast...
+Function t_bigint_timestampltz is undefined or given wrong number of parameter. select t_BIGINT_TIMESTAMPLTZ('BIGINT', 'TIMESTAMPLTZ',  cast...
 
 ===================================================
 Error:-894
@@ -271,7 +271,7 @@ Semantic: Unsupported return type 'timestampltz' of the stored procedure create 
 Error:-494
 Semantic: before ' ,
 typeof( t_INT_TIMESTAMPLTZ('INT', 'TIMESTAMPLTZ', cast( 782...'
-Function t_INT_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_INT_TIMESTAMPLTZ('INT', 'TIMESTAMPLTZ',  cast(78234...
+Function t_int_timestampltz is undefined or given wrong number of parameter. select t_INT_TIMESTAMPLTZ('INT', 'TIMESTAMPLTZ',  cast(78234...
 
 ===================================================
 Error:-894
@@ -291,7 +291,7 @@ Semantic: Unsupported return type 'timestampltz' of the stored procedure create 
 Error:-494
 Semantic: before ' ,
 typeof( t_SHORT_TIMESTAMPLTZ('SHORT', 'TIMESTAMPLTZ', cast(...'
-Function t_SHORT_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_SHORT_TIMESTAMPLTZ('SHORT', 'TIMESTAMPLTZ',  cast(8...
+Function t_short_timestampltz is undefined or given wrong number of parameter. select t_SHORT_TIMESTAMPLTZ('SHORT', 'TIMESTAMPLTZ',  cast(8...
 
 ===================================================
 Error:-894
@@ -315,7 +315,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_TIMESTAMPLTZ('BIT(8)', 'TIMESTAMPLTZ', 0xaa )...'
-Function t_BIT_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_BIT_TIMESTAMPLTZ('BIT(8)', 'TIMESTAMPLTZ', X'aa'), ...
+Function t_bit_timestampltz is undefined or given wrong number of parameter. select t_BIT_TIMESTAMPLTZ('BIT(8)', 'TIMESTAMPLTZ', X'aa'), ...
 
 ===================================================
 Error:-894
@@ -339,7 +339,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_TIME
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_TIMESTAMPLTZ('BIT VARYING', 'TIMESTAMP...'
-Function t_BITVARYING_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_BITVARYING_TIMESTAMPLTZ('BIT VARYING', 'TIMESTAMPLT...
+Function t_bitvarying_timestampltz is undefined or given wrong number of parameter. select t_BITVARYING_TIMESTAMPLTZ('BIT VARYING', 'TIMESTAMPLT...
 
 ===================================================
 Error:-894
@@ -359,7 +359,7 @@ Semantic: Unsupported return type 'timestampltz' of the stored procedure create 
 Error:-494
 Semantic: before ' ,
 typeof( t_CHAR_TIMESTAMPLTZ('CHAR', 'TIMESTAMPLTZ', cast( '...'
-Function t_CHAR_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_CHAR_TIMESTAMPLTZ('CHAR', 'TIMESTAMPLTZ',  cast('09...
+Function t_char_timestampltz is undefined or given wrong number of parameter. select t_CHAR_TIMESTAMPLTZ('CHAR', 'TIMESTAMPLTZ',  cast('09...
 
 ===================================================
 Error:-894
@@ -379,7 +379,7 @@ Semantic: Unsupported return type 'timestampltz' of the stored procedure create 
 Error:-494
 Semantic: before ' ,
 typeof( t_VARCHAR_TIMESTAMPLTZ('VARCHAR', 'TIMESTAMPLTZ', c...'
-Function t_VARCHAR_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_VARCHAR_TIMESTAMPLTZ('VARCHAR', 'TIMESTAMPLTZ',  ca...
+Function t_varchar_timestampltz is undefined or given wrong number of parameter. select t_VARCHAR_TIMESTAMPLTZ('VARCHAR', 'TIMESTAMPLTZ',  ca...
 
 ===================================================
 Error:-894
@@ -399,7 +399,7 @@ Semantic: Unsupported return type 'timestampltz' of the stored procedure create 
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_TIMESTAMPLTZ('SET', 'TIMESTAMPLTZ', {'c','c',...'
-Function t_SET_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_SET_TIMESTAMPLTZ('SET', 'TIMESTAMPLTZ'),  typeof(t_...
+Function t_set_timestampltz is undefined or given wrong number of parameter. select t_SET_TIMESTAMPLTZ('SET', 'TIMESTAMPLTZ'),  typeof(t_...
 
 ===================================================
 Error:-894
@@ -419,7 +419,7 @@ Semantic: Unsupported return type 'timestampltz' of the stored procedure create 
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_TIMESTAMPLTZ('MULTISET', 'TIMESTAMPLTZ',...'
-Function t_MULTISET_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_MULTISET_TIMESTAMPLTZ('MULTISET', 'TIMESTAMPLTZ'), ...
+Function t_multiset_timestampltz is undefined or given wrong number of parameter. select t_MULTISET_TIMESTAMPLTZ('MULTISET', 'TIMESTAMPLTZ'), ...
 
 ===================================================
 Error:-894
@@ -439,7 +439,7 @@ Semantic: Unsupported return type 'timestampltz' of the stored procedure create 
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_TIMESTAMPLTZ('LIST', 'TIMESTAMPLTZ', {'c','c...'
-Function t_LIST_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_LIST_TIMESTAMPLTZ('LIST', 'TIMESTAMPLTZ'),  typeof(...
+Function t_list_timestampltz is undefined or given wrong number of parameter. select t_LIST_TIMESTAMPLTZ('LIST', 'TIMESTAMPLTZ'),  typeof(...
 
 ===================================================
 Error:-894
@@ -460,7 +460,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_TIMESTAMPLTZ('ENUM', 'TIMESTAMPLTZ', 'yellow...'
-Function t_ENUM_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_ENUM_TIMESTAMPLTZ('ENUM', 'TIMESTAMPLTZ', 'yellow')...
+Function t_enum_timestampltz is undefined or given wrong number of parameter. select t_ENUM_TIMESTAMPLTZ('ENUM', 'TIMESTAMPLTZ', 'yellow')...
 
 ===================================================
 Error:-894
@@ -484,7 +484,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_TIMESTAMPLTZ('BLOB', 'TIMESTAMPLTZ', BIT_TO_...'
-Function t_BLOB_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_BLOB_TIMESTAMPLTZ('BLOB', 'TIMESTAMPLTZ',  bit_to_b...
+Function t_blob_timestampltz is undefined or given wrong number of parameter. select t_BLOB_TIMESTAMPLTZ('BLOB', 'TIMESTAMPLTZ',  bit_to_b...
 
 ===================================================
 Error:-894
@@ -508,7 +508,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_TIMESTAMPLTZ('CLOB', 'TIMESTAMPLTZ', CHAR_TO...'
-Function t_CLOB_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_CLOB_TIMESTAMPLTZ('CLOB', 'TIMESTAMPLTZ',  char_to_...
+Function t_clob_timestampltz is undefined or given wrong number of parameter. select t_CLOB_TIMESTAMPLTZ('CLOB', 'TIMESTAMPLTZ',  char_to_...
 
 ===================================================
 Error:-894
@@ -532,7 +532,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_TIMESTAMPLTZ('JSON', 'TIMESTAMPLTZ', '{"a":1...'
-Function t_JSON_TIMESTAMPLTZ is undefined or given wrong number of parameter. select t_JSON_TIMESTAMPLTZ('JSON', 'TIMESTAMPLTZ', '{"a":1}'...
+Function t_json_timestampltz is undefined or given wrong number of parameter. select t_JSON_TIMESTAMPLTZ('JSON', 'TIMESTAMPLTZ', '{"a":1}'...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-08_variable_to_return_TIMESTAMPTZ.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-08_variable_to_return_TIMESTAMPTZ.answer
@@ -15,7 +15,7 @@ Semantic: Unsupported return type 'timestamptz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_TIMESTAMPTZ('DATETIME', 'TIMESTAMPTZ', D...'
-Function t_DATETIME_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_DATETIME_TIMESTAMPTZ('DATETIME', 'TIMESTAMPTZ', dat...
+Function t_datetime_timestamptz is undefined or given wrong number of parameter. select t_DATETIME_TIMESTAMPTZ('DATETIME', 'TIMESTAMPTZ', dat...
 
 ===================================================
 Error:-894
@@ -39,7 +39,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_TIMESTAMPTZ('DATETIMELTZ', 'TIMESTAMP...'
-Function t_DATETIMELTZ_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_DATETIMELTZ_TIMESTAMPTZ('DATETIMELTZ', 'TIMESTAMPTZ...
+Function t_datetimeltz_timestamptz is undefined or given wrong number of parameter. select t_DATETIMELTZ_TIMESTAMPTZ('DATETIMELTZ', 'TIMESTAMPTZ...
 
 ===================================================
 Error:-894
@@ -63,7 +63,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_TIMESTAMPTZ('DATETIMETZ', 'TIMESTAMPTZ...'
-Function t_DATETIMETZ_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_DATETIMETZ_TIMESTAMPTZ('DATETIMETZ', 'TIMESTAMPTZ',...
+Function t_datetimetz_timestamptz is undefined or given wrong number of parameter. select t_DATETIMETZ_TIMESTAMPTZ('DATETIMETZ', 'TIMESTAMPTZ',...
 
 ===================================================
 Error:-894
@@ -83,7 +83,7 @@ Semantic: Unsupported return type 'timestamptz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_TIMESTAMPTZ('DATE', 'TIMESTAMPTZ', DATE'2008...'
-Function t_DATE_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_DATE_TIMESTAMPTZ('DATE', 'TIMESTAMPTZ', date '2008-...
+Function t_date_timestamptz is undefined or given wrong number of parameter. select t_DATE_TIMESTAMPTZ('DATE', 'TIMESTAMPTZ', date '2008-...
 
 ===================================================
 Error:-894
@@ -103,7 +103,7 @@ Semantic: Unsupported return type 'timestamptz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_TIMESTAMPTZ('TIME', 'TIMESTAMPTZ', TIME'13:1...'
-Function t_TIME_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_TIME_TIMESTAMPTZ('TIME', 'TIMESTAMPTZ', time '13:15...
+Function t_time_timestamptz is undefined or given wrong number of parameter. select t_TIME_TIMESTAMPTZ('TIME', 'TIMESTAMPTZ', time '13:15...
 
 ===================================================
 Error:-894
@@ -123,7 +123,7 @@ Semantic: Unsupported return type 'timestamptz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_TIMESTAMPTZ('TIMESTAMP', 'TIMESTAMPTZ',...'
-Function t_TIMESTAMP_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_TIMESTAMP_TIMESTAMPTZ('TIMESTAMP', 'TIMESTAMPTZ', t...
+Function t_timestamp_timestamptz is undefined or given wrong number of parameter. select t_TIMESTAMP_TIMESTAMPTZ('TIMESTAMP', 'TIMESTAMPTZ', t...
 
 ===================================================
 Error:-894
@@ -147,7 +147,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_TIMESTAMPTZ('TIMESTAMPLTZ', 'TIMESTA...'
-Function t_TIMESTAMPLTZ_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_TIMESTAMPTZ('TIMESTAMPLTZ', 'TIMESTAMP...
+Function t_timestampltz_timestamptz is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_TIMESTAMPTZ('TIMESTAMPLTZ', 'TIMESTAMP...
 
 ===================================================
 Error:-894
@@ -171,7 +171,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_TIMESTAMPTZ('TIMESTAMPTZ', 'TIMESTAMP...'
-Function t_TIMESTAMPTZ_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_TIMESTAMPTZ('TIMESTAMPTZ', 'TIMESTAMPTZ...
+Function t_timestamptz_timestamptz is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_TIMESTAMPTZ('TIMESTAMPTZ', 'TIMESTAMPTZ...
 
 ===================================================
 Error:-894
@@ -191,7 +191,7 @@ Semantic: Unsupported return type 'timestamptz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_DOUBLE_TIMESTAMPTZ('DOUBLE', 'TIMESTAMPTZ', cast(...'
-Function t_DOUBLE_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_DOUBLE_TIMESTAMPTZ('DOUBLE', 'TIMESTAMPTZ',  cast(1...
+Function t_double_timestamptz is undefined or given wrong number of parameter. select t_DOUBLE_TIMESTAMPTZ('DOUBLE', 'TIMESTAMPTZ',  cast(1...
 
 ===================================================
 Error:-894
@@ -211,7 +211,7 @@ Semantic: Unsupported return type 'timestamptz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_FLOAT_TIMESTAMPTZ('FLOAT', 'TIMESTAMPTZ', cast( 1...'
-Function t_FLOAT_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_FLOAT_TIMESTAMPTZ('FLOAT', 'TIMESTAMPTZ',  cast(167...
+Function t_float_timestamptz is undefined or given wrong number of parameter. select t_FLOAT_TIMESTAMPTZ('FLOAT', 'TIMESTAMPTZ',  cast(167...
 
 ===================================================
 Error:-894
@@ -231,7 +231,7 @@ Semantic: Unsupported return type 'timestamptz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_NUMERIC_TIMESTAMPTZ('NUMERIC(8,4)', 'TIMESTAMPTZ'...'
-Function t_NUMERIC_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_NUMERIC_TIMESTAMPTZ('NUMERIC(8,4)', 'TIMESTAMPTZ', ...
+Function t_numeric_timestamptz is undefined or given wrong number of parameter. select t_NUMERIC_TIMESTAMPTZ('NUMERIC(8,4)', 'TIMESTAMPTZ', ...
 
 ===================================================
 Error:-894
@@ -251,7 +251,7 @@ Semantic: Unsupported return type 'timestamptz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_BIGINT_TIMESTAMPTZ('BIGINT', 'TIMESTAMPTZ', cast(...'
-Function t_BIGINT_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_BIGINT_TIMESTAMPTZ('BIGINT', 'TIMESTAMPTZ',  cast(3...
+Function t_bigint_timestamptz is undefined or given wrong number of parameter. select t_BIGINT_TIMESTAMPTZ('BIGINT', 'TIMESTAMPTZ',  cast(3...
 
 ===================================================
 Error:-894
@@ -271,7 +271,7 @@ Semantic: Unsupported return type 'timestamptz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_INT_TIMESTAMPTZ('INT', 'TIMESTAMPTZ', cast( 78234...'
-Function t_INT_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_INT_TIMESTAMPTZ('INT', 'TIMESTAMPTZ',  cast(782346 ...
+Function t_int_timestamptz is undefined or given wrong number of parameter. select t_INT_TIMESTAMPTZ('INT', 'TIMESTAMPTZ',  cast(782346 ...
 
 ===================================================
 Error:-894
@@ -291,7 +291,7 @@ Semantic: Unsupported return type 'timestamptz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_SHORT_TIMESTAMPTZ('SHORT', 'TIMESTAMPTZ', cast( 8...'
-Function t_SHORT_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_SHORT_TIMESTAMPTZ('SHORT', 'TIMESTAMPTZ',  cast(893...
+Function t_short_timestamptz is undefined or given wrong number of parameter. select t_SHORT_TIMESTAMPTZ('SHORT', 'TIMESTAMPTZ',  cast(893...
 
 ===================================================
 Error:-894
@@ -315,7 +315,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_TIMESTAMPTZ('BIT(8)', 'TIMESTAMPTZ', 0xaa ) ) ; '
-Function t_BIT_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_BIT_TIMESTAMPTZ('BIT(8)', 'TIMESTAMPTZ', X'aa'),  t...
+Function t_bit_timestamptz is undefined or given wrong number of parameter. select t_BIT_TIMESTAMPTZ('BIT(8)', 'TIMESTAMPTZ', X'aa'),  t...
 
 ===================================================
 Error:-894
@@ -339,7 +339,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_TIME
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_TIMESTAMPTZ('BIT VARYING', 'TIMESTAMPT...'
-Function t_BITVARYING_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_BITVARYING_TIMESTAMPTZ('BIT VARYING', 'TIMESTAMPTZ'...
+Function t_bitvarying_timestamptz is undefined or given wrong number of parameter. select t_BITVARYING_TIMESTAMPTZ('BIT VARYING', 'TIMESTAMPTZ'...
 
 ===================================================
 Error:-894
@@ -359,7 +359,7 @@ Semantic: Unsupported return type 'timestamptz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_CHAR_TIMESTAMPTZ('CHAR', 'TIMESTAMPTZ', cast( '09...'
-Function t_CHAR_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_CHAR_TIMESTAMPTZ('CHAR', 'TIMESTAMPTZ',  cast('09/0...
+Function t_char_timestamptz is undefined or given wrong number of parameter. select t_CHAR_TIMESTAMPTZ('CHAR', 'TIMESTAMPTZ',  cast('09/0...
 
 ===================================================
 Error:-894
@@ -379,7 +379,7 @@ Semantic: Unsupported return type 'timestamptz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_VARCHAR_TIMESTAMPTZ('VARCHAR', 'TIMESTAMPTZ', cas...'
-Function t_VARCHAR_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_VARCHAR_TIMESTAMPTZ('VARCHAR', 'TIMESTAMPTZ',  cast...
+Function t_varchar_timestamptz is undefined or given wrong number of parameter. select t_VARCHAR_TIMESTAMPTZ('VARCHAR', 'TIMESTAMPTZ',  cast...
 
 ===================================================
 Error:-894
@@ -399,7 +399,7 @@ Semantic: Unsupported return type 'timestamptz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_TIMESTAMPTZ('SET', 'TIMESTAMPTZ', {'c','c','c...'
-Function t_SET_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_SET_TIMESTAMPTZ('SET', 'TIMESTAMPTZ'),  typeof(t_SE...
+Function t_set_timestamptz is undefined or given wrong number of parameter. select t_SET_TIMESTAMPTZ('SET', 'TIMESTAMPTZ'),  typeof(t_SE...
 
 ===================================================
 Error:-894
@@ -419,7 +419,7 @@ Semantic: Unsupported return type 'timestamptz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_TIMESTAMPTZ('MULTISET', 'TIMESTAMPTZ', {...'
-Function t_MULTISET_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_MULTISET_TIMESTAMPTZ('MULTISET', 'TIMESTAMPTZ'),  t...
+Function t_multiset_timestamptz is undefined or given wrong number of parameter. select t_MULTISET_TIMESTAMPTZ('MULTISET', 'TIMESTAMPTZ'),  t...
 
 ===================================================
 Error:-894
@@ -439,7 +439,7 @@ Semantic: Unsupported return type 'timestamptz' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_TIMESTAMPTZ('LIST', 'TIMESTAMPTZ', {'c','c',...'
-Function t_LIST_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_LIST_TIMESTAMPTZ('LIST', 'TIMESTAMPTZ'),  typeof(t_...
+Function t_list_timestamptz is undefined or given wrong number of parameter. select t_LIST_TIMESTAMPTZ('LIST', 'TIMESTAMPTZ'),  typeof(t_...
 
 ===================================================
 Error:-894
@@ -460,7 +460,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_TIMESTAMPTZ('ENUM', 'TIMESTAMPTZ', 'yellow' ...'
-Function t_ENUM_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_ENUM_TIMESTAMPTZ('ENUM', 'TIMESTAMPTZ', 'yellow'), ...
+Function t_enum_timestamptz is undefined or given wrong number of parameter. select t_ENUM_TIMESTAMPTZ('ENUM', 'TIMESTAMPTZ', 'yellow'), ...
 
 ===================================================
 Error:-894
@@ -484,7 +484,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_TIMESTAMPTZ('BLOB', 'TIMESTAMPTZ', BIT_TO_BL...'
-Function t_BLOB_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_BLOB_TIMESTAMPTZ('BLOB', 'TIMESTAMPTZ',  bit_to_blo...
+Function t_blob_timestamptz is undefined or given wrong number of parameter. select t_BLOB_TIMESTAMPTZ('BLOB', 'TIMESTAMPTZ',  bit_to_blo...
 
 ===================================================
 Error:-894
@@ -508,7 +508,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_TIMESTAMPTZ('CLOB', 'TIMESTAMPTZ', CHAR_TO_C...'
-Function t_CLOB_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_CLOB_TIMESTAMPTZ('CLOB', 'TIMESTAMPTZ',  char_to_cl...
+Function t_clob_timestamptz is undefined or given wrong number of parameter. select t_CLOB_TIMESTAMPTZ('CLOB', 'TIMESTAMPTZ',  char_to_cl...
 
 ===================================================
 Error:-894
@@ -532,7 +532,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_TIMESTAMPTZ('JSON', 'TIMESTAMPTZ', '{"a":1}'...'
-Function t_JSON_TIMESTAMPTZ is undefined or given wrong number of parameter. select t_JSON_TIMESTAMPTZ('JSON', 'TIMESTAMPTZ', '{"a":1}'),...
+Function t_json_timestamptz is undefined or given wrong number of parameter. select t_JSON_TIMESTAMPTZ('JSON', 'TIMESTAMPTZ', '{"a":1}'),...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-09_variable_to_return_INT.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-09_variable_to_return_INT.answer
@@ -16,7 +16,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_INT('DATETIME', 'INT', DATETIME'2023-02-...'
-Function t_DATETIME_INT is undefined or given wrong number of parameter. select t_DATETIME_INT('DATETIME', 'INT', datetime '2023-02-1...
+Function t_datetime_int is undefined or given wrong number of parameter. select t_DATETIME_INT('DATETIME', 'INT', datetime '2023-02-1...
 
 ===================================================
 Error:-894
@@ -40,7 +40,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_INT('DATETIMELTZ', 'INT', datetimeltz...'
-Function t_DATETIMELTZ_INT is undefined or given wrong number of parameter. select t_DATETIMELTZ_INT('DATETIMELTZ', 'INT', datetimeltz '...
+Function t_datetimeltz_int is undefined or given wrong number of parameter. select t_DATETIMELTZ_INT('DATETIMELTZ', 'INT', datetimeltz '...
 
 ===================================================
 Error:-894
@@ -64,7 +64,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_INT('DATETIMETZ', 'INT', datetimetz '0...'
-Function t_DATETIMETZ_INT is undefined or given wrong number of parameter. select t_DATETIMETZ_INT('DATETIMETZ', 'INT', datetimetz '09/...
+Function t_datetimetz_int is undefined or given wrong number of parameter. select t_DATETIMETZ_INT('DATETIMETZ', 'INT', datetimetz '09/...
 
 ===================================================
 Error:-894
@@ -85,7 +85,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_INT('DATE', 'INT', DATE'2008-10-31' ) ) ; '
-Function t_DATE_INT is undefined or given wrong number of parameter. select t_DATE_INT('DATE', 'INT', date '2008-10-31'),  typeof...
+Function t_date_int is undefined or given wrong number of parameter. select t_DATE_INT('DATE', 'INT', date '2008-10-31'),  typeof...
 
 ===================================================
 Error:-894
@@ -106,7 +106,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_INT('TIME', 'INT', TIME'13:15:45' ) ) ; '
-Function t_TIME_INT is undefined or given wrong number of parameter. select t_TIME_INT('TIME', 'INT', time '13:15:45'),  typeof(t...
+Function t_time_int is undefined or given wrong number of parameter. select t_TIME_INT('TIME', 'INT', time '13:15:45'),  typeof(t...
 
 ===================================================
 Error:-894
@@ -127,7 +127,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_INT('TIMESTAMP', 'INT', TIMESTAMP'2023-...'
-Function t_TIMESTAMP_INT is undefined or given wrong number of parameter. select t_TIMESTAMP_INT('TIMESTAMP', 'INT', timestamp '2023-1...
+Function t_timestamp_int is undefined or given wrong number of parameter. select t_TIMESTAMP_INT('TIMESTAMP', 'INT', timestamp '2023-1...
 
 ===================================================
 Error:-894
@@ -151,7 +151,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_INT('TIMESTAMPLTZ', 'INT', timestamp...'
-Function t_TIMESTAMPLTZ_INT is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_INT('TIMESTAMPLTZ', 'INT', timestamptz...
+Function t_timestampltz_int is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_INT('TIMESTAMPLTZ', 'INT', timestamptz...
 
 ===================================================
 Error:-894
@@ -175,7 +175,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_INT('TIMESTAMPTZ', 'INT', timestamptz...'
-Function t_TIMESTAMPTZ_INT is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_INT('TIMESTAMPTZ', 'INT', timestamptz '...
+Function t_timestamptz_int is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_INT('TIMESTAMPTZ', 'INT', timestamptz '...
 
 ===================================================
 Error:-894
@@ -314,7 +314,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_INT('BIT(8)', 'INT', 0xaa ) ) ; '
-Function t_BIT_INT is undefined or given wrong number of parameter. select t_BIT_INT('BIT(8)', 'INT', X'aa'),  typeof(t_BIT_INT(...
+Function t_bit_int is undefined or given wrong number of parameter. select t_BIT_INT('BIT(8)', 'INT', X'aa'),  typeof(t_BIT_INT(...
 
 ===================================================
 Error:-894
@@ -338,7 +338,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_INT]
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_INT('BIT VARYING', 'INT', 0xaa ) ) ; '
-Function t_BITVARYING_INT is undefined or given wrong number of parameter. select t_BITVARYING_INT('BIT VARYING', 'INT', X'aa'),  typeo...
+Function t_bitvarying_int is undefined or given wrong number of parameter. select t_BITVARYING_INT('BIT VARYING', 'INT', X'aa'),  typeo...
 
 ===================================================
 Error:-894
@@ -395,7 +395,7 @@ Stored procedure compile error: no viable alternative at input 'VAR SET'
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_INT('SET', 'INT', {'c','c','c','b','b','a'} )...'
-Function t_SET_INT is undefined or given wrong number of parameter. select t_SET_INT('SET', 'INT'),  typeof(t_SET_INT('SET', 'INT'))
+Function t_set_int is undefined or given wrong number of parameter. select t_SET_INT('SET', 'INT'),  typeof(t_SET_INT('SET', 'INT'))
 
 ===================================================
 Error:-894
@@ -416,7 +416,7 @@ Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_INT('MULTISET', 'INT', {'c','c','c','b',...'
-Function t_MULTISET_INT is undefined or given wrong number of parameter. select t_MULTISET_INT('MULTISET', 'INT'),  typeof(t_MULTISET...
+Function t_multiset_int is undefined or given wrong number of parameter. select t_MULTISET_INT('MULTISET', 'INT'),  typeof(t_MULTISET...
 
 ===================================================
 Error:-894
@@ -437,7 +437,7 @@ Stored procedure compile error: no viable alternative at input 'VAR LIST'
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_INT('LIST', 'INT', {'c','c','c','b','b', 'a'...'
-Function t_LIST_INT is undefined or given wrong number of parameter. select t_LIST_INT('LIST', 'INT'),  typeof(t_LIST_INT('LIST',...
+Function t_list_int is undefined or given wrong number of parameter. select t_LIST_INT('LIST', 'INT'),  typeof(t_LIST_INT('LIST',...
 
 ===================================================
 Error:-894
@@ -458,7 +458,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_INT('ENUM', 'INT', 'yellow' ) ) ; '
-Function t_ENUM_INT is undefined or given wrong number of parameter. select t_ENUM_INT('ENUM', 'INT', 'yellow'),  typeof(t_ENUM_I...
+Function t_enum_int is undefined or given wrong number of parameter. select t_ENUM_INT('ENUM', 'INT', 'yellow'),  typeof(t_ENUM_I...
 
 ===================================================
 Error:-894
@@ -483,7 +483,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_INT('BLOB', 'INT', BIT_TO_BLOB(X'000010') ) ...'
-Function t_BLOB_INT is undefined or given wrong number of parameter. select t_BLOB_INT('BLOB', 'INT',  bit_to_blob(X'000010')),  ...
+Function t_blob_int is undefined or given wrong number of parameter. select t_BLOB_INT('BLOB', 'INT',  bit_to_blob(X'000010')),  ...
 
 ===================================================
 Error:-894
@@ -508,7 +508,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_INT('CLOB', 'INT', CHAR_TO_CLOB('This is a D...'
-Function t_CLOB_INT is undefined or given wrong number of parameter. select t_CLOB_INT('CLOB', 'INT',  char_to_clob('This is a Do...
+Function t_clob_int is undefined or given wrong number of parameter. select t_CLOB_INT('CLOB', 'INT',  char_to_clob('This is a Do...
 
 ===================================================
 Error:-894
@@ -533,7 +533,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_INT('JSON', 'INT', '{"a":1}' ) ) ; '
-Function t_JSON_INT is undefined or given wrong number of parameter. select t_JSON_INT('JSON', 'INT', '{"a":1}'),  typeof(t_JSON_...
+Function t_json_int is undefined or given wrong number of parameter. select t_JSON_INT('JSON', 'INT', '{"a":1}'),  typeof(t_JSON_...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-10_variable_to_return_SHORT.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-10_variable_to_return_SHORT.answer
@@ -16,7 +16,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_SHORT('DATETIME', 'SHORT', DATETIME'2023...'
-Function t_DATETIME_SHORT is undefined or given wrong number of parameter. select t_DATETIME_SHORT('DATETIME', 'SHORT', datetime '2023-...
+Function t_datetime_short is undefined or given wrong number of parameter. select t_DATETIME_SHORT('DATETIME', 'SHORT', datetime '2023-...
 
 ===================================================
 Error:-894
@@ -40,7 +40,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_SHORT('DATETIMELTZ', 'SHORT', datetim...'
-Function t_DATETIMELTZ_SHORT is undefined or given wrong number of parameter. select t_DATETIMELTZ_SHORT('DATETIMELTZ', 'SHORT', datetimel...
+Function t_datetimeltz_short is undefined or given wrong number of parameter. select t_DATETIMELTZ_SHORT('DATETIMELTZ', 'SHORT', datetimel...
 
 ===================================================
 Error:-894
@@ -64,7 +64,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_SHORT('DATETIMETZ', 'SHORT', datetimet...'
-Function t_DATETIMETZ_SHORT is undefined or given wrong number of parameter. select t_DATETIMETZ_SHORT('DATETIMETZ', 'SHORT', datetimetz ...
+Function t_datetimetz_short is undefined or given wrong number of parameter. select t_DATETIMETZ_SHORT('DATETIMETZ', 'SHORT', datetimetz ...
 
 ===================================================
 Error:-894
@@ -85,7 +85,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_SHORT('DATE', 'SHORT', DATE'2008-10-31' ) ) ; '
-Function t_DATE_SHORT is undefined or given wrong number of parameter. select t_DATE_SHORT('DATE', 'SHORT', date '2008-10-31'),  ty...
+Function t_date_short is undefined or given wrong number of parameter. select t_DATE_SHORT('DATE', 'SHORT', date '2008-10-31'),  ty...
 
 ===================================================
 Error:-894
@@ -106,7 +106,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_SHORT('TIME', 'SHORT', TIME'13:15:45' ) ) ; '
-Function t_TIME_SHORT is undefined or given wrong number of parameter. select t_TIME_SHORT('TIME', 'SHORT', time '13:15:45'),  type...
+Function t_time_short is undefined or given wrong number of parameter. select t_TIME_SHORT('TIME', 'SHORT', time '13:15:45'),  type...
 
 ===================================================
 Error:-894
@@ -127,7 +127,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_SHORT('TIMESTAMP', 'SHORT', TIMESTAMP'2...'
-Function t_TIMESTAMP_SHORT is undefined or given wrong number of parameter. select t_TIMESTAMP_SHORT('TIMESTAMP', 'SHORT', timestamp '20...
+Function t_timestamp_short is undefined or given wrong number of parameter. select t_TIMESTAMP_SHORT('TIMESTAMP', 'SHORT', timestamp '20...
 
 ===================================================
 Error:-894
@@ -151,7 +151,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_SHORT('TIMESTAMPLTZ', 'SHORT', times...'
-Function t_TIMESTAMPLTZ_SHORT is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_SHORT('TIMESTAMPLTZ', 'SHORT', timesta...
+Function t_timestampltz_short is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_SHORT('TIMESTAMPLTZ', 'SHORT', timesta...
 
 ===================================================
 Error:-894
@@ -175,7 +175,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_SHORT('TIMESTAMPTZ', 'SHORT', timesta...'
-Function t_TIMESTAMPTZ_SHORT is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_SHORT('TIMESTAMPTZ', 'SHORT', timestamp...
+Function t_timestamptz_short is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_SHORT('TIMESTAMPTZ', 'SHORT', timestamp...
 
 ===================================================
 Error:-894
@@ -314,7 +314,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_SHORT('BIT(8)', 'SHORT', 0xaa ) ) ; '
-Function t_BIT_SHORT is undefined or given wrong number of parameter. select t_BIT_SHORT('BIT(8)', 'SHORT', X'aa'),  typeof(t_BIT_...
+Function t_bit_short is undefined or given wrong number of parameter. select t_BIT_SHORT('BIT(8)', 'SHORT', X'aa'),  typeof(t_BIT_...
 
 ===================================================
 Error:-894
@@ -338,7 +338,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_SHOR
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_SHORT('BIT VARYING', 'SHORT', 0xaa ) ) ; '
-Function t_BITVARYING_SHORT is undefined or given wrong number of parameter. select t_BITVARYING_SHORT('BIT VARYING', 'SHORT', X'aa'),  t...
+Function t_bitvarying_short is undefined or given wrong number of parameter. select t_BITVARYING_SHORT('BIT VARYING', 'SHORT', X'aa'),  t...
 
 ===================================================
 Error:-894
@@ -395,7 +395,7 @@ Stored procedure compile error: no viable alternative at input 'VAR SET'
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_SHORT('SET', 'SHORT', {'c','c','c','b','b','a...'
-Function t_SET_SHORT is undefined or given wrong number of parameter. select t_SET_SHORT('SET', 'SHORT'),  typeof(t_SET_SHORT('SET...
+Function t_set_short is undefined or given wrong number of parameter. select t_SET_SHORT('SET', 'SHORT'),  typeof(t_SET_SHORT('SET...
 
 ===================================================
 Error:-894
@@ -416,7 +416,7 @@ Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_SHORT('MULTISET', 'SHORT', {'c','c','c',...'
-Function t_MULTISET_SHORT is undefined or given wrong number of parameter. select t_MULTISET_SHORT('MULTISET', 'SHORT'),  typeof(t_MULT...
+Function t_multiset_short is undefined or given wrong number of parameter. select t_MULTISET_SHORT('MULTISET', 'SHORT'),  typeof(t_MULT...
 
 ===================================================
 Error:-894
@@ -437,7 +437,7 @@ Stored procedure compile error: no viable alternative at input 'VAR LIST'
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_SHORT('LIST', 'SHORT', {'c','c','c','b','b',...'
-Function t_LIST_SHORT is undefined or given wrong number of parameter. select t_LIST_SHORT('LIST', 'SHORT'),  typeof(t_LIST_SHORT('...
+Function t_list_short is undefined or given wrong number of parameter. select t_LIST_SHORT('LIST', 'SHORT'),  typeof(t_LIST_SHORT('...
 
 ===================================================
 Error:-894
@@ -458,7 +458,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_SHORT('ENUM', 'SHORT', 'yellow' ) ) ; '
-Function t_ENUM_SHORT is undefined or given wrong number of parameter. select t_ENUM_SHORT('ENUM', 'SHORT', 'yellow'),  typeof(t_EN...
+Function t_enum_short is undefined or given wrong number of parameter. select t_ENUM_SHORT('ENUM', 'SHORT', 'yellow'),  typeof(t_EN...
 
 ===================================================
 Error:-894
@@ -483,7 +483,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_SHORT('BLOB', 'SHORT', BIT_TO_BLOB(X'000010'...'
-Function t_BLOB_SHORT is undefined or given wrong number of parameter. select t_BLOB_SHORT('BLOB', 'SHORT',  bit_to_blob(X'000010')...
+Function t_blob_short is undefined or given wrong number of parameter. select t_BLOB_SHORT('BLOB', 'SHORT',  bit_to_blob(X'000010')...
 
 ===================================================
 Error:-894
@@ -508,7 +508,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_SHORT('CLOB', 'SHORT', CHAR_TO_CLOB('This is...'
-Function t_CLOB_SHORT is undefined or given wrong number of parameter. select t_CLOB_SHORT('CLOB', 'SHORT',  char_to_clob('This is ...
+Function t_clob_short is undefined or given wrong number of parameter. select t_CLOB_SHORT('CLOB', 'SHORT',  char_to_clob('This is ...
 
 ===================================================
 Error:-894
@@ -533,7 +533,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_SHORT('JSON', 'SHORT', '{"a":1}' ) ) ; '
-Function t_JSON_SHORT is undefined or given wrong number of parameter. select t_JSON_SHORT('JSON', 'SHORT', '{"a":1}'),  typeof(t_J...
+Function t_json_short is undefined or given wrong number of parameter. select t_JSON_SHORT('JSON', 'SHORT', '{"a":1}'),  typeof(t_J...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-11_variable_to_return_BIT.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-11_variable_to_return_BIT.answer
@@ -15,7 +15,7 @@ Semantic: Unsupported return type 'bit' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_BIT('DATETIME', 'BIT', DATETIME'2023-02-...'
-Function t_DATETIME_BIT is undefined or given wrong number of parameter. select t_DATETIME_BIT('DATETIME', 'BIT', datetime '2023-02-1...
+Function t_datetime_bit is undefined or given wrong number of parameter. select t_DATETIME_BIT('DATETIME', 'BIT', datetime '2023-02-1...
 
 ===================================================
 Error:-894
@@ -39,7 +39,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_BIT('DATETIMELTZ', 'BIT', datetimeltz...'
-Function t_DATETIMELTZ_BIT is undefined or given wrong number of parameter. select t_DATETIMELTZ_BIT('DATETIMELTZ', 'BIT', datetimeltz '...
+Function t_datetimeltz_bit is undefined or given wrong number of parameter. select t_DATETIMELTZ_BIT('DATETIMELTZ', 'BIT', datetimeltz '...
 
 ===================================================
 Error:-894
@@ -63,7 +63,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_BIT('DATETIMETZ', 'BIT', datetimetz '0...'
-Function t_DATETIMETZ_BIT is undefined or given wrong number of parameter. select t_DATETIMETZ_BIT('DATETIMETZ', 'BIT', datetimetz '09/...
+Function t_datetimetz_bit is undefined or given wrong number of parameter. select t_DATETIMETZ_BIT('DATETIMETZ', 'BIT', datetimetz '09/...
 
 ===================================================
 Error:-894
@@ -83,7 +83,7 @@ Semantic: Unsupported return type 'bit' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_BIT('DATE', 'BIT', DATE'2008-10-31' ) ) ; '
-Function t_DATE_BIT is undefined or given wrong number of parameter. select t_DATE_BIT('DATE', 'BIT', date '2008-10-31'),  typeof...
+Function t_date_bit is undefined or given wrong number of parameter. select t_DATE_BIT('DATE', 'BIT', date '2008-10-31'),  typeof...
 
 ===================================================
 Error:-894
@@ -103,7 +103,7 @@ Semantic: Unsupported return type 'bit' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_BIT('TIME', 'BIT', TIME'13:15:45' ) ) ; '
-Function t_TIME_BIT is undefined or given wrong number of parameter. select t_TIME_BIT('TIME', 'BIT', time '13:15:45'),  typeof(t...
+Function t_time_bit is undefined or given wrong number of parameter. select t_TIME_BIT('TIME', 'BIT', time '13:15:45'),  typeof(t...
 
 ===================================================
 Error:-894
@@ -123,7 +123,7 @@ Semantic: Unsupported return type 'bit' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_BIT('TIMESTAMP', 'BIT', TIMESTAMP'2023-...'
-Function t_TIMESTAMP_BIT is undefined or given wrong number of parameter. select t_TIMESTAMP_BIT('TIMESTAMP', 'BIT', timestamp '2023-1...
+Function t_timestamp_bit is undefined or given wrong number of parameter. select t_TIMESTAMP_BIT('TIMESTAMP', 'BIT', timestamp '2023-1...
 
 ===================================================
 Error:-894
@@ -147,7 +147,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_BIT('TIMESTAMPLTZ', 'BIT', timestamp...'
-Function t_TIMESTAMPLTZ_BIT is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_BIT('TIMESTAMPLTZ', 'BIT', timestamptz...
+Function t_timestampltz_bit is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_BIT('TIMESTAMPLTZ', 'BIT', timestamptz...
 
 ===================================================
 Error:-894
@@ -171,7 +171,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_BIT('TIMESTAMPTZ', 'BIT', timestamptz...'
-Function t_TIMESTAMPTZ_BIT is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_BIT('TIMESTAMPTZ', 'BIT', timestamptz '...
+Function t_timestamptz_bit is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_BIT('TIMESTAMPTZ', 'BIT', timestamptz '...
 
 ===================================================
 Error:-894
@@ -191,7 +191,7 @@ Semantic: Unsupported return type 'bit' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DOUBLE_BIT('DOUBLE', 'BIT', cast( 1234.56789 as d...'
-Function t_DOUBLE_BIT is undefined or given wrong number of parameter. select t_DOUBLE_BIT('DOUBLE', 'BIT',  cast(1234.56789 as dou...
+Function t_double_bit is undefined or given wrong number of parameter. select t_DOUBLE_BIT('DOUBLE', 'BIT',  cast(1234.56789 as dou...
 
 ===================================================
 Error:-894
@@ -211,7 +211,7 @@ Semantic: Unsupported return type 'bit' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_FLOAT_BIT('FLOAT', 'BIT', cast( 16777.217 as floa...'
-Function t_FLOAT_BIT is undefined or given wrong number of parameter. select t_FLOAT_BIT('FLOAT', 'BIT',  cast(16777.217 as float)...
+Function t_float_bit is undefined or given wrong number of parameter. select t_FLOAT_BIT('FLOAT', 'BIT',  cast(16777.217 as float)...
 
 ===================================================
 Error:-894
@@ -231,7 +231,7 @@ Semantic: Unsupported return type 'bit' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_NUMERIC_BIT('NUMERIC(8,4)', 'BIT', cast( 0.123456...'
-Function t_NUMERIC_BIT is undefined or given wrong number of parameter. select t_NUMERIC_BIT('NUMERIC(8,4)', 'BIT',  cast(0.12345678...
+Function t_numeric_bit is undefined or given wrong number of parameter. select t_NUMERIC_BIT('NUMERIC(8,4)', 'BIT',  cast(0.12345678...
 
 ===================================================
 Error:-894
@@ -251,7 +251,7 @@ Semantic: Unsupported return type 'bit' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_BIGINT_BIT('BIGINT', 'BIT', cast( 34589012 as big...'
-Function t_BIGINT_BIT is undefined or given wrong number of parameter. select t_BIGINT_BIT('BIGINT', 'BIT',  cast(34589012 as bigin...
+Function t_bigint_bit is undefined or given wrong number of parameter. select t_BIGINT_BIT('BIGINT', 'BIT',  cast(34589012 as bigin...
 
 ===================================================
 Error:-894
@@ -271,7 +271,7 @@ Semantic: Unsupported return type 'bit' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_INT_BIT('INT', 'BIT', cast( 782346 as int ) ) ) ; '
-Function t_INT_BIT is undefined or given wrong number of parameter. select t_INT_BIT('INT', 'BIT',  cast(782346 as integer)),  t...
+Function t_int_bit is undefined or given wrong number of parameter. select t_INT_BIT('INT', 'BIT',  cast(782346 as integer)),  t...
 
 ===================================================
 Error:-894
@@ -291,7 +291,7 @@ Semantic: Unsupported return type 'bit' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_SHORT_BIT('SHORT', 'BIT', cast( 8934 as short ) )...'
-Function t_SHORT_BIT is undefined or given wrong number of parameter. select t_SHORT_BIT('SHORT', 'BIT',  cast(8934 as smallint)),...
+Function t_short_bit is undefined or given wrong number of parameter. select t_SHORT_BIT('SHORT', 'BIT',  cast(8934 as smallint)),...
 
 ===================================================
 Error:-894
@@ -316,7 +316,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_BIT('BIT(8)', 'BIT', 0xaa ) ) ; '
-Function t_BIT_BIT is undefined or given wrong number of parameter. select t_BIT_BIT('BIT(8)', 'BIT', X'aa'),  typeof(t_BIT_BIT(...
+Function t_bit_bit is undefined or given wrong number of parameter. select t_BIT_BIT('BIT(8)', 'BIT', X'aa'),  typeof(t_BIT_BIT(...
 
 ===================================================
 Error:-894
@@ -340,7 +340,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_BIT]
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_BIT('BIT VARYING', 'BIT', 0xaa ) ) ; '
-Function t_BITVARYING_BIT is undefined or given wrong number of parameter. select t_BITVARYING_BIT('BIT VARYING', 'BIT', X'aa'),  typeo...
+Function t_bitvarying_bit is undefined or given wrong number of parameter. select t_BITVARYING_BIT('BIT VARYING', 'BIT', X'aa'),  typeo...
 
 ===================================================
 Error:-894
@@ -360,7 +360,7 @@ Semantic: Unsupported return type 'bit' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_CHAR_BIT('CHAR', 'BIT', 'CHAR CUBRID' ) ) ; '
-Function t_CHAR_BIT is undefined or given wrong number of parameter. select t_CHAR_BIT('CHAR', 'BIT', 'CHAR CUBRID'),  typeof(t_C...
+Function t_char_bit is undefined or given wrong number of parameter. select t_CHAR_BIT('CHAR', 'BIT', 'CHAR CUBRID'),  typeof(t_C...
 
 ===================================================
 Error:-894
@@ -380,7 +380,7 @@ Semantic: Unsupported return type 'bit' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_VARCHAR_BIT('VARCHAR', 'BIT', 'VARCHAR CUBRID' ) ...'
-Function t_VARCHAR_BIT is undefined or given wrong number of parameter. select t_VARCHAR_BIT('VARCHAR', 'BIT', 'VARCHAR CUBRID'),  t...
+Function t_varchar_bit is undefined or given wrong number of parameter. select t_VARCHAR_BIT('VARCHAR', 'BIT', 'VARCHAR CUBRID'),  t...
 
 ===================================================
 Error:-894
@@ -400,7 +400,7 @@ Semantic: Unsupported return type 'bit' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_BIT('SET', 'BIT', {'c','c','c','b','b','a'} )...'
-Function t_SET_BIT is undefined or given wrong number of parameter. select t_SET_BIT('SET', 'BIT'),  typeof(t_SET_BIT('SET', 'BIT'))
+Function t_set_bit is undefined or given wrong number of parameter. select t_SET_BIT('SET', 'BIT'),  typeof(t_SET_BIT('SET', 'BIT'))
 
 ===================================================
 Error:-894
@@ -420,7 +420,7 @@ Semantic: Unsupported return type 'bit' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_BIT('MULTISET', 'BIT', {'c','c','c','b',...'
-Function t_MULTISET_BIT is undefined or given wrong number of parameter. select t_MULTISET_BIT('MULTISET', 'BIT'),  typeof(t_MULTISET...
+Function t_multiset_bit is undefined or given wrong number of parameter. select t_MULTISET_BIT('MULTISET', 'BIT'),  typeof(t_MULTISET...
 
 ===================================================
 Error:-894
@@ -440,7 +440,7 @@ Semantic: Unsupported return type 'bit' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_BIT('LIST', 'BIT', {'c','c','c','b','b', 'a'...'
-Function t_LIST_BIT is undefined or given wrong number of parameter. select t_LIST_BIT('LIST', 'BIT'),  typeof(t_LIST_BIT('LIST',...
+Function t_list_bit is undefined or given wrong number of parameter. select t_LIST_BIT('LIST', 'BIT'),  typeof(t_LIST_BIT('LIST',...
 
 ===================================================
 Error:-894
@@ -461,7 +461,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_BIT('ENUM', 'BIT', 'yellow' ) ) ; '
-Function t_ENUM_BIT is undefined or given wrong number of parameter. select t_ENUM_BIT('ENUM', 'BIT', 'yellow'),  typeof(t_ENUM_B...
+Function t_enum_bit is undefined or given wrong number of parameter. select t_ENUM_BIT('ENUM', 'BIT', 'yellow'),  typeof(t_ENUM_B...
 
 ===================================================
 Error:-894
@@ -486,7 +486,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_BIT('BLOB', 'BIT', BIT_TO_BLOB(X'000010') ) ...'
-Function t_BLOB_BIT is undefined or given wrong number of parameter. select t_BLOB_BIT('BLOB', 'BIT',  bit_to_blob(X'000010')),  ...
+Function t_blob_bit is undefined or given wrong number of parameter. select t_BLOB_BIT('BLOB', 'BIT',  bit_to_blob(X'000010')),  ...
 
 ===================================================
 Error:-894
@@ -511,7 +511,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_BIT('CLOB', 'BIT', CHAR_TO_CLOB('This is a D...'
-Function t_CLOB_BIT is undefined or given wrong number of parameter. select t_CLOB_BIT('CLOB', 'BIT',  char_to_clob('This is a Do...
+Function t_clob_bit is undefined or given wrong number of parameter. select t_CLOB_BIT('CLOB', 'BIT',  char_to_clob('This is a Do...
 
 ===================================================
 Error:-894
@@ -536,7 +536,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_BIT('JSON', 'BIT', '{"a":1}' ) ) ; '
-Function t_JSON_BIT is undefined or given wrong number of parameter. select t_JSON_BIT('JSON', 'BIT', '{"a":1}'),  typeof(t_JSON_...
+Function t_json_bit is undefined or given wrong number of parameter. select t_JSON_BIT('JSON', 'BIT', '{"a":1}'),  typeof(t_JSON_...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-12_variable_to_return_BIT_VARYING.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-12_variable_to_return_BIT_VARYING.answer
@@ -15,7 +15,7 @@ Semantic: Unsupported return type 'bit varying' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_BITVARYING('DATETIME', 'BIT VARYING', DA...'
-Function t_DATETIME_BITVARYING is undefined or given wrong number of parameter. select t_DATETIME_BITVARYING('DATETIME', 'BIT VARYING', date...
+Function t_datetime_bitvarying is undefined or given wrong number of parameter. select t_DATETIME_BITVARYING('DATETIME', 'BIT VARYING', date...
 
 ===================================================
 Error:-894
@@ -39,7 +39,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_BITVARYING('DATETIMELTZ', 'BIT VARYIN...'
-Function t_DATETIMELTZ_BITVARYING is undefined or given wrong number of parameter. select t_DATETIMELTZ_BITVARYING('DATETIMELTZ', 'BIT VARYING'...
+Function t_datetimeltz_bitvarying is undefined or given wrong number of parameter. select t_DATETIMELTZ_BITVARYING('DATETIMELTZ', 'BIT VARYING'...
 
 ===================================================
 Error:-894
@@ -63,7 +63,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_BITVARYING('DATETIMETZ', 'BIT VARYING'...'
-Function t_DATETIMETZ_BITVARYING is undefined or given wrong number of parameter. select t_DATETIMETZ_BITVARYING('DATETIMETZ', 'BIT VARYING', ...
+Function t_datetimetz_bitvarying is undefined or given wrong number of parameter. select t_DATETIMETZ_BITVARYING('DATETIMETZ', 'BIT VARYING', ...
 
 ===================================================
 Error:-894
@@ -83,7 +83,7 @@ Semantic: Unsupported return type 'bit varying' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_BITVARYING('DATE', 'BIT VARYING', DATE'2008-...'
-Function t_DATE_BITVARYING is undefined or given wrong number of parameter. select t_DATE_BITVARYING('DATE', 'BIT VARYING', date '2008-1...
+Function t_date_bitvarying is undefined or given wrong number of parameter. select t_DATE_BITVARYING('DATE', 'BIT VARYING', date '2008-1...
 
 ===================================================
 Error:-894
@@ -103,7 +103,7 @@ Semantic: Unsupported return type 'bit varying' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_BITVARYING('TIME', 'BIT VARYING', TIME'13:15...'
-Function t_TIME_BITVARYING is undefined or given wrong number of parameter. select t_TIME_BITVARYING('TIME', 'BIT VARYING', time '13:15:...
+Function t_time_bitvarying is undefined or given wrong number of parameter. select t_TIME_BITVARYING('TIME', 'BIT VARYING', time '13:15:...
 
 ===================================================
 Error:-894
@@ -123,7 +123,7 @@ Semantic: Unsupported return type 'bit varying' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_BITVARYING('TIMESTAMP', 'BIT VARYING', ...'
-Function t_TIMESTAMP_BITVARYING is undefined or given wrong number of parameter. select t_TIMESTAMP_BITVARYING('TIMESTAMP', 'BIT VARYING', ti...
+Function t_timestamp_bitvarying is undefined or given wrong number of parameter. select t_TIMESTAMP_BITVARYING('TIMESTAMP', 'BIT VARYING', ti...
 
 ===================================================
 Error:-894
@@ -147,7 +147,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_BITVARYING('TIMESTAMPLTZ', 'BIT VARY...'
-Function t_TIMESTAMPLTZ_BITVARYING is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_BITVARYING('TIMESTAMPLTZ', 'BIT VARYIN...
+Function t_timestampltz_bitvarying is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_BITVARYING('TIMESTAMPLTZ', 'BIT VARYIN...
 
 ===================================================
 Error:-894
@@ -171,7 +171,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_BITVARYING('TIMESTAMPTZ', 'BIT VARYIN...'
-Function t_TIMESTAMPTZ_BITVARYING is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_BITVARYING('TIMESTAMPTZ', 'BIT VARYING'...
+Function t_timestamptz_bitvarying is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_BITVARYING('TIMESTAMPTZ', 'BIT VARYING'...
 
 ===================================================
 Error:-894
@@ -191,7 +191,7 @@ Semantic: Unsupported return type 'bit varying' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_DOUBLE_BITVARYING('DOUBLE', 'BIT VARYING', cast( ...'
-Function t_DOUBLE_BITVARYING is undefined or given wrong number of parameter. select t_DOUBLE_BITVARYING('DOUBLE', 'BIT VARYING',  cast(12...
+Function t_double_bitvarying is undefined or given wrong number of parameter. select t_DOUBLE_BITVARYING('DOUBLE', 'BIT VARYING',  cast(12...
 
 ===================================================
 Error:-894
@@ -211,7 +211,7 @@ Semantic: Unsupported return type 'bit varying' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_FLOAT_BITVARYING('FLOAT', 'BIT VARYING', cast( 16...'
-Function t_FLOAT_BITVARYING is undefined or given wrong number of parameter. select t_FLOAT_BITVARYING('FLOAT', 'BIT VARYING',  cast(1677...
+Function t_float_bitvarying is undefined or given wrong number of parameter. select t_FLOAT_BITVARYING('FLOAT', 'BIT VARYING',  cast(1677...
 
 ===================================================
 Error:-894
@@ -231,7 +231,7 @@ Semantic: Unsupported return type 'bit varying' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_NUMERIC_BITVARYING('NUMERIC(8,4)', 'BIT VARYING',...'
-Function t_NUMERIC_BITVARYING is undefined or given wrong number of parameter. select t_NUMERIC_BITVARYING('NUMERIC(8,4)', 'BIT VARYING',  ...
+Function t_numeric_bitvarying is undefined or given wrong number of parameter. select t_NUMERIC_BITVARYING('NUMERIC(8,4)', 'BIT VARYING',  ...
 
 ===================================================
 Error:-894
@@ -251,7 +251,7 @@ Semantic: Unsupported return type 'bit varying' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_BIGINT_BITVARYING('BIGINT', 'BIT VARYING', cast( ...'
-Function t_BIGINT_BITVARYING is undefined or given wrong number of parameter. select t_BIGINT_BITVARYING('BIGINT', 'BIT VARYING',  cast(34...
+Function t_bigint_bitvarying is undefined or given wrong number of parameter. select t_BIGINT_BITVARYING('BIGINT', 'BIT VARYING',  cast(34...
 
 ===================================================
 Error:-894
@@ -271,7 +271,7 @@ Semantic: Unsupported return type 'bit varying' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_INT_BITVARYING('INT', 'BIT VARYING', cast( 782346...'
-Function t_INT_BITVARYING is undefined or given wrong number of parameter. select t_INT_BITVARYING('INT', 'BIT VARYING',  cast(782346 a...
+Function t_int_bitvarying is undefined or given wrong number of parameter. select t_INT_BITVARYING('INT', 'BIT VARYING',  cast(782346 a...
 
 ===================================================
 Error:-894
@@ -291,7 +291,7 @@ Semantic: Unsupported return type 'bit varying' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_SHORT_BITVARYING('SHORT', 'BIT VARYING', cast( 89...'
-Function t_SHORT_BITVARYING is undefined or given wrong number of parameter. select t_SHORT_BITVARYING('SHORT', 'BIT VARYING',  cast(8934...
+Function t_short_bitvarying is undefined or given wrong number of parameter. select t_SHORT_BITVARYING('SHORT', 'BIT VARYING',  cast(8934...
 
 ===================================================
 Error:-894
@@ -315,7 +315,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_BITVARYING('BIT(8)', 'BIT VARYING', 0xaa ) ) ; '
-Function t_BIT_BITVARYING is undefined or given wrong number of parameter. select t_BIT_BITVARYING('BIT(8)', 'BIT VARYING', X'aa'),  ty...
+Function t_bit_bitvarying is undefined or given wrong number of parameter. select t_BIT_BITVARYING('BIT(8)', 'BIT VARYING', X'aa'),  ty...
 
 ===================================================
 Error:-894
@@ -339,7 +339,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_BITV
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_BITVARYING('BIT VARYING', 'BIT VARYING...'
-Function t_BITVARYING_BITVARYING is undefined or given wrong number of parameter. select t_BITVARYING_BITVARYING('BIT VARYING', 'BIT VARYING',...
+Function t_bitvarying_bitvarying is undefined or given wrong number of parameter. select t_BITVARYING_BITVARYING('BIT VARYING', 'BIT VARYING',...
 
 ===================================================
 Error:-894
@@ -359,7 +359,7 @@ Semantic: Unsupported return type 'bit varying' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_CHAR_BITVARYING('CHAR', 'BIT VARYING', 0xaa ) ) ; '
-Function t_CHAR_BITVARYING is undefined or given wrong number of parameter. select t_CHAR_BITVARYING('CHAR', 'BIT VARYING', X'aa'),  typ...
+Function t_char_bitvarying is undefined or given wrong number of parameter. select t_CHAR_BITVARYING('CHAR', 'BIT VARYING', X'aa'),  typ...
 
 ===================================================
 Error:-894
@@ -379,7 +379,7 @@ Semantic: Unsupported return type 'bit varying' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_VARCHAR_BITVARYING('VARCHAR', 'BIT VARYING', 0xaa...'
-Function t_VARCHAR_BITVARYING is undefined or given wrong number of parameter. select t_VARCHAR_BITVARYING('VARCHAR', 'BIT VARYING', X'aa')...
+Function t_varchar_bitvarying is undefined or given wrong number of parameter. select t_VARCHAR_BITVARYING('VARCHAR', 'BIT VARYING', X'aa')...
 
 ===================================================
 Error:-894
@@ -399,7 +399,7 @@ Semantic: Unsupported return type 'bit varying' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_BITVARYING('SET', 'BIT VARYING', {'c','c','c'...'
-Function t_SET_BITVARYING is undefined or given wrong number of parameter. select t_SET_BITVARYING('SET', 'BIT VARYING'),  typeof(t_SET...
+Function t_set_bitvarying is undefined or given wrong number of parameter. select t_SET_BITVARYING('SET', 'BIT VARYING'),  typeof(t_SET...
 
 ===================================================
 Error:-894
@@ -419,7 +419,7 @@ Semantic: Unsupported return type 'bit varying' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_BITVARYING('MULTISET', 'BIT VARYING', {'...'
-Function t_MULTISET_BITVARYING is undefined or given wrong number of parameter. select t_MULTISET_BITVARYING('MULTISET', 'BIT VARYING'),  ty...
+Function t_multiset_bitvarying is undefined or given wrong number of parameter. select t_MULTISET_BITVARYING('MULTISET', 'BIT VARYING'),  ty...
 
 ===================================================
 Error:-894
@@ -439,7 +439,7 @@ Semantic: Unsupported return type 'bit varying' of the stored procedure create o
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_BITVARYING('LIST', 'BIT VARYING', {'c','c','...'
-Function t_LIST_BITVARYING is undefined or given wrong number of parameter. select t_LIST_BITVARYING('LIST', 'BIT VARYING'),  typeof(t_L...
+Function t_list_bitvarying is undefined or given wrong number of parameter. select t_LIST_BITVARYING('LIST', 'BIT VARYING'),  typeof(t_L...
 
 ===================================================
 Error:-894
@@ -460,7 +460,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_BITVARYING('ENUM', 'BIT VARYING', 'yellow' )...'
-Function t_ENUM_BITVARYING is undefined or given wrong number of parameter. select t_ENUM_BITVARYING('ENUM', 'BIT VARYING', 'yellow'),  ...
+Function t_enum_bitvarying is undefined or given wrong number of parameter. select t_ENUM_BITVARYING('ENUM', 'BIT VARYING', 'yellow'),  ...
 
 ===================================================
 Error:-894
@@ -484,7 +484,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_BITVARYING('BLOB', 'BIT VARYING', BIT_TO_BLO...'
-Function t_BLOB_BITVARYING is undefined or given wrong number of parameter. select t_BLOB_BITVARYING('BLOB', 'BIT VARYING',  bit_to_blob...
+Function t_blob_bitvarying is undefined or given wrong number of parameter. select t_BLOB_BITVARYING('BLOB', 'BIT VARYING',  bit_to_blob...
 
 ===================================================
 Error:-894
@@ -508,7 +508,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_BITVARYING('CLOB', 'BIT VARYING', CHAR_TO_CL...'
-Function t_CLOB_BITVARYING is undefined or given wrong number of parameter. select t_CLOB_BITVARYING('CLOB', 'BIT VARYING',  char_to_clo...
+Function t_clob_bitvarying is undefined or given wrong number of parameter. select t_CLOB_BITVARYING('CLOB', 'BIT VARYING',  char_to_clo...
 
 ===================================================
 Error:-894
@@ -532,7 +532,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_BITVARYING('JSON', 'BIT VARYING', '{"a":1}' ...'
-Function t_JSON_BITVARYING is undefined or given wrong number of parameter. select t_JSON_BITVARYING('JSON', 'BIT VARYING', '{"a":1}'), ...
+Function t_json_bitvarying is undefined or given wrong number of parameter. select t_JSON_BITVARYING('JSON', 'BIT VARYING', '{"a":1}'), ...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-13_variable_to_return_CHAR.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-13_variable_to_return_CHAR.answer
@@ -31,14 +31,14 @@ Error:-494
 Semantic: before '  ) RETURN CHAR IS
 VAR DATETIMELTZ  ;
 begin
-VAR := param_v...'
+VAR := param_value...'
 Unsupported argument type 'datetimeltz' of the stored procedure create or replace function [dba.t_DATETIMELTZ_CHAR](variable...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_CHAR('DATETIMELTZ', 'CHAR', datetimel...'
-Function t_DATETIMELTZ_CHAR is undefined or given wrong number of parameter. select t_DATETIMELTZ_CHAR('DATETIMELTZ', 'CHAR', datetimeltz...
+Function t_datetimeltz_char is undefined or given wrong number of parameter. select t_DATETIMELTZ_CHAR('DATETIMELTZ', 'CHAR', datetimeltz...
 
 ===================================================
 Error:-894
@@ -55,12 +55,14 @@ Error:-494
 Semantic: before '  ) RETURN CHAR IS
 VAR DATETIMETZ  ;
 begin
+VAR := param_value ...'
+Unsupported argument type 'datetimetz' of the stored procedure create or replace function [dba.t_DATETIMETZ_CHAR](variables...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_CHAR('DATETIMETZ', 'CHAR', datetimetz ...'
-Function t_DATETIMETZ_CHAR is undefined or given wrong number of parameter. select t_DATETIMETZ_CHAR('DATETIMETZ', 'CHAR', datetimetz '0...
+Function t_datetimetz_char is undefined or given wrong number of parameter. select t_DATETIMETZ_CHAR('DATETIMETZ', 'CHAR', datetimetz '0...
 
 ===================================================
 Error:-894
@@ -134,12 +136,14 @@ Error:-494
 Semantic: before '  ) RETURN CHAR IS
 VAR TIMESTAMPLTZ  ;
 begin
+VAR := param_valu...'
+Unsupported argument type 'timestampltz' of the stored procedure create or replace function [dba.t_TIMESTAMPLTZ_CHAR](variabl...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_CHAR('TIMESTAMPLTZ', 'CHAR', timesta...'
-Function t_TIMESTAMPLTZ_CHAR is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_CHAR('TIMESTAMPLTZ', 'CHAR', timestamp...
+Function t_timestampltz_char is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_CHAR('TIMESTAMPLTZ', 'CHAR', timestamp...
 
 ===================================================
 Error:-894
@@ -156,12 +160,14 @@ Error:-494
 Semantic: before '  ) RETURN CHAR IS
 VAR TIMESTAMPTZ  ;
 begin
+VAR := param_value...'
+Unsupported argument type 'timestamptz' of the stored procedure create or replace function [dba.t_TIMESTAMPTZ_CHAR](variable...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_CHAR('TIMESTAMPTZ', 'CHAR', timestamp...'
-Function t_TIMESTAMPTZ_CHAR is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_CHAR('TIMESTAMPTZ', 'CHAR', timestamptz...
+Function t_timestamptz_char is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_CHAR('TIMESTAMPTZ', 'CHAR', timestamptz...
 
 ===================================================
 Error:-894
@@ -292,12 +298,15 @@ Error:-494
 Semantic: before '  ) RETURN CHAR IS
 VAR BIT(8)  ;
 begin
+VAR := param_value ;
+db...'
+Unsupported argument type 'bit' of the stored procedure create or replace function [dba.t_BIT_CHAR](variables_type  ...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_CHAR('BIT(8)', 'CHAR', 0xaa ) ) ; '
-Function t_BIT_CHAR is undefined or given wrong number of parameter. select t_BIT_CHAR('BIT(8)', 'CHAR', X'aa'),  typeof(t_BIT_CH...
+Function t_bit_char is undefined or given wrong number of parameter. select t_BIT_CHAR('BIT(8)', 'CHAR', X'aa'),  typeof(t_BIT_CH...
 
 ===================================================
 Error:-894
@@ -314,12 +323,14 @@ Error:-494
 Semantic: before '  ) RETURN CHAR IS
 VAR BIT VARYING  ;
 begin
+VAR := param_value...'
+dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_CHAR](variables...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_CHAR('BIT VARYING', 'CHAR', 0xaa ) ) ; '
-Function t_BITVARYING_CHAR is undefined or given wrong number of parameter. select t_BITVARYING_CHAR('BIT VARYING', 'CHAR', X'aa'),  typ...
+Function t_bitvarying_char is undefined or given wrong number of parameter. select t_BITVARYING_CHAR('BIT VARYING', 'CHAR', X'aa'),  typ...
 
 ===================================================
 Error:-894
@@ -376,7 +387,7 @@ Stored procedure compile error: no viable alternative at input 'VAR SET'
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_CHAR('SET', 'CHAR', {'c','c','c','b','b','a'}...'
-Function t_SET_CHAR is undefined or given wrong number of parameter. select t_SET_CHAR('SET', 'CHAR'),  typeof(t_SET_CHAR('SET', ...
+Function t_set_char is undefined or given wrong number of parameter. select t_SET_CHAR('SET', 'CHAR'),  typeof(t_SET_CHAR('SET', ...
 
 ===================================================
 Error:-894
@@ -397,7 +408,7 @@ Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_CHAR('MULTISET', 'CHAR', {'c','c','c','b...'
-Function t_MULTISET_CHAR is undefined or given wrong number of parameter. select t_MULTISET_CHAR('MULTISET', 'CHAR'),  typeof(t_MULTIS...
+Function t_multiset_char is undefined or given wrong number of parameter. select t_MULTISET_CHAR('MULTISET', 'CHAR'),  typeof(t_MULTIS...
 
 ===================================================
 Error:-894
@@ -418,7 +429,7 @@ Stored procedure compile error: no viable alternative at input 'VAR LIST'
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_CHAR('LIST', 'CHAR', {'c','c','c','b','b', '...'
-Function t_LIST_CHAR is undefined or given wrong number of parameter. select t_LIST_CHAR('LIST', 'CHAR'),  typeof(t_LIST_CHAR('LIS...
+Function t_list_char is undefined or given wrong number of parameter. select t_LIST_CHAR('LIST', 'CHAR'),  typeof(t_LIST_CHAR('LIS...
 
 ===================================================
 Error:-894
@@ -439,7 +450,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_CHAR('ENUM', 'CHAR', 'yellow' ) ) ; '
-Function t_ENUM_CHAR is undefined or given wrong number of parameter. select t_ENUM_CHAR('ENUM', 'CHAR', 'yellow'),  typeof(t_ENUM...
+Function t_enum_char is undefined or given wrong number of parameter. select t_ENUM_CHAR('ENUM', 'CHAR', 'yellow'),  typeof(t_ENUM...
 
 ===================================================
 Error:-894
@@ -457,12 +468,14 @@ Semantic: before '  ) RETURN CHAR IS
 VAR BLOB  ;
 begin
 VAR := param_value ;
+dbms...'
+Unsupported argument type 'blob' of the stored procedure create or replace function [dba.t_BLOB_CHAR](variables_type ...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_CHAR('BLOB', 'CHAR', BIT_TO_BLOB(X'000010') ...'
-Function t_BLOB_CHAR is undefined or given wrong number of parameter. select t_BLOB_CHAR('BLOB', 'CHAR',  bit_to_blob(X'000010')),...
+Function t_blob_char is undefined or given wrong number of parameter. select t_BLOB_CHAR('BLOB', 'CHAR',  bit_to_blob(X'000010')),...
 
 ===================================================
 Error:-894
@@ -480,12 +493,14 @@ Semantic: before '  ) RETURN CHAR IS
 VAR CLOB  ;
 begin
 VAR := param_value ;
+dbms...'
+Unsupported argument type 'clob' of the stored procedure create or replace function [dba.t_CLOB_CHAR](variables_type ...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_CHAR('CLOB', 'CHAR', CHAR_TO_CLOB('This is a...'
-Function t_CLOB_CHAR is undefined or given wrong number of parameter. select t_CLOB_CHAR('CLOB', 'CHAR',  char_to_clob('This is a ...
+Function t_clob_char is undefined or given wrong number of parameter. select t_CLOB_CHAR('CLOB', 'CHAR',  char_to_clob('This is a ...
 
 ===================================================
 Error:-894
@@ -503,12 +518,14 @@ Semantic: before '  ) RETURN CHAR IS
 VAR JSON  ;
 begin
 VAR := param_value ;
+dbms...'
+Unsupported argument type 'json' of the stored procedure create or replace function [dba.t_JSON_CHAR](variables_type ...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_CHAR('JSON', 'CHAR', '{"a":1}' ) ) ; '
-Function t_JSON_CHAR is undefined or given wrong number of parameter. select t_JSON_CHAR('JSON', 'CHAR', '{"a":1}'),  typeof(t_JSO...
+Function t_json_char is undefined or given wrong number of parameter. select t_JSON_CHAR('JSON', 'CHAR', '{"a":1}'),  typeof(t_JSO...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-14_variable_to_return_VARCHAR.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-14_variable_to_return_VARCHAR.answer
@@ -38,7 +38,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_VARCHAR('DATETIMELTZ', 'VARCHAR', dat...'
-Function t_DATETIMELTZ_VARCHAR is undefined or given wrong number of parameter. select t_DATETIMELTZ_VARCHAR('DATETIMELTZ', 'VARCHAR', datet...
+Function t_datetimeltz_varchar is undefined or given wrong number of parameter. select t_DATETIMELTZ_VARCHAR('DATETIMELTZ', 'VARCHAR', datet...
 
 ===================================================
 Error:-894
@@ -62,7 +62,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_VARCHAR('DATETIMETZ', 'VARCHAR', datet...'
-Function t_DATETIMETZ_VARCHAR is undefined or given wrong number of parameter. select t_DATETIMETZ_VARCHAR('DATETIMETZ', 'VARCHAR', datetim...
+Function t_datetimetz_varchar is undefined or given wrong number of parameter. select t_DATETIMETZ_VARCHAR('DATETIMETZ', 'VARCHAR', datetim...
 
 ===================================================
 Error:-894
@@ -143,7 +143,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_VARCHAR('TIMESTAMPLTZ', 'VARCHAR', t...'
-Function t_TIMESTAMPLTZ_VARCHAR is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_VARCHAR('TIMESTAMPLTZ', 'VARCHAR', tim...
+Function t_timestampltz_varchar is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_VARCHAR('TIMESTAMPLTZ', 'VARCHAR', tim...
 
 ===================================================
 Error:-894
@@ -167,7 +167,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_VARCHAR('TIMESTAMPTZ', 'VARCHAR', tim...'
-Function t_TIMESTAMPTZ_VARCHAR is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_VARCHAR('TIMESTAMPTZ', 'VARCHAR', times...
+Function t_timestamptz_varchar is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_VARCHAR('TIMESTAMPTZ', 'VARCHAR', times...
 
 ===================================================
 Error:-894
@@ -305,7 +305,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_VARCHAR('BIT(8)', 'VARCHAR', 0xaa ) ) ; '
-Function t_BIT_VARCHAR is undefined or given wrong number of parameter. select t_BIT_VARCHAR('BIT(8)', 'VARCHAR', X'aa'),  typeof(t_...
+Function t_bit_varchar is undefined or given wrong number of parameter. select t_BIT_VARCHAR('BIT(8)', 'VARCHAR', X'aa'),  typeof(t_...
 
 ===================================================
 Error:-894
@@ -329,7 +329,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_VARC
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_VARCHAR('BIT VARYING', 'VARCHAR', 0xaa...'
-Function t_BITVARYING_VARCHAR is undefined or given wrong number of parameter. select t_BITVARYING_VARCHAR('BIT VARYING', 'VARCHAR', X'aa')...
+Function t_bitvarying_varchar is undefined or given wrong number of parameter. select t_BITVARYING_VARCHAR('BIT VARYING', 'VARCHAR', X'aa')...
 
 ===================================================
 Error:-894
@@ -386,7 +386,7 @@ Stored procedure compile error: no viable alternative at input 'VAR SET'
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_VARCHAR('SET', 'VARCHAR', {'c','c','c','b','b...'
-Function t_SET_VARCHAR is undefined or given wrong number of parameter. select t_SET_VARCHAR('SET', 'VARCHAR'),  typeof(t_SET_VARCHA...
+Function t_set_varchar is undefined or given wrong number of parameter. select t_SET_VARCHAR('SET', 'VARCHAR'),  typeof(t_SET_VARCHA...
 
 ===================================================
 Error:-894
@@ -407,7 +407,7 @@ Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_VARCHAR('MULTISET', 'VARCHAR', {'c','c',...'
-Function t_MULTISET_VARCHAR is undefined or given wrong number of parameter. select t_MULTISET_VARCHAR('MULTISET', 'VARCHAR'),  typeof(t_...
+Function t_multiset_varchar is undefined or given wrong number of parameter. select t_MULTISET_VARCHAR('MULTISET', 'VARCHAR'),  typeof(t_...
 
 ===================================================
 Error:-894
@@ -428,7 +428,7 @@ Stored procedure compile error: no viable alternative at input 'VAR LIST'
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_VARCHAR('LIST', 'VARCHAR', {'c','c','c','b',...'
-Function t_LIST_VARCHAR is undefined or given wrong number of parameter. select t_LIST_VARCHAR('LIST', 'VARCHAR'),  typeof(t_LIST_VAR...
+Function t_list_varchar is undefined or given wrong number of parameter. select t_LIST_VARCHAR('LIST', 'VARCHAR'),  typeof(t_LIST_VAR...
 
 ===================================================
 Error:-894
@@ -449,7 +449,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_VARCHAR('ENUM', 'VARCHAR', 'yellow' ) ) ; '
-Function t_ENUM_VARCHAR is undefined or given wrong number of parameter. select t_ENUM_VARCHAR('ENUM', 'VARCHAR', 'yellow'),  typeof(...
+Function t_enum_varchar is undefined or given wrong number of parameter. select t_ENUM_VARCHAR('ENUM', 'VARCHAR', 'yellow'),  typeof(...
 
 ===================================================
 Error:-894
@@ -474,7 +474,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_VARCHAR('BLOB', 'VARCHAR', BIT_TO_BLOB(X'000...'
-Function t_BLOB_VARCHAR is undefined or given wrong number of parameter. select t_BLOB_VARCHAR('BLOB', 'VARCHAR',  bit_to_blob(X'0000...
+Function t_blob_varchar is undefined or given wrong number of parameter. select t_BLOB_VARCHAR('BLOB', 'VARCHAR',  bit_to_blob(X'0000...
 
 ===================================================
 Error:-894
@@ -499,7 +499,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_VARCHAR('CLOB', 'VARCHAR', CHAR_TO_CLOB('Thi...'
-Function t_CLOB_VARCHAR is undefined or given wrong number of parameter. select t_CLOB_VARCHAR('CLOB', 'VARCHAR',  char_to_clob('This...
+Function t_clob_varchar is undefined or given wrong number of parameter. select t_CLOB_VARCHAR('CLOB', 'VARCHAR',  char_to_clob('This...
 
 ===================================================
 Error:-894
@@ -524,7 +524,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_VARCHAR('JSON', 'VARCHAR', '{"a":1}' ) ) ; '
-Function t_JSON_VARCHAR is undefined or given wrong number of parameter. select t_JSON_VARCHAR('JSON', 'VARCHAR', '{"a":1}'),  typeof...
+Function t_json_varchar is undefined or given wrong number of parameter. select t_JSON_VARCHAR('JSON', 'VARCHAR', '{"a":1}'),  typeof...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-15_variable_to_return_DOUBLE.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-15_variable_to_return_DOUBLE.answer
@@ -16,7 +16,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_DOUBLE('DATETIME', 'DOUBLE', DATETIME'20...'
-Function t_DATETIME_DOUBLE is undefined or given wrong number of parameter. select t_DATETIME_DOUBLE('DATETIME', 'DOUBLE', datetime '202...
+Function t_datetime_double is undefined or given wrong number of parameter. select t_DATETIME_DOUBLE('DATETIME', 'DOUBLE', datetime '202...
 
 ===================================================
 Error:-894
@@ -40,7 +40,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_DOUBLE('DATETIMELTZ', 'DOUBLE', datet...'
-Function t_DATETIMELTZ_DOUBLE is undefined or given wrong number of parameter. select t_DATETIMELTZ_DOUBLE('DATETIMELTZ', 'DOUBLE', datetim...
+Function t_datetimeltz_double is undefined or given wrong number of parameter. select t_DATETIMELTZ_DOUBLE('DATETIMELTZ', 'DOUBLE', datetim...
 
 ===================================================
 Error:-894
@@ -64,7 +64,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_DOUBLE('DATETIMETZ', 'DOUBLE', datetim...'
-Function t_DATETIMETZ_DOUBLE is undefined or given wrong number of parameter. select t_DATETIMETZ_DOUBLE('DATETIMETZ', 'DOUBLE', datetimet...
+Function t_datetimetz_double is undefined or given wrong number of parameter. select t_DATETIMETZ_DOUBLE('DATETIMETZ', 'DOUBLE', datetimet...
 
 ===================================================
 Error:-894
@@ -85,7 +85,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_DOUBLE('DATE', 'DOUBLE', DATE'2008-10-31' ) ...'
-Function t_DATE_DOUBLE is undefined or given wrong number of parameter. select t_DATE_DOUBLE('DATE', 'DOUBLE', date '2008-10-31'),  ...
+Function t_date_double is undefined or given wrong number of parameter. select t_DATE_DOUBLE('DATE', 'DOUBLE', date '2008-10-31'),  ...
 
 ===================================================
 Error:-894
@@ -106,7 +106,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_DOUBLE('TIME', 'DOUBLE', TIME'13:15:45' ) ) ; '
-Function t_TIME_DOUBLE is undefined or given wrong number of parameter. select t_TIME_DOUBLE('TIME', 'DOUBLE', time '13:15:45'),  ty...
+Function t_time_double is undefined or given wrong number of parameter. select t_TIME_DOUBLE('TIME', 'DOUBLE', time '13:15:45'),  ty...
 
 ===================================================
 Error:-894
@@ -127,7 +127,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_DOUBLE('TIMESTAMP', 'DOUBLE', TIMESTAMP...'
-Function t_TIMESTAMP_DOUBLE is undefined or given wrong number of parameter. select t_TIMESTAMP_DOUBLE('TIMESTAMP', 'DOUBLE', timestamp '...
+Function t_timestamp_double is undefined or given wrong number of parameter. select t_TIMESTAMP_DOUBLE('TIMESTAMP', 'DOUBLE', timestamp '...
 
 ===================================================
 Error:-894
@@ -151,7 +151,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_DOUBLE('TIMESTAMPLTZ', 'DOUBLE', tim...'
-Function t_TIMESTAMPLTZ_DOUBLE is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_DOUBLE('TIMESTAMPLTZ', 'DOUBLE', times...
+Function t_timestampltz_double is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_DOUBLE('TIMESTAMPLTZ', 'DOUBLE', times...
 
 ===================================================
 Error:-894
@@ -175,7 +175,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_DOUBLE('TIMESTAMPTZ', 'DOUBLE', times...'
-Function t_TIMESTAMPTZ_DOUBLE is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_DOUBLE('TIMESTAMPTZ', 'DOUBLE', timesta...
+Function t_timestamptz_double is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_DOUBLE('TIMESTAMPTZ', 'DOUBLE', timesta...
 
 ===================================================
 Error:-894
@@ -314,7 +314,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_DOUBLE('BIT(8)', 'DOUBLE', 0xaa ) ) ; '
-Function t_BIT_DOUBLE is undefined or given wrong number of parameter. select t_BIT_DOUBLE('BIT(8)', 'DOUBLE', X'aa'),  typeof(t_BI...
+Function t_bit_double is undefined or given wrong number of parameter. select t_BIT_DOUBLE('BIT(8)', 'DOUBLE', X'aa'),  typeof(t_BI...
 
 ===================================================
 Error:-894
@@ -338,7 +338,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_DOUB
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_DOUBLE('BIT VARYING', 'DOUBLE', 0xaa )...'
-Function t_BITVARYING_DOUBLE is undefined or given wrong number of parameter. select t_BITVARYING_DOUBLE('BIT VARYING', 'DOUBLE', X'aa'), ...
+Function t_bitvarying_double is undefined or given wrong number of parameter. select t_BITVARYING_DOUBLE('BIT VARYING', 'DOUBLE', X'aa'), ...
 
 ===================================================
 Error:-894
@@ -397,7 +397,7 @@ Stored procedure compile error: no viable alternative at input 'VAR SET'
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_DOUBLE('SET', 'DOUBLE', {'c','c','c','b','b',...'
-Function t_SET_DOUBLE is undefined or given wrong number of parameter. select t_SET_DOUBLE('SET', 'DOUBLE'),  typeof(t_SET_DOUBLE('...
+Function t_set_double is undefined or given wrong number of parameter. select t_SET_DOUBLE('SET', 'DOUBLE'),  typeof(t_SET_DOUBLE('...
 
 ===================================================
 Error:-894
@@ -418,7 +418,7 @@ Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_DOUBLE('MULTISET', 'DOUBLE', {'c','c','c...'
-Function t_MULTISET_DOUBLE is undefined or given wrong number of parameter. select t_MULTISET_DOUBLE('MULTISET', 'DOUBLE'),  typeof(t_MU...
+Function t_multiset_double is undefined or given wrong number of parameter. select t_MULTISET_DOUBLE('MULTISET', 'DOUBLE'),  typeof(t_MU...
 
 ===================================================
 Error:-894
@@ -439,7 +439,7 @@ Stored procedure compile error: no viable alternative at input 'VAR LIST'
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_DOUBLE('LIST', 'DOUBLE', {'c','c','c','b','b...'
-Function t_LIST_DOUBLE is undefined or given wrong number of parameter. select t_LIST_DOUBLE('LIST', 'DOUBLE'),  typeof(t_LIST_DOUBL...
+Function t_list_double is undefined or given wrong number of parameter. select t_LIST_DOUBLE('LIST', 'DOUBLE'),  typeof(t_LIST_DOUBL...
 
 ===================================================
 Error:-894
@@ -460,7 +460,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_DOUBLE('ENUM', 'DOUBLE', 'yellow' ) ) ; '
-Function t_ENUM_DOUBLE is undefined or given wrong number of parameter. select t_ENUM_DOUBLE('ENUM', 'DOUBLE', 'yellow'),  typeof(t_...
+Function t_enum_double is undefined or given wrong number of parameter. select t_ENUM_DOUBLE('ENUM', 'DOUBLE', 'yellow'),  typeof(t_...
 
 ===================================================
 Error:-894
@@ -485,7 +485,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_DOUBLE('BLOB', 'DOUBLE', BIT_TO_BLOB(X'00001...'
-Function t_BLOB_DOUBLE is undefined or given wrong number of parameter. select t_BLOB_DOUBLE('BLOB', 'DOUBLE',  bit_to_blob(X'000010...
+Function t_blob_double is undefined or given wrong number of parameter. select t_BLOB_DOUBLE('BLOB', 'DOUBLE',  bit_to_blob(X'000010...
 
 ===================================================
 Error:-894
@@ -510,7 +510,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_DOUBLE('CLOB', 'DOUBLE', CHAR_TO_CLOB('This ...'
-Function t_CLOB_DOUBLE is undefined or given wrong number of parameter. select t_CLOB_DOUBLE('CLOB', 'DOUBLE',  char_to_clob('This i...
+Function t_clob_double is undefined or given wrong number of parameter. select t_CLOB_DOUBLE('CLOB', 'DOUBLE',  char_to_clob('This i...
 
 ===================================================
 Error:-894
@@ -535,7 +535,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_DOUBLE('JSON', 'DOUBLE', '{"a":1}' ) ) ; '
-Function t_JSON_DOUBLE is undefined or given wrong number of parameter. select t_JSON_DOUBLE('JSON', 'DOUBLE', '{"a":1}'),  typeof(t...
+Function t_json_double is undefined or given wrong number of parameter. select t_JSON_DOUBLE('JSON', 'DOUBLE', '{"a":1}'),  typeof(t...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-15_variable_to_return_DOUBLE.answer_cci
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-15_variable_to_return_DOUBLE.answer_cci
@@ -16,11 +16,11 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_DOUBLE('DATETIME', 'DOUBLE', DATETIME'20...'
-Function t_DATETIME_DOUBLE is undefined or given wrong number of parameter. select t_DATETIME_DOUBLE('DATETIME', 'DOUBLE', datetime '202...
+Function t_datetime_double is undefined or given wrong number of parameter. select t_DATETIME_DOUBLE('DATETIME', 'DOUBLE', datetime '202...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_DATETIME_DOUBLE' does not exist.
+Stored procedure/function 'dba.t_datetime_double' does not exist.
 
 ===================================================
     
@@ -34,17 +34,17 @@ Semantic: before '  ) RETURN DOUBLE IS
 VAR DATETIMELTZ  ;
 begin
 VAR := param_val...'
-Unsupported argument type 'datetimeltz' of the stored procedure create or replace function t_DATETIMELTZ_DOUBLE(variables_ty...
+Unsupported argument type 'datetimeltz' of the stored procedure create or replace function [dba.t_DATETIMELTZ_DOUBLE](variab...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_DOUBLE('DATETIMELTZ', 'DOUBLE', datet...'
-Function t_DATETIMELTZ_DOUBLE is undefined or given wrong number of parameter. select t_DATETIMELTZ_DOUBLE('DATETIMELTZ', 'DOUBLE', datetim...
+Function t_datetimeltz_double is undefined or given wrong number of parameter. select t_DATETIMELTZ_DOUBLE('DATETIMELTZ', 'DOUBLE', datetim...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_DATETIMELTZ_DOUBLE' does not exist.
+Stored procedure/function 'dba.t_datetimeltz_double' does not exist.
 
 ===================================================
     
@@ -58,17 +58,17 @@ Semantic: before '  ) RETURN DOUBLE IS
 VAR DATETIMETZ  ;
 begin
 VAR := param_valu...'
-Unsupported argument type 'datetimetz' of the stored procedure create or replace function t_DATETIMETZ_DOUBLE(variables_typ...
+Unsupported argument type 'datetimetz' of the stored procedure create or replace function [dba.t_DATETIMETZ_DOUBLE](variabl...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_DOUBLE('DATETIMETZ', 'DOUBLE', datetim...'
-Function t_DATETIMETZ_DOUBLE is undefined or given wrong number of parameter. select t_DATETIMETZ_DOUBLE('DATETIMETZ', 'DOUBLE', datetimet...
+Function t_datetimetz_double is undefined or given wrong number of parameter. select t_DATETIMETZ_DOUBLE('DATETIMETZ', 'DOUBLE', datetimet...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_DATETIMETZ_DOUBLE' does not exist.
+Stored procedure/function 'dba.t_datetimetz_double' does not exist.
 
 ===================================================
     
@@ -85,11 +85,11 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_DOUBLE('DATE', 'DOUBLE', DATE'2008-10-31' ) ...'
-Function t_DATE_DOUBLE is undefined or given wrong number of parameter. select t_DATE_DOUBLE('DATE', 'DOUBLE', date '2008-10-31'),  ...
+Function t_date_double is undefined or given wrong number of parameter. select t_DATE_DOUBLE('DATE', 'DOUBLE', date '2008-10-31'),  ...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_DATE_DOUBLE' does not exist.
+Stored procedure/function 'dba.t_date_double' does not exist.
 
 ===================================================
     
@@ -106,11 +106,11 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_DOUBLE('TIME', 'DOUBLE', TIME'13:15:45' ) ) ; '
-Function t_TIME_DOUBLE is undefined or given wrong number of parameter. select t_TIME_DOUBLE('TIME', 'DOUBLE', time '13:15:45'),  ty...
+Function t_time_double is undefined or given wrong number of parameter. select t_TIME_DOUBLE('TIME', 'DOUBLE', time '13:15:45'),  ty...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_TIME_DOUBLE' does not exist.
+Stored procedure/function 'dba.t_time_double' does not exist.
 
 ===================================================
     
@@ -127,11 +127,11 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_DOUBLE('TIMESTAMP', 'DOUBLE', TIMESTAMP...'
-Function t_TIMESTAMP_DOUBLE is undefined or given wrong number of parameter. select t_TIMESTAMP_DOUBLE('TIMESTAMP', 'DOUBLE', timestamp '...
+Function t_timestamp_double is undefined or given wrong number of parameter. select t_TIMESTAMP_DOUBLE('TIMESTAMP', 'DOUBLE', timestamp '...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_TIMESTAMP_DOUBLE' does not exist.
+Stored procedure/function 'dba.t_timestamp_double' does not exist.
 
 ===================================================
     
@@ -145,17 +145,17 @@ Semantic: before '  ) RETURN DOUBLE IS
 VAR TIMESTAMPLTZ  ;
 begin
 VAR := param_va...'
-Unsupported argument type 'timestampltz' of the stored procedure create or replace function t_TIMESTAMPLTZ_DOUBLE(variables_t...
+Unsupported argument type 'timestampltz' of the stored procedure create or replace function [dba.t_TIMESTAMPLTZ_DOUBLE](varia...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_DOUBLE('TIMESTAMPLTZ', 'DOUBLE', tim...'
-Function t_TIMESTAMPLTZ_DOUBLE is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_DOUBLE('TIMESTAMPLTZ', 'DOUBLE', times...
+Function t_timestampltz_double is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_DOUBLE('TIMESTAMPLTZ', 'DOUBLE', times...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_TIMESTAMPLTZ_DOUBLE' does not exist.
+Stored procedure/function 'dba.t_timestampltz_double' does not exist.
 
 ===================================================
     
@@ -169,17 +169,17 @@ Semantic: before '  ) RETURN DOUBLE IS
 VAR TIMESTAMPTZ  ;
 begin
 VAR := param_val...'
-Unsupported argument type 'timestamptz' of the stored procedure create or replace function t_TIMESTAMPTZ_DOUBLE(variables_ty...
+Unsupported argument type 'timestamptz' of the stored procedure create or replace function [dba.t_TIMESTAMPTZ_DOUBLE](variab...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_DOUBLE('TIMESTAMPTZ', 'DOUBLE', times...'
-Function t_TIMESTAMPTZ_DOUBLE is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_DOUBLE('TIMESTAMPTZ', 'DOUBLE', timesta...
+Function t_timestamptz_double is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_DOUBLE('TIMESTAMPTZ', 'DOUBLE', timesta...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_TIMESTAMPTZ_DOUBLE' does not exist.
+Stored procedure/function 'dba.t_timestamptz_double' does not exist.
 
 ===================================================
     
@@ -308,17 +308,17 @@ VAR BIT(8)  ;
 begin
 VAR := param_value ;
 ...'
-Unsupported argument type 'bit' of the stored procedure create or replace function t_BIT_DOUBLE(variables_type  varc...
+Unsupported argument type 'bit' of the stored procedure create or replace function [dba.t_BIT_DOUBLE](variables_type...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_DOUBLE('BIT(8)', 'DOUBLE', 0xaa ) ) ; '
-Function t_BIT_DOUBLE is undefined or given wrong number of parameter. select t_BIT_DOUBLE('BIT(8)', 'DOUBLE', X'aa'),  typeof(t_BI...
+Function t_bit_double is undefined or given wrong number of parameter. select t_BIT_DOUBLE('BIT(8)', 'DOUBLE', X'aa'),  typeof(t_BI...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_BIT_DOUBLE' does not exist.
+Stored procedure/function 'dba.t_bit_double' does not exist.
 
 ===================================================
     
@@ -332,17 +332,17 @@ Semantic: before '  ) RETURN DOUBLE IS
 VAR BIT VARYING  ;
 begin
 VAR := param_val...'
-dba.BITVARYING is not defined. create or replace function t_BITVARYING_DOUBLE(variables_typ...
+dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_DOUBLE](variabl...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_DOUBLE('BIT VARYING', 'DOUBLE', 0xaa )...'
-Function t_BITVARYING_DOUBLE is undefined or given wrong number of parameter. select t_BITVARYING_DOUBLE('BIT VARYING', 'DOUBLE', X'aa'), ...
+Function t_bitvarying_double is undefined or given wrong number of parameter. select t_BITVARYING_DOUBLE('BIT VARYING', 'DOUBLE', X'aa'), ...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_BITVARYING_DOUBLE' does not exist.
+Stored procedure/function 'dba.t_bitvarying_double' does not exist.
 
 ===================================================
     
@@ -397,11 +397,11 @@ Stored procedure compile error: no viable alternative at input 'VAR SET'
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_DOUBLE('SET', 'DOUBLE', {'c','c','c','b','b',...'
-Function t_SET_DOUBLE is undefined or given wrong number of parameter. select t_SET_DOUBLE('SET', 'DOUBLE'),  typeof(t_SET_DOUBLE('...
+Function t_set_double is undefined or given wrong number of parameter. select t_SET_DOUBLE('SET', 'DOUBLE'),  typeof(t_SET_DOUBLE('...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_SET_DOUBLE' does not exist.
+Stored procedure/function 'dba.t_set_double' does not exist.
 
 ===================================================
     
@@ -418,11 +418,11 @@ Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_DOUBLE('MULTISET', 'DOUBLE', {'c','c','c...'
-Function t_MULTISET_DOUBLE is undefined or given wrong number of parameter. select t_MULTISET_DOUBLE('MULTISET', 'DOUBLE'),  typeof(t_MU...
+Function t_multiset_double is undefined or given wrong number of parameter. select t_MULTISET_DOUBLE('MULTISET', 'DOUBLE'),  typeof(t_MU...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_MULTISET_DOUBLE' does not exist.
+Stored procedure/function 'dba.t_multiset_double' does not exist.
 
 ===================================================
     
@@ -439,11 +439,11 @@ Stored procedure compile error: no viable alternative at input 'VAR LIST'
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_DOUBLE('LIST', 'DOUBLE', {'c','c','c','b','b...'
-Function t_LIST_DOUBLE is undefined or given wrong number of parameter. select t_LIST_DOUBLE('LIST', 'DOUBLE'),  typeof(t_LIST_DOUBL...
+Function t_list_double is undefined or given wrong number of parameter. select t_LIST_DOUBLE('LIST', 'DOUBLE'),  typeof(t_LIST_DOUBL...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_LIST_DOUBLE' does not exist.
+Stored procedure/function 'dba.t_list_double' does not exist.
 
 ===================================================
     
@@ -460,11 +460,11 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_DOUBLE('ENUM', 'DOUBLE', 'yellow' ) ) ; '
-Function t_ENUM_DOUBLE is undefined or given wrong number of parameter. select t_ENUM_DOUBLE('ENUM', 'DOUBLE', 'yellow'),  typeof(t_...
+Function t_enum_double is undefined or given wrong number of parameter. select t_ENUM_DOUBLE('ENUM', 'DOUBLE', 'yellow'),  typeof(t_...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_ENUM_DOUBLE' does not exist.
+Stored procedure/function 'dba.t_enum_double' does not exist.
 
 ===================================================
     
@@ -479,17 +479,17 @@ VAR BLOB  ;
 begin
 VAR := param_value ;
 db...'
-Unsupported argument type 'blob' of the stored procedure create or replace function t_BLOB_DOUBLE(variables_type  var...
+Unsupported argument type 'blob' of the stored procedure create or replace function [dba.t_BLOB_DOUBLE](variables_typ...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_DOUBLE('BLOB', 'DOUBLE', BIT_TO_BLOB(X'00001...'
-Function t_BLOB_DOUBLE is undefined or given wrong number of parameter. select t_BLOB_DOUBLE('BLOB', 'DOUBLE',  bit_to_blob(X'000010...
+Function t_blob_double is undefined or given wrong number of parameter. select t_BLOB_DOUBLE('BLOB', 'DOUBLE',  bit_to_blob(X'000010...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_BLOB_DOUBLE' does not exist.
+Stored procedure/function 'dba.t_blob_double' does not exist.
 
 ===================================================
     
@@ -504,17 +504,17 @@ VAR CLOB  ;
 begin
 VAR := param_value ;
 db...'
-Unsupported argument type 'clob' of the stored procedure create or replace function t_CLOB_DOUBLE(variables_type  var...
+Unsupported argument type 'clob' of the stored procedure create or replace function [dba.t_CLOB_DOUBLE](variables_typ...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_DOUBLE('CLOB', 'DOUBLE', CHAR_TO_CLOB('This ...'
-Function t_CLOB_DOUBLE is undefined or given wrong number of parameter. select t_CLOB_DOUBLE('CLOB', 'DOUBLE',  char_to_clob('This i...
+Function t_clob_double is undefined or given wrong number of parameter. select t_CLOB_DOUBLE('CLOB', 'DOUBLE',  char_to_clob('This i...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_CLOB_DOUBLE' does not exist.
+Stored procedure/function 'dba.t_clob_double' does not exist.
 
 ===================================================
     
@@ -529,17 +529,17 @@ VAR JSON  ;
 begin
 VAR := param_value ;
 db...'
-Unsupported argument type 'json' of the stored procedure create or replace function t_JSON_DOUBLE(variables_type  var...
+Unsupported argument type 'json' of the stored procedure create or replace function [dba.t_JSON_DOUBLE](variables_typ...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_DOUBLE('JSON', 'DOUBLE', '{"a":1}' ) ) ; '
-Function t_JSON_DOUBLE is undefined or given wrong number of parameter. select t_JSON_DOUBLE('JSON', 'DOUBLE', '{"a":1}'),  typeof(t...
+Function t_json_double is undefined or given wrong number of parameter. select t_JSON_DOUBLE('JSON', 'DOUBLE', '{"a":1}'),  typeof(t...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_JSON_DOUBLE' does not exist.
+Stored procedure/function 'dba.t_json_double' does not exist.
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-16_variable_to_return_FLOAT.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-16_variable_to_return_FLOAT.answer
@@ -16,7 +16,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_FLOAT('DATETIME', 'FLOAT', DATETIME'2023...'
-Function t_DATETIME_FLOAT is undefined or given wrong number of parameter. select t_DATETIME_FLOAT('DATETIME', 'FLOAT', datetime '2023-...
+Function t_datetime_float is undefined or given wrong number of parameter. select t_DATETIME_FLOAT('DATETIME', 'FLOAT', datetime '2023-...
 
 ===================================================
 Error:-894
@@ -40,7 +40,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_FLOAT('DATETIMELTZ', 'FLOAT', datetim...'
-Function t_DATETIMELTZ_FLOAT is undefined or given wrong number of parameter. select t_DATETIMELTZ_FLOAT('DATETIMELTZ', 'FLOAT', datetimel...
+Function t_datetimeltz_float is undefined or given wrong number of parameter. select t_DATETIMELTZ_FLOAT('DATETIMELTZ', 'FLOAT', datetimel...
 
 ===================================================
 Error:-894
@@ -64,7 +64,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_FLOAT('DATETIMETZ', 'FLOAT', datetimet...'
-Function t_DATETIMETZ_FLOAT is undefined or given wrong number of parameter. select t_DATETIMETZ_FLOAT('DATETIMETZ', 'FLOAT', datetimetz ...
+Function t_datetimetz_float is undefined or given wrong number of parameter. select t_DATETIMETZ_FLOAT('DATETIMETZ', 'FLOAT', datetimetz ...
 
 ===================================================
 Error:-894
@@ -85,7 +85,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_FLOAT('DATE', 'FLOAT', DATE'2008-10-31' ) ) ; '
-Function t_DATE_FLOAT is undefined or given wrong number of parameter. select t_DATE_FLOAT('DATE', 'FLOAT', date '2008-10-31'),  ty...
+Function t_date_float is undefined or given wrong number of parameter. select t_DATE_FLOAT('DATE', 'FLOAT', date '2008-10-31'),  ty...
 
 ===================================================
 Error:-894
@@ -106,7 +106,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_FLOAT('TIME', 'FLOAT', TIME'13:15:45' ) ) ; '
-Function t_TIME_FLOAT is undefined or given wrong number of parameter. select t_TIME_FLOAT('TIME', 'FLOAT', time '13:15:45'),  type...
+Function t_time_float is undefined or given wrong number of parameter. select t_TIME_FLOAT('TIME', 'FLOAT', time '13:15:45'),  type...
 
 ===================================================
 Error:-894
@@ -127,7 +127,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_FLOAT('TIMESTAMP', 'FLOAT', TIMESTAMP'2...'
-Function t_TIMESTAMP_FLOAT is undefined or given wrong number of parameter. select t_TIMESTAMP_FLOAT('TIMESTAMP', 'FLOAT', timestamp '20...
+Function t_timestamp_float is undefined or given wrong number of parameter. select t_TIMESTAMP_FLOAT('TIMESTAMP', 'FLOAT', timestamp '20...
 
 ===================================================
 Error:-894
@@ -151,7 +151,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_FLOAT('TIMESTAMPLTZ', 'FLOAT', times...'
-Function t_TIMESTAMPLTZ_FLOAT is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_FLOAT('TIMESTAMPLTZ', 'FLOAT', timesta...
+Function t_timestampltz_float is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_FLOAT('TIMESTAMPLTZ', 'FLOAT', timesta...
 
 ===================================================
 Error:-894
@@ -175,7 +175,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_FLOAT('TIMESTAMPTZ', 'FLOAT', timesta...'
-Function t_TIMESTAMPTZ_FLOAT is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_FLOAT('TIMESTAMPTZ', 'FLOAT', timestamp...
+Function t_timestamptz_float is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_FLOAT('TIMESTAMPTZ', 'FLOAT', timestamp...
 
 ===================================================
 Error:-894
@@ -314,7 +314,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_FLOAT('BIT(8)', 'FLOAT', 0xaa ) ) ; '
-Function t_BIT_FLOAT is undefined or given wrong number of parameter. select t_BIT_FLOAT('BIT(8)', 'FLOAT', X'aa'),  typeof(t_BIT_...
+Function t_bit_float is undefined or given wrong number of parameter. select t_BIT_FLOAT('BIT(8)', 'FLOAT', X'aa'),  typeof(t_BIT_...
 
 ===================================================
 Error:-894
@@ -338,7 +338,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_FLOA
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_FLOAT('BIT VARYING', 'FLOAT', 0xaa ) ) ; '
-Function t_BITVARYING_FLOAT is undefined or given wrong number of parameter. select t_BITVARYING_FLOAT('BIT VARYING', 'FLOAT', X'aa'),  t...
+Function t_bitvarying_float is undefined or given wrong number of parameter. select t_BITVARYING_FLOAT('BIT VARYING', 'FLOAT', X'aa'),  t...
 
 ===================================================
 Error:-894
@@ -397,7 +397,7 @@ Stored procedure compile error: no viable alternative at input 'VAR SET'
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_FLOAT('SET', 'FLOAT', {'c','c','c','b','b','a...'
-Function t_SET_FLOAT is undefined or given wrong number of parameter. select t_SET_FLOAT('SET', 'FLOAT'),  typeof(t_SET_FLOAT('SET...
+Function t_set_float is undefined or given wrong number of parameter. select t_SET_FLOAT('SET', 'FLOAT'),  typeof(t_SET_FLOAT('SET...
 
 ===================================================
 Error:-894
@@ -418,7 +418,7 @@ Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_FLOAT('MULTISET', 'FLOAT', {'c','c','c',...'
-Function t_MULTISET_FLOAT is undefined or given wrong number of parameter. select t_MULTISET_FLOAT('MULTISET', 'FLOAT'),  typeof(t_MULT...
+Function t_multiset_float is undefined or given wrong number of parameter. select t_MULTISET_FLOAT('MULTISET', 'FLOAT'),  typeof(t_MULT...
 
 ===================================================
 Error:-894
@@ -439,7 +439,7 @@ Stored procedure compile error: no viable alternative at input 'VAR LIST'
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_FLOAT('LIST', 'FLOAT', {'c','c','c','b','b',...'
-Function t_LIST_FLOAT is undefined or given wrong number of parameter. select t_LIST_FLOAT('LIST', 'FLOAT'),  typeof(t_LIST_FLOAT('...
+Function t_list_float is undefined or given wrong number of parameter. select t_LIST_FLOAT('LIST', 'FLOAT'),  typeof(t_LIST_FLOAT('...
 
 ===================================================
 Error:-894
@@ -460,7 +460,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_FLOAT('ENUM', 'FLOAT', 'yellow' ) ) ; '
-Function t_ENUM_FLOAT is undefined or given wrong number of parameter. select t_ENUM_FLOAT('ENUM', 'FLOAT', 'yellow'),  typeof(t_EN...
+Function t_enum_float is undefined or given wrong number of parameter. select t_ENUM_FLOAT('ENUM', 'FLOAT', 'yellow'),  typeof(t_EN...
 
 ===================================================
 Error:-894
@@ -485,7 +485,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_FLOAT('BLOB', 'FLOAT', BIT_TO_BLOB(X'000010'...'
-Function t_BLOB_FLOAT is undefined or given wrong number of parameter. select t_BLOB_FLOAT('BLOB', 'FLOAT',  bit_to_blob(X'000010')...
+Function t_blob_float is undefined or given wrong number of parameter. select t_BLOB_FLOAT('BLOB', 'FLOAT',  bit_to_blob(X'000010')...
 
 ===================================================
 Error:-894
@@ -510,7 +510,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_FLOAT('CLOB', 'FLOAT', CHAR_TO_CLOB('This is...'
-Function t_CLOB_FLOAT is undefined or given wrong number of parameter. select t_CLOB_FLOAT('CLOB', 'FLOAT',  char_to_clob('This is ...
+Function t_clob_float is undefined or given wrong number of parameter. select t_CLOB_FLOAT('CLOB', 'FLOAT',  char_to_clob('This is ...
 
 ===================================================
 Error:-894
@@ -535,7 +535,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_FLOAT('JSON', 'FLOAT', '{"a":1}' ) ) ; '
-Function t_JSON_FLOAT is undefined or given wrong number of parameter. select t_JSON_FLOAT('JSON', 'FLOAT', '{"a":1}'),  typeof(t_J...
+Function t_json_float is undefined or given wrong number of parameter. select t_JSON_FLOAT('JSON', 'FLOAT', '{"a":1}'),  typeof(t_J...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-16_variable_to_return_FLOAT.answer_cci
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-16_variable_to_return_FLOAT.answer_cci
@@ -16,11 +16,11 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_FLOAT('DATETIME', 'FLOAT', DATETIME'2023...'
-Function t_DATETIME_FLOAT is undefined or given wrong number of parameter. select t_DATETIME_FLOAT('DATETIME', 'FLOAT', datetime '2023-...
+Function t_datetime_float is undefined or given wrong number of parameter. select t_DATETIME_FLOAT('DATETIME', 'FLOAT', datetime '2023-...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_DATETIME_FLOAT' does not exist.
+Stored procedure/function 'dba.t_datetime_float' does not exist.
 
 ===================================================
     
@@ -34,17 +34,17 @@ Semantic: before '  ) RETURN FLOAT IS
 VAR DATETIMELTZ  ;
 begin
 VAR := param_valu...'
-Unsupported argument type 'datetimeltz' of the stored procedure create or replace function t_DATETIMELTZ_FLOAT(variables_typ...
+Unsupported argument type 'datetimeltz' of the stored procedure create or replace function [dba.t_DATETIMELTZ_FLOAT](variabl...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_FLOAT('DATETIMELTZ', 'FLOAT', datetim...'
-Function t_DATETIMELTZ_FLOAT is undefined or given wrong number of parameter. select t_DATETIMELTZ_FLOAT('DATETIMELTZ', 'FLOAT', datetimel...
+Function t_datetimeltz_float is undefined or given wrong number of parameter. select t_DATETIMELTZ_FLOAT('DATETIMELTZ', 'FLOAT', datetimel...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_DATETIMELTZ_FLOAT' does not exist.
+Stored procedure/function 'dba.t_datetimeltz_float' does not exist.
 
 ===================================================
     
@@ -58,17 +58,17 @@ Semantic: before '  ) RETURN FLOAT IS
 VAR DATETIMETZ  ;
 begin
 VAR := param_value...'
-Unsupported argument type 'datetimetz' of the stored procedure create or replace function t_DATETIMETZ_FLOAT(variables_type...
+Unsupported argument type 'datetimetz' of the stored procedure create or replace function [dba.t_DATETIMETZ_FLOAT](variable...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_FLOAT('DATETIMETZ', 'FLOAT', datetimet...'
-Function t_DATETIMETZ_FLOAT is undefined or given wrong number of parameter. select t_DATETIMETZ_FLOAT('DATETIMETZ', 'FLOAT', datetimetz ...
+Function t_datetimetz_float is undefined or given wrong number of parameter. select t_DATETIMETZ_FLOAT('DATETIMETZ', 'FLOAT', datetimetz ...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_DATETIMETZ_FLOAT' does not exist.
+Stored procedure/function 'dba.t_datetimetz_float' does not exist.
 
 ===================================================
     
@@ -85,11 +85,11 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_FLOAT('DATE', 'FLOAT', DATE'2008-10-31' ) ) ; '
-Function t_DATE_FLOAT is undefined or given wrong number of parameter. select t_DATE_FLOAT('DATE', 'FLOAT', date '2008-10-31'),  ty...
+Function t_date_float is undefined or given wrong number of parameter. select t_DATE_FLOAT('DATE', 'FLOAT', date '2008-10-31'),  ty...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_DATE_FLOAT' does not exist.
+Stored procedure/function 'dba.t_date_float' does not exist.
 
 ===================================================
     
@@ -106,11 +106,11 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_FLOAT('TIME', 'FLOAT', TIME'13:15:45' ) ) ; '
-Function t_TIME_FLOAT is undefined or given wrong number of parameter. select t_TIME_FLOAT('TIME', 'FLOAT', time '13:15:45'),  type...
+Function t_time_float is undefined or given wrong number of parameter. select t_TIME_FLOAT('TIME', 'FLOAT', time '13:15:45'),  type...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_TIME_FLOAT' does not exist.
+Stored procedure/function 'dba.t_time_float' does not exist.
 
 ===================================================
     
@@ -127,11 +127,11 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_FLOAT('TIMESTAMP', 'FLOAT', TIMESTAMP'2...'
-Function t_TIMESTAMP_FLOAT is undefined or given wrong number of parameter. select t_TIMESTAMP_FLOAT('TIMESTAMP', 'FLOAT', timestamp '20...
+Function t_timestamp_float is undefined or given wrong number of parameter. select t_TIMESTAMP_FLOAT('TIMESTAMP', 'FLOAT', timestamp '20...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_TIMESTAMP_FLOAT' does not exist.
+Stored procedure/function 'dba.t_timestamp_float' does not exist.
 
 ===================================================
     
@@ -145,17 +145,17 @@ Semantic: before '  ) RETURN FLOAT IS
 VAR TIMESTAMPLTZ  ;
 begin
 VAR := param_val...'
-Unsupported argument type 'timestampltz' of the stored procedure create or replace function t_TIMESTAMPLTZ_FLOAT(variables_ty...
+Unsupported argument type 'timestampltz' of the stored procedure create or replace function [dba.t_TIMESTAMPLTZ_FLOAT](variab...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_FLOAT('TIMESTAMPLTZ', 'FLOAT', times...'
-Function t_TIMESTAMPLTZ_FLOAT is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_FLOAT('TIMESTAMPLTZ', 'FLOAT', timesta...
+Function t_timestampltz_float is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_FLOAT('TIMESTAMPLTZ', 'FLOAT', timesta...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_TIMESTAMPLTZ_FLOAT' does not exist.
+Stored procedure/function 'dba.t_timestampltz_float' does not exist.
 
 ===================================================
     
@@ -169,17 +169,17 @@ Semantic: before '  ) RETURN FLOAT IS
 VAR TIMESTAMPTZ  ;
 begin
 VAR := param_valu...'
-Unsupported argument type 'timestamptz' of the stored procedure create or replace function t_TIMESTAMPTZ_FLOAT(variables_typ...
+Unsupported argument type 'timestamptz' of the stored procedure create or replace function [dba.t_TIMESTAMPTZ_FLOAT](variabl...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_FLOAT('TIMESTAMPTZ', 'FLOAT', timesta...'
-Function t_TIMESTAMPTZ_FLOAT is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_FLOAT('TIMESTAMPTZ', 'FLOAT', timestamp...
+Function t_timestamptz_float is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_FLOAT('TIMESTAMPTZ', 'FLOAT', timestamp...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_TIMESTAMPTZ_FLOAT' does not exist.
+Stored procedure/function 'dba.t_timestamptz_float' does not exist.
 
 ===================================================
     
@@ -308,17 +308,17 @@ VAR BIT(8)  ;
 begin
 VAR := param_value ;
 d...'
-Unsupported argument type 'bit' of the stored procedure create or replace function t_BIT_FLOAT(variables_type  varch...
+Unsupported argument type 'bit' of the stored procedure create or replace function [dba.t_BIT_FLOAT](variables_type ...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_FLOAT('BIT(8)', 'FLOAT', 0xaa ) ) ; '
-Function t_BIT_FLOAT is undefined or given wrong number of parameter. select t_BIT_FLOAT('BIT(8)', 'FLOAT', X'aa'),  typeof(t_BIT_...
+Function t_bit_float is undefined or given wrong number of parameter. select t_BIT_FLOAT('BIT(8)', 'FLOAT', X'aa'),  typeof(t_BIT_...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_BIT_FLOAT' does not exist.
+Stored procedure/function 'dba.t_bit_float' does not exist.
 
 ===================================================
     
@@ -332,17 +332,17 @@ Semantic: before '  ) RETURN FLOAT IS
 VAR BIT VARYING  ;
 begin
 VAR := param_valu...'
-dba.BITVARYING is not defined. create or replace function t_BITVARYING_FLOAT(variables_type...
+dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_FLOAT](variable...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_FLOAT('BIT VARYING', 'FLOAT', 0xaa ) ) ; '
-Function t_BITVARYING_FLOAT is undefined or given wrong number of parameter. select t_BITVARYING_FLOAT('BIT VARYING', 'FLOAT', X'aa'),  t...
+Function t_bitvarying_float is undefined or given wrong number of parameter. select t_BITVARYING_FLOAT('BIT VARYING', 'FLOAT', X'aa'),  t...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_BITVARYING_FLOAT' does not exist.
+Stored procedure/function 'dba.t_bitvarying_float' does not exist.
 
 ===================================================
     
@@ -397,11 +397,11 @@ Stored procedure compile error: no viable alternative at input 'VAR SET'
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_FLOAT('SET', 'FLOAT', {'c','c','c','b','b','a...'
-Function t_SET_FLOAT is undefined or given wrong number of parameter. select t_SET_FLOAT('SET', 'FLOAT'),  typeof(t_SET_FLOAT('SET...
+Function t_set_float is undefined or given wrong number of parameter. select t_SET_FLOAT('SET', 'FLOAT'),  typeof(t_SET_FLOAT('SET...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_SET_FLOAT' does not exist.
+Stored procedure/function 'dba.t_set_float' does not exist.
 
 ===================================================
     
@@ -418,11 +418,11 @@ Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_FLOAT('MULTISET', 'FLOAT', {'c','c','c',...'
-Function t_MULTISET_FLOAT is undefined or given wrong number of parameter. select t_MULTISET_FLOAT('MULTISET', 'FLOAT'),  typeof(t_MULT...
+Function t_multiset_float is undefined or given wrong number of parameter. select t_MULTISET_FLOAT('MULTISET', 'FLOAT'),  typeof(t_MULT...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_MULTISET_FLOAT' does not exist.
+Stored procedure/function 'dba.t_multiset_float' does not exist.
 
 ===================================================
     
@@ -439,11 +439,11 @@ Stored procedure compile error: no viable alternative at input 'VAR LIST'
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_FLOAT('LIST', 'FLOAT', {'c','c','c','b','b',...'
-Function t_LIST_FLOAT is undefined or given wrong number of parameter. select t_LIST_FLOAT('LIST', 'FLOAT'),  typeof(t_LIST_FLOAT('...
+Function t_list_float is undefined or given wrong number of parameter. select t_LIST_FLOAT('LIST', 'FLOAT'),  typeof(t_LIST_FLOAT('...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_LIST_FLOAT' does not exist.
+Stored procedure/function 'dba.t_list_float' does not exist.
 
 ===================================================
     
@@ -460,11 +460,11 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_FLOAT('ENUM', 'FLOAT', 'yellow' ) ) ; '
-Function t_ENUM_FLOAT is undefined or given wrong number of parameter. select t_ENUM_FLOAT('ENUM', 'FLOAT', 'yellow'),  typeof(t_EN...
+Function t_enum_float is undefined or given wrong number of parameter. select t_ENUM_FLOAT('ENUM', 'FLOAT', 'yellow'),  typeof(t_EN...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_ENUM_FLOAT' does not exist.
+Stored procedure/function 'dba.t_enum_float' does not exist.
 
 ===================================================
     
@@ -479,17 +479,17 @@ VAR BLOB  ;
 begin
 VAR := param_value ;
 dbm...'
-Unsupported argument type 'blob' of the stored procedure create or replace function t_BLOB_FLOAT(variables_type  varc...
+Unsupported argument type 'blob' of the stored procedure create or replace function [dba.t_BLOB_FLOAT](variables_type...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_FLOAT('BLOB', 'FLOAT', BIT_TO_BLOB(X'000010'...'
-Function t_BLOB_FLOAT is undefined or given wrong number of parameter. select t_BLOB_FLOAT('BLOB', 'FLOAT',  bit_to_blob(X'000010')...
+Function t_blob_float is undefined or given wrong number of parameter. select t_BLOB_FLOAT('BLOB', 'FLOAT',  bit_to_blob(X'000010')...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_BLOB_FLOAT' does not exist.
+Stored procedure/function 'dba.t_blob_float' does not exist.
 
 ===================================================
     
@@ -504,17 +504,17 @@ VAR CLOB  ;
 begin
 VAR := param_value ;
 dbm...'
-Unsupported argument type 'clob' of the stored procedure create or replace function t_CLOB_FLOAT(variables_type  varc...
+Unsupported argument type 'clob' of the stored procedure create or replace function [dba.t_CLOB_FLOAT](variables_type...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_FLOAT('CLOB', 'FLOAT', CHAR_TO_CLOB('This is...'
-Function t_CLOB_FLOAT is undefined or given wrong number of parameter. select t_CLOB_FLOAT('CLOB', 'FLOAT',  char_to_clob('This is ...
+Function t_clob_float is undefined or given wrong number of parameter. select t_CLOB_FLOAT('CLOB', 'FLOAT',  char_to_clob('This is ...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_CLOB_FLOAT' does not exist.
+Stored procedure/function 'dba.t_clob_float' does not exist.
 
 ===================================================
     
@@ -529,17 +529,17 @@ VAR JSON  ;
 begin
 VAR := param_value ;
 dbm...'
-Unsupported argument type 'json' of the stored procedure create or replace function t_JSON_FLOAT(variables_type  varc...
+Unsupported argument type 'json' of the stored procedure create or replace function [dba.t_JSON_FLOAT](variables_type...
 
 ===================================================
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_FLOAT('JSON', 'FLOAT', '{"a":1}' ) ) ; '
-Function t_JSON_FLOAT is undefined or given wrong number of parameter. select t_JSON_FLOAT('JSON', 'FLOAT', '{"a":1}'),  typeof(t_J...
+Function t_json_float is undefined or given wrong number of parameter. select t_JSON_FLOAT('JSON', 'FLOAT', '{"a":1}'),  typeof(t_J...
 
 ===================================================
 Error:-894
-Stored procedure/function 't_JSON_FLOAT' does not exist.
+Stored procedure/function 'dba.t_json_float' does not exist.
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-17_variable_to_return_NUMERIC.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-17_variable_to_return_NUMERIC.answer
@@ -16,7 +16,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_NUMERIC('DATETIME', 'NUMERIC(38,15)', DA...'
-Function t_DATETIME_NUMERIC is undefined or given wrong number of parameter. select t_DATETIME_NUMERIC('DATETIME', 'NUMERIC(38,15)', date...
+Function t_datetime_numeric is undefined or given wrong number of parameter. select t_DATETIME_NUMERIC('DATETIME', 'NUMERIC(38,15)', date...
 
 ===================================================
 Error:-894
@@ -40,7 +40,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_NUMERIC('DATETIMELTZ', 'NUMERIC(38,15...'
-Function t_DATETIMELTZ_NUMERIC is undefined or given wrong number of parameter. select t_DATETIMELTZ_NUMERIC('DATETIMELTZ', 'NUMERIC(38,15)'...
+Function t_datetimeltz_numeric is undefined or given wrong number of parameter. select t_DATETIMELTZ_NUMERIC('DATETIMELTZ', 'NUMERIC(38,15)'...
 
 ===================================================
 Error:-894
@@ -64,7 +64,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_NUMERIC('DATETIMETZ', 'NUMERIC(38,15)'...'
-Function t_DATETIMETZ_NUMERIC is undefined or given wrong number of parameter. select t_DATETIMETZ_NUMERIC('DATETIMETZ', 'NUMERIC(38,15)', ...
+Function t_datetimetz_numeric is undefined or given wrong number of parameter. select t_DATETIMETZ_NUMERIC('DATETIMETZ', 'NUMERIC(38,15)', ...
 
 ===================================================
 Error:-894
@@ -85,7 +85,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_NUMERIC('DATE', 'NUMERIC(38,15)', DATE'2008-...'
-Function t_DATE_NUMERIC is undefined or given wrong number of parameter. select t_DATE_NUMERIC('DATE', 'NUMERIC(38,15)', date '2008-1...
+Function t_date_numeric is undefined or given wrong number of parameter. select t_DATE_NUMERIC('DATE', 'NUMERIC(38,15)', date '2008-1...
 
 ===================================================
 Error:-894
@@ -106,7 +106,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_NUMERIC('TIME', 'NUMERIC(38,15)', TIME'13:15...'
-Function t_TIME_NUMERIC is undefined or given wrong number of parameter. select t_TIME_NUMERIC('TIME', 'NUMERIC(38,15)', time '13:15:...
+Function t_time_numeric is undefined or given wrong number of parameter. select t_TIME_NUMERIC('TIME', 'NUMERIC(38,15)', time '13:15:...
 
 ===================================================
 Error:-894
@@ -127,7 +127,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_NUMERIC('TIMESTAMP', 'NUMERIC(38,15)', ...'
-Function t_TIMESTAMP_NUMERIC is undefined or given wrong number of parameter. select t_TIMESTAMP_NUMERIC('TIMESTAMP', 'NUMERIC(38,15)', ti...
+Function t_timestamp_numeric is undefined or given wrong number of parameter. select t_TIMESTAMP_NUMERIC('TIMESTAMP', 'NUMERIC(38,15)', ti...
 
 ===================================================
 Error:-894
@@ -151,7 +151,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_NUMERIC('TIMESTAMPLTZ', 'NUMERIC(38,...'
-Function t_TIMESTAMPLTZ_NUMERIC is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_NUMERIC('TIMESTAMPLTZ', 'NUMERIC(38,15...
+Function t_timestampltz_numeric is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_NUMERIC('TIMESTAMPLTZ', 'NUMERIC(38,15...
 
 ===================================================
 Error:-894
@@ -175,7 +175,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_NUMERIC('TIMESTAMPTZ', 'NUMERIC(38,15...'
-Function t_TIMESTAMPTZ_NUMERIC is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_NUMERIC('TIMESTAMPTZ', 'NUMERIC(38,15)'...
+Function t_timestamptz_numeric is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_NUMERIC('TIMESTAMPTZ', 'NUMERIC(38,15)'...
 
 ===================================================
 Error:-894
@@ -211,7 +211,7 @@ t_FLOAT_NUMERIC. This scenario is a success.
 
 ===================================================
 t_FLOAT_NUMERIC('FLOAT', 'NUMERIC(38,15)',  cast(16777.217 as float))    typeof(t_FLOAT_NUMERIC('FLOAT', 'NUMERIC(38,15)',  cast(16777.217 as float)))    
-16777.21     numeric (7, 2)     
+16777     numeric (7, 2)     
 
 
 variables_type = FLOAT, return_type = NUMERIC(38,15), param_value(variable value) = 1.677722e+04
@@ -313,7 +313,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_NUMERIC('BIT(8)', 'NUMERIC(38,15)', 0xaa ) ) ; '
-Function t_BIT_NUMERIC is undefined or given wrong number of parameter. select t_BIT_NUMERIC('BIT(8)', 'NUMERIC(38,15)', X'aa'),  ty...
+Function t_bit_numeric is undefined or given wrong number of parameter. select t_BIT_NUMERIC('BIT(8)', 'NUMERIC(38,15)', X'aa'),  ty...
 
 ===================================================
 Error:-894
@@ -337,7 +337,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_NUME
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_NUMERIC('BIT VARYING', 'NUMERIC(38,15)...'
-Function t_BITVARYING_NUMERIC is undefined or given wrong number of parameter. select t_BITVARYING_NUMERIC('BIT VARYING', 'NUMERIC(38,15)',...
+Function t_bitvarying_numeric is undefined or given wrong number of parameter. select t_BITVARYING_NUMERIC('BIT VARYING', 'NUMERIC(38,15)',...
 
 ===================================================
 Error:-894
@@ -394,7 +394,7 @@ Stored procedure compile error: no viable alternative at input 'VAR SET'
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_NUMERIC('SET', 'NUMERIC(38,15)', {'c','c','c'...'
-Function t_SET_NUMERIC is undefined or given wrong number of parameter. select t_SET_NUMERIC('SET', 'NUMERIC(38,15)'),  typeof(t_SET...
+Function t_set_numeric is undefined or given wrong number of parameter. select t_SET_NUMERIC('SET', 'NUMERIC(38,15)'),  typeof(t_SET...
 
 ===================================================
 Error:-894
@@ -415,7 +415,7 @@ Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_NUMERIC('MULTISET', 'NUMERIC(38,15)', {'...'
-Function t_MULTISET_NUMERIC is undefined or given wrong number of parameter. select t_MULTISET_NUMERIC('MULTISET', 'NUMERIC(38,15)'),  ty...
+Function t_multiset_numeric is undefined or given wrong number of parameter. select t_MULTISET_NUMERIC('MULTISET', 'NUMERIC(38,15)'),  ty...
 
 ===================================================
 Error:-894
@@ -436,7 +436,7 @@ Stored procedure compile error: no viable alternative at input 'VAR LIST'
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_NUMERIC('LIST', 'NUMERIC(38,15)', {'c','c','...'
-Function t_LIST_NUMERIC is undefined or given wrong number of parameter. select t_LIST_NUMERIC('LIST', 'NUMERIC(38,15)'),  typeof(t_L...
+Function t_list_numeric is undefined or given wrong number of parameter. select t_LIST_NUMERIC('LIST', 'NUMERIC(38,15)'),  typeof(t_L...
 
 ===================================================
 Error:-894
@@ -457,7 +457,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_NUMERIC('ENUM', 'NUMERIC(38,15)', 'yellow' )...'
-Function t_ENUM_NUMERIC is undefined or given wrong number of parameter. select t_ENUM_NUMERIC('ENUM', 'NUMERIC(38,15)', 'yellow'),  ...
+Function t_enum_numeric is undefined or given wrong number of parameter. select t_ENUM_NUMERIC('ENUM', 'NUMERIC(38,15)', 'yellow'),  ...
 
 ===================================================
 Error:-894
@@ -482,7 +482,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_NUMERIC('BLOB', 'NUMERIC(38,15)', BIT_TO_BLO...'
-Function t_BLOB_NUMERIC is undefined or given wrong number of parameter. select t_BLOB_NUMERIC('BLOB', 'NUMERIC(38,15)',  bit_to_blob...
+Function t_blob_numeric is undefined or given wrong number of parameter. select t_BLOB_NUMERIC('BLOB', 'NUMERIC(38,15)',  bit_to_blob...
 
 ===================================================
 Error:-894
@@ -507,7 +507,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_NUMERIC('CLOB', 'NUMERIC(38,15)', CHAR_TO_CL...'
-Function t_CLOB_NUMERIC is undefined or given wrong number of parameter. select t_CLOB_NUMERIC('CLOB', 'NUMERIC(38,15)',  char_to_clo...
+Function t_clob_numeric is undefined or given wrong number of parameter. select t_CLOB_NUMERIC('CLOB', 'NUMERIC(38,15)',  char_to_clo...
 
 ===================================================
 Error:-894
@@ -532,7 +532,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_NUMERIC('JSON', 'NUMERIC(38,15)', '{"a":1}' ...'
-Function t_JSON_NUMERIC is undefined or given wrong number of parameter. select t_JSON_NUMERIC('JSON', 'NUMERIC(38,15)', '{"a":1}'), ...
+Function t_json_numeric is undefined or given wrong number of parameter. select t_JSON_NUMERIC('JSON', 'NUMERIC(38,15)', '{"a":1}'), ...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-18_variable_to_return_BIGINT.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-18_variable_to_return_BIGINT.answer
@@ -16,7 +16,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_BIGINT('DATETIME', 'BIGINT', DATETIME'20...'
-Function t_DATETIME_BIGINT is undefined or given wrong number of parameter. select t_DATETIME_BIGINT('DATETIME', 'BIGINT', datetime '202...
+Function t_datetime_bigint is undefined or given wrong number of parameter. select t_DATETIME_BIGINT('DATETIME', 'BIGINT', datetime '202...
 
 ===================================================
 Error:-894
@@ -40,7 +40,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_BIGINT('DATETIMELTZ', 'BIGINT', datet...'
-Function t_DATETIMELTZ_BIGINT is undefined or given wrong number of parameter. select t_DATETIMELTZ_BIGINT('DATETIMELTZ', 'BIGINT', datetim...
+Function t_datetimeltz_bigint is undefined or given wrong number of parameter. select t_DATETIMELTZ_BIGINT('DATETIMELTZ', 'BIGINT', datetim...
 
 ===================================================
 Error:-894
@@ -64,7 +64,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_BIGINT('DATETIMETZ', 'BIGINT', datetim...'
-Function t_DATETIMETZ_BIGINT is undefined or given wrong number of parameter. select t_DATETIMETZ_BIGINT('DATETIMETZ', 'BIGINT', datetimet...
+Function t_datetimetz_bigint is undefined or given wrong number of parameter. select t_DATETIMETZ_BIGINT('DATETIMETZ', 'BIGINT', datetimet...
 
 ===================================================
 Error:-894
@@ -85,7 +85,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_BIGINT('DATE', 'BIGINT', DATE'2008-10-31' ) ...'
-Function t_DATE_BIGINT is undefined or given wrong number of parameter. select t_DATE_BIGINT('DATE', 'BIGINT', date '2008-10-31'),  ...
+Function t_date_bigint is undefined or given wrong number of parameter. select t_DATE_BIGINT('DATE', 'BIGINT', date '2008-10-31'),  ...
 
 ===================================================
 Error:-894
@@ -106,7 +106,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_BIGINT('TIME', 'BIGINT', TIME'13:15:45' ) ) ; '
-Function t_TIME_BIGINT is undefined or given wrong number of parameter. select t_TIME_BIGINT('TIME', 'BIGINT', time '13:15:45'),  ty...
+Function t_time_bigint is undefined or given wrong number of parameter. select t_TIME_BIGINT('TIME', 'BIGINT', time '13:15:45'),  ty...
 
 ===================================================
 Error:-894
@@ -127,7 +127,7 @@ Stored procedure compile error: type of the return value is not compatible with 
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_BIGINT('TIMESTAMP', 'BIGINT', TIMESTAMP...'
-Function t_TIMESTAMP_BIGINT is undefined or given wrong number of parameter. select t_TIMESTAMP_BIGINT('TIMESTAMP', 'BIGINT', timestamp '...
+Function t_timestamp_bigint is undefined or given wrong number of parameter. select t_TIMESTAMP_BIGINT('TIMESTAMP', 'BIGINT', timestamp '...
 
 ===================================================
 Error:-894
@@ -151,7 +151,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_BIGINT('TIMESTAMPLTZ', 'BIGINT', tim...'
-Function t_TIMESTAMPLTZ_BIGINT is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_BIGINT('TIMESTAMPLTZ', 'BIGINT', times...
+Function t_timestampltz_bigint is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_BIGINT('TIMESTAMPLTZ', 'BIGINT', times...
 
 ===================================================
 Error:-894
@@ -175,7 +175,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_BIGINT('TIMESTAMPTZ', 'BIGINT', times...'
-Function t_TIMESTAMPTZ_BIGINT is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_BIGINT('TIMESTAMPTZ', 'BIGINT', timesta...
+Function t_timestamptz_bigint is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_BIGINT('TIMESTAMPTZ', 'BIGINT', timesta...
 
 ===================================================
 Error:-894
@@ -314,7 +314,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_BIGINT('BIT(8)', 'BIGINT', 0xaa ) ) ; '
-Function t_BIT_BIGINT is undefined or given wrong number of parameter. select t_BIT_BIGINT('BIT(8)', 'BIGINT', X'aa'),  typeof(t_BI...
+Function t_bit_bigint is undefined or given wrong number of parameter. select t_BIT_BIGINT('BIT(8)', 'BIGINT', X'aa'),  typeof(t_BI...
 
 ===================================================
 Error:-894
@@ -338,7 +338,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_BIGI
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_BIGINT('BIT VARYING', 'BIGINT', 0xaa )...'
-Function t_BITVARYING_BIGINT is undefined or given wrong number of parameter. select t_BITVARYING_BIGINT('BIT VARYING', 'BIGINT', X'aa'), ...
+Function t_bitvarying_bigint is undefined or given wrong number of parameter. select t_BITVARYING_BIGINT('BIT VARYING', 'BIGINT', X'aa'), ...
 
 ===================================================
 Error:-894
@@ -395,7 +395,7 @@ Stored procedure compile error: no viable alternative at input 'VAR SET'
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_BIGINT('SET', 'BIGINT', {'c','c','c','b','b',...'
-Function t_SET_BIGINT is undefined or given wrong number of parameter. select t_SET_BIGINT('SET', 'BIGINT'),  typeof(t_SET_BIGINT('...
+Function t_set_bigint is undefined or given wrong number of parameter. select t_SET_BIGINT('SET', 'BIGINT'),  typeof(t_SET_BIGINT('...
 
 ===================================================
 Error:-894
@@ -416,7 +416,7 @@ Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_BIGINT('MULTISET', 'BIGINT', {'c','c','c...'
-Function t_MULTISET_BIGINT is undefined or given wrong number of parameter. select t_MULTISET_BIGINT('MULTISET', 'BIGINT'),  typeof(t_MU...
+Function t_multiset_bigint is undefined or given wrong number of parameter. select t_MULTISET_BIGINT('MULTISET', 'BIGINT'),  typeof(t_MU...
 
 ===================================================
 Error:-894
@@ -437,7 +437,7 @@ Stored procedure compile error: no viable alternative at input 'VAR LIST'
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_BIGINT('LIST', 'BIGINT', {'c','c','c','b','b...'
-Function t_LIST_BIGINT is undefined or given wrong number of parameter. select t_LIST_BIGINT('LIST', 'BIGINT'),  typeof(t_LIST_BIGIN...
+Function t_list_bigint is undefined or given wrong number of parameter. select t_LIST_BIGINT('LIST', 'BIGINT'),  typeof(t_LIST_BIGIN...
 
 ===================================================
 Error:-894
@@ -458,7 +458,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_BIGINT('ENUM', 'BIGINT', 'yellow' ) ) ; '
-Function t_ENUM_BIGINT is undefined or given wrong number of parameter. select t_ENUM_BIGINT('ENUM', 'BIGINT', 'yellow'),  typeof(t_...
+Function t_enum_bigint is undefined or given wrong number of parameter. select t_ENUM_BIGINT('ENUM', 'BIGINT', 'yellow'),  typeof(t_...
 
 ===================================================
 Error:-894
@@ -483,7 +483,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_BIGINT('BLOB', 'BIGINT', BIT_TO_BLOB(X'00001...'
-Function t_BLOB_BIGINT is undefined or given wrong number of parameter. select t_BLOB_BIGINT('BLOB', 'BIGINT',  bit_to_blob(X'000010...
+Function t_blob_bigint is undefined or given wrong number of parameter. select t_BLOB_BIGINT('BLOB', 'BIGINT',  bit_to_blob(X'000010...
 
 ===================================================
 Error:-894
@@ -508,7 +508,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_BIGINT('CLOB', 'BIGINT', CHAR_TO_CLOB('This ...'
-Function t_CLOB_BIGINT is undefined or given wrong number of parameter. select t_CLOB_BIGINT('CLOB', 'BIGINT',  char_to_clob('This i...
+Function t_clob_bigint is undefined or given wrong number of parameter. select t_CLOB_BIGINT('CLOB', 'BIGINT',  char_to_clob('This i...
 
 ===================================================
 Error:-894
@@ -533,7 +533,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_BIGINT('JSON', 'BIGINT', '{"a":1}' ) ) ; '
-Function t_JSON_BIGINT is undefined or given wrong number of parameter. select t_JSON_BIGINT('JSON', 'BIGINT', '{"a":1}'),  typeof(t...
+Function t_json_bigint is undefined or given wrong number of parameter. select t_JSON_BIGINT('JSON', 'BIGINT', '{"a":1}'),  typeof(t...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-19_variable_to_return_SET.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-19_variable_to_return_SET.answer
@@ -16,7 +16,7 @@ Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEA
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_SET('DATETIME', 'SET', DATETIME'2023-02-...'
-Function t_DATETIME_SET is undefined or given wrong number of parameter. select t_DATETIME_SET('DATETIME', 'SET', datetime '2023-02-1...
+Function t_datetime_set is undefined or given wrong number of parameter. select t_DATETIME_SET('DATETIME', 'SET', datetime '2023-02-1...
 
 ===================================================
 Error:-894
@@ -40,7 +40,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_SET('DATETIMELTZ', 'SET', datetimeltz...'
-Function t_DATETIMELTZ_SET is undefined or given wrong number of parameter. select t_DATETIMELTZ_SET('DATETIMELTZ', 'SET', datetimeltz '...
+Function t_datetimeltz_set is undefined or given wrong number of parameter. select t_DATETIMELTZ_SET('DATETIMELTZ', 'SET', datetimeltz '...
 
 ===================================================
 Error:-894
@@ -64,7 +64,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_SET('DATETIMETZ', 'SET', datetimetz '0...'
-Function t_DATETIMETZ_SET is undefined or given wrong number of parameter. select t_DATETIMETZ_SET('DATETIMETZ', 'SET', datetimetz '09/...
+Function t_datetimetz_set is undefined or given wrong number of parameter. select t_DATETIMETZ_SET('DATETIMETZ', 'SET', datetimetz '09/...
 
 ===================================================
 Error:-894
@@ -85,7 +85,7 @@ Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEA
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_SET('DATE', 'SET', DATE'2008-10-31' ) ) ; '
-Function t_DATE_SET is undefined or given wrong number of parameter. select t_DATE_SET('DATE', 'SET', date '2008-10-31'),  typeof...
+Function t_date_set is undefined or given wrong number of parameter. select t_DATE_SET('DATE', 'SET', date '2008-10-31'),  typeof...
 
 ===================================================
 Error:-894
@@ -106,7 +106,7 @@ Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEA
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_SET('TIME', 'SET', TIME'13:15:45' ) ) ; '
-Function t_TIME_SET is undefined or given wrong number of parameter. select t_TIME_SET('TIME', 'SET', time '13:15:45'),  typeof(t...
+Function t_time_set is undefined or given wrong number of parameter. select t_TIME_SET('TIME', 'SET', time '13:15:45'),  typeof(t...
 
 ===================================================
 Error:-894
@@ -127,7 +127,7 @@ Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEA
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_SET('TIMESTAMP', 'SET', TIMESTAMP'2023-...'
-Function t_TIMESTAMP_SET is undefined or given wrong number of parameter. select t_TIMESTAMP_SET('TIMESTAMP', 'SET', timestamp '2023-1...
+Function t_timestamp_set is undefined or given wrong number of parameter. select t_TIMESTAMP_SET('TIMESTAMP', 'SET', timestamp '2023-1...
 
 ===================================================
 Error:-894
@@ -151,7 +151,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_SET('TIMESTAMPLTZ', 'SET', timestamp...'
-Function t_TIMESTAMPLTZ_SET is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_SET('TIMESTAMPLTZ', 'SET', timestamptz...
+Function t_timestampltz_set is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_SET('TIMESTAMPLTZ', 'SET', timestamptz...
 
 ===================================================
 Error:-894
@@ -175,7 +175,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_SET('TIMESTAMPTZ', 'SET', timestamptz...'
-Function t_TIMESTAMPTZ_SET is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_SET('TIMESTAMPTZ', 'SET', timestamptz '...
+Function t_timestamptz_set is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_SET('TIMESTAMPTZ', 'SET', timestamptz '...
 
 ===================================================
 Error:-894
@@ -196,7 +196,7 @@ Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEA
 Error:-494
 Semantic: before ' ,
 typeof( t_DOUBLE_SET('DOUBLE', 'SET', cast( 1234.56789 as d...'
-Function t_DOUBLE_SET is undefined or given wrong number of parameter. select t_DOUBLE_SET('DOUBLE', 'SET',  cast(1234.56789 as dou...
+Function t_double_set is undefined or given wrong number of parameter. select t_DOUBLE_SET('DOUBLE', 'SET',  cast(1234.56789 as dou...
 
 ===================================================
 Error:-894
@@ -217,7 +217,7 @@ Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEA
 Error:-494
 Semantic: before ' ,
 typeof( t_FLOAT_SET('FLOAT', 'SET', cast( 16777.217 as floa...'
-Function t_FLOAT_SET is undefined or given wrong number of parameter. select t_FLOAT_SET('FLOAT', 'SET',  cast(16777.217 as float)...
+Function t_float_set is undefined or given wrong number of parameter. select t_FLOAT_SET('FLOAT', 'SET',  cast(16777.217 as float)...
 
 ===================================================
 Error:-894
@@ -238,7 +238,7 @@ Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEA
 Error:-494
 Semantic: before ' ,
 typeof( t_NUMERIC_SET('NUMERIC(8,4)', 'SET', cast( 0.123456...'
-Function t_NUMERIC_SET is undefined or given wrong number of parameter. select t_NUMERIC_SET('NUMERIC(8,4)', 'SET',  cast(0.12345678...
+Function t_numeric_set is undefined or given wrong number of parameter. select t_NUMERIC_SET('NUMERIC(8,4)', 'SET',  cast(0.12345678...
 
 ===================================================
 Error:-894
@@ -259,7 +259,7 @@ Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEA
 Error:-494
 Semantic: before ' ,
 typeof( t_BIGINT_SET('BIGINT', 'SET', cast( 34589012 as big...'
-Function t_BIGINT_SET is undefined or given wrong number of parameter. select t_BIGINT_SET('BIGINT', 'SET',  cast(34589012 as bigin...
+Function t_bigint_set is undefined or given wrong number of parameter. select t_BIGINT_SET('BIGINT', 'SET',  cast(34589012 as bigin...
 
 ===================================================
 Error:-894
@@ -280,7 +280,7 @@ Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEA
 Error:-494
 Semantic: before ' ,
 typeof( t_INT_SET('INT', 'SET', cast( 782346 as int ) ) ) ; '
-Function t_INT_SET is undefined or given wrong number of parameter. select t_INT_SET('INT', 'SET',  cast(782346 as integer)),  t...
+Function t_int_set is undefined or given wrong number of parameter. select t_INT_SET('INT', 'SET',  cast(782346 as integer)),  t...
 
 ===================================================
 Error:-894
@@ -301,7 +301,7 @@ Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEA
 Error:-494
 Semantic: before ' ,
 typeof( t_SHORT_SET('SHORT', 'SET', cast( 8934 as short ) )...'
-Function t_SHORT_SET is undefined or given wrong number of parameter. select t_SHORT_SET('SHORT', 'SET',  cast(8934 as smallint)),...
+Function t_short_set is undefined or given wrong number of parameter. select t_SHORT_SET('SHORT', 'SET',  cast(8934 as smallint)),...
 
 ===================================================
 Error:-894
@@ -326,7 +326,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_SET('BIT(8)', 'SET', 0xaa ) ) ; '
-Function t_BIT_SET is undefined or given wrong number of parameter. select t_BIT_SET('BIT(8)', 'SET', X'aa'),  typeof(t_BIT_SET(...
+Function t_bit_set is undefined or given wrong number of parameter. select t_BIT_SET('BIT(8)', 'SET', X'aa'),  typeof(t_BIT_SET(...
 
 ===================================================
 Error:-894
@@ -350,7 +350,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_SET]
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_SET('BIT VARYING', 'SET', 0xaa ) ) ; '
-Function t_BITVARYING_SET is undefined or given wrong number of parameter. select t_BITVARYING_SET('BIT VARYING', 'SET', X'aa'),  typeo...
+Function t_bitvarying_set is undefined or given wrong number of parameter. select t_BITVARYING_SET('BIT VARYING', 'SET', X'aa'),  typeo...
 
 ===================================================
 Error:-894
@@ -371,7 +371,7 @@ Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEA
 Error:-494
 Semantic: before ' ,
 typeof( t_CHAR_SET('CHAR', 'SET', {'c','c','c','b','b','a'}...'
-Function t_CHAR_SET is undefined or given wrong number of parameter. select t_CHAR_SET('CHAR', 'SET'),  typeof(t_CHAR_SET('CHAR',...
+Function t_char_set is undefined or given wrong number of parameter. select t_CHAR_SET('CHAR', 'SET'),  typeof(t_CHAR_SET('CHAR',...
 
 ===================================================
 Error:-894
@@ -392,7 +392,7 @@ Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEA
 Error:-494
 Semantic: before ' ,
 typeof( t_VARCHAR_SET('VARCHAR', 'SET', {'c','c','c','b','b...'
-Function t_VARCHAR_SET is undefined or given wrong number of parameter. select t_VARCHAR_SET('VARCHAR', 'SET'),  typeof(t_VARCHAR_SE...
+Function t_varchar_set is undefined or given wrong number of parameter. select t_VARCHAR_SET('VARCHAR', 'SET'),  typeof(t_VARCHAR_SE...
 
 ===================================================
 Error:-894
@@ -413,7 +413,7 @@ Stored procedure compile error: no viable alternative at input 'VAR SET'
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_SET('SET', 'SET', {'c','c','c','b','b','a'} )...'
-Function t_SET_SET is undefined or given wrong number of parameter. select t_SET_SET('SET', 'SET'),  typeof(t_SET_SET('SET', 'SET'))
+Function t_set_set is undefined or given wrong number of parameter. select t_SET_SET('SET', 'SET'),  typeof(t_SET_SET('SET', 'SET'))
 
 ===================================================
 Error:-894
@@ -434,7 +434,7 @@ Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_SET('MULTISET', 'SET', {'c','c','c','b',...'
-Function t_MULTISET_SET is undefined or given wrong number of parameter. select t_MULTISET_SET('MULTISET', 'SET'),  typeof(t_MULTISET...
+Function t_multiset_set is undefined or given wrong number of parameter. select t_MULTISET_SET('MULTISET', 'SET'),  typeof(t_MULTISET...
 
 ===================================================
 Error:-894
@@ -455,7 +455,7 @@ Stored procedure compile error: no viable alternative at input 'VAR LIST'
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_SET('LIST', 'SET', {'c','c','c','b','b', 'a'...'
-Function t_LIST_SET is undefined or given wrong number of parameter. select t_LIST_SET('LIST', 'SET'),  typeof(t_LIST_SET('LIST',...
+Function t_list_set is undefined or given wrong number of parameter. select t_LIST_SET('LIST', 'SET'),  typeof(t_LIST_SET('LIST',...
 
 ===================================================
 Error:-894
@@ -476,7 +476,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_SET('ENUM', 'SET', 'yellow' ) ) ; '
-Function t_ENUM_SET is undefined or given wrong number of parameter. select t_ENUM_SET('ENUM', 'SET', 'yellow'),  typeof(t_ENUM_S...
+Function t_enum_set is undefined or given wrong number of parameter. select t_ENUM_SET('ENUM', 'SET', 'yellow'),  typeof(t_ENUM_S...
 
 ===================================================
 Error:-894
@@ -501,7 +501,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_SET('BLOB', 'SET', BIT_TO_BLOB(X'000010') ) ...'
-Function t_BLOB_SET is undefined or given wrong number of parameter. select t_BLOB_SET('BLOB', 'SET',  bit_to_blob(X'000010')),  ...
+Function t_blob_set is undefined or given wrong number of parameter. select t_BLOB_SET('BLOB', 'SET',  bit_to_blob(X'000010')),  ...
 
 ===================================================
 Error:-894
@@ -526,7 +526,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_SET('CLOB', 'SET', CHAR_TO_CLOB('This is a D...'
-Function t_CLOB_SET is undefined or given wrong number of parameter. select t_CLOB_SET('CLOB', 'SET',  char_to_clob('This is a Do...
+Function t_clob_set is undefined or given wrong number of parameter. select t_CLOB_SET('CLOB', 'SET',  char_to_clob('This is a Do...
 
 ===================================================
 Error:-894
@@ -551,7 +551,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_SET('JSON', 'SET', '{"a":1}' ) ) ; '
-Function t_JSON_SET is undefined or given wrong number of parameter. select t_JSON_SET('JSON', 'SET', '{"a":1}'),  typeof(t_JSON_...
+Function t_json_set is undefined or given wrong number of parameter. select t_JSON_SET('JSON', 'SET', '{"a":1}'),  typeof(t_JSON_...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-20_variable_to_return_MULTISET.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-20_variable_to_return_MULTISET.answer
@@ -16,7 +16,7 @@ Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, B
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_MULTISET('DATETIME', 'MULTISET', DATETIM...'
-Function t_DATETIME_MULTISET is undefined or given wrong number of parameter. select t_DATETIME_MULTISET('DATETIME', 'MULTISET', datetime ...
+Function t_datetime_multiset is undefined or given wrong number of parameter. select t_DATETIME_MULTISET('DATETIME', 'MULTISET', datetime ...
 
 ===================================================
 Error:-894
@@ -40,7 +40,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_MULTISET('DATETIMELTZ', 'MULTISET', d...'
-Function t_DATETIMELTZ_MULTISET is undefined or given wrong number of parameter. select t_DATETIMELTZ_MULTISET('DATETIMELTZ', 'MULTISET', dat...
+Function t_datetimeltz_multiset is undefined or given wrong number of parameter. select t_DATETIMELTZ_MULTISET('DATETIMELTZ', 'MULTISET', dat...
 
 ===================================================
 Error:-894
@@ -64,7 +64,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_MULTISET('DATETIMETZ', 'MULTISET', dat...'
-Function t_DATETIMETZ_MULTISET is undefined or given wrong number of parameter. select t_DATETIMETZ_MULTISET('DATETIMETZ', 'MULTISET', datet...
+Function t_datetimetz_multiset is undefined or given wrong number of parameter. select t_DATETIMETZ_MULTISET('DATETIMETZ', 'MULTISET', datet...
 
 ===================================================
 Error:-894
@@ -85,7 +85,7 @@ Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, B
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_MULTISET('DATE', 'MULTISET', DATE'2008-10-31...'
-Function t_DATE_MULTISET is undefined or given wrong number of parameter. select t_DATE_MULTISET('DATE', 'MULTISET', date '2008-10-31'...
+Function t_date_multiset is undefined or given wrong number of parameter. select t_DATE_MULTISET('DATE', 'MULTISET', date '2008-10-31'...
 
 ===================================================
 Error:-894
@@ -106,7 +106,7 @@ Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, B
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_MULTISET('TIME', 'MULTISET', TIME'13:15:45' ...'
-Function t_TIME_MULTISET is undefined or given wrong number of parameter. select t_TIME_MULTISET('TIME', 'MULTISET', time '13:15:45'),...
+Function t_time_multiset is undefined or given wrong number of parameter. select t_TIME_MULTISET('TIME', 'MULTISET', time '13:15:45'),...
 
 ===================================================
 Error:-894
@@ -127,7 +127,7 @@ Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, B
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_MULTISET('TIMESTAMP', 'MULTISET', TIMES...'
-Function t_TIMESTAMP_MULTISET is undefined or given wrong number of parameter. select t_TIMESTAMP_MULTISET('TIMESTAMP', 'MULTISET', timesta...
+Function t_timestamp_multiset is undefined or given wrong number of parameter. select t_TIMESTAMP_MULTISET('TIMESTAMP', 'MULTISET', timesta...
 
 ===================================================
 Error:-894
@@ -151,7 +151,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_MULTISET('TIMESTAMPLTZ', 'MULTISET',...'
-Function t_TIMESTAMPLTZ_MULTISET is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_MULTISET('TIMESTAMPLTZ', 'MULTISET', t...
+Function t_timestampltz_multiset is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_MULTISET('TIMESTAMPLTZ', 'MULTISET', t...
 
 ===================================================
 Error:-894
@@ -175,7 +175,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_MULTISET('TIMESTAMPTZ', 'MULTISET', t...'
-Function t_TIMESTAMPTZ_MULTISET is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_MULTISET('TIMESTAMPTZ', 'MULTISET', tim...
+Function t_timestamptz_multiset is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_MULTISET('TIMESTAMPTZ', 'MULTISET', tim...
 
 ===================================================
 Error:-894
@@ -196,7 +196,7 @@ Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, B
 Error:-494
 Semantic: before ' ,
 typeof( t_DOUBLE_MULTISET('DOUBLE', 'MULTISET', cast( 1234....'
-Function t_DOUBLE_MULTISET is undefined or given wrong number of parameter. select t_DOUBLE_MULTISET('DOUBLE', 'MULTISET',  cast(1234.56...
+Function t_double_multiset is undefined or given wrong number of parameter. select t_DOUBLE_MULTISET('DOUBLE', 'MULTISET',  cast(1234.56...
 
 ===================================================
 Error:-894
@@ -217,7 +217,7 @@ Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, B
 Error:-494
 Semantic: before ' ,
 typeof( t_FLOAT_MULTISET('FLOAT', 'MULTISET', cast( 16777.2...'
-Function t_FLOAT_MULTISET is undefined or given wrong number of parameter. select t_FLOAT_MULTISET('FLOAT', 'MULTISET',  cast(16777.217...
+Function t_float_multiset is undefined or given wrong number of parameter. select t_FLOAT_MULTISET('FLOAT', 'MULTISET',  cast(16777.217...
 
 ===================================================
 Error:-894
@@ -238,7 +238,7 @@ Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, B
 Error:-494
 Semantic: before ' ,
 typeof( t_NUMERIC_MULTISET('NUMERIC(8,4)', 'MULTISET', cast...'
-Function t_NUMERIC_MULTISET is undefined or given wrong number of parameter. select t_NUMERIC_MULTISET('NUMERIC(8,4)', 'MULTISET',  cast(...
+Function t_numeric_multiset is undefined or given wrong number of parameter. select t_NUMERIC_MULTISET('NUMERIC(8,4)', 'MULTISET',  cast(...
 
 ===================================================
 Error:-894
@@ -259,7 +259,7 @@ Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, B
 Error:-494
 Semantic: before ' ,
 typeof( t_BIGINT_MULTISET('BIGINT', 'MULTISET', cast( 34589...'
-Function t_BIGINT_MULTISET is undefined or given wrong number of parameter. select t_BIGINT_MULTISET('BIGINT', 'MULTISET',  cast(3458901...
+Function t_bigint_multiset is undefined or given wrong number of parameter. select t_BIGINT_MULTISET('BIGINT', 'MULTISET',  cast(3458901...
 
 ===================================================
 Error:-894
@@ -280,7 +280,7 @@ Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, B
 Error:-494
 Semantic: before ' ,
 typeof( t_INT_MULTISET('INT', 'MULTISET', cast( 782346 as i...'
-Function t_INT_MULTISET is undefined or given wrong number of parameter. select t_INT_MULTISET('INT', 'MULTISET',  cast(782346 as int...
+Function t_int_multiset is undefined or given wrong number of parameter. select t_INT_MULTISET('INT', 'MULTISET',  cast(782346 as int...
 
 ===================================================
 Error:-894
@@ -301,7 +301,7 @@ Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, B
 Error:-494
 Semantic: before ' ,
 typeof( t_SHORT_MULTISET('SHORT', 'MULTISET', cast( 8934 as...'
-Function t_SHORT_MULTISET is undefined or given wrong number of parameter. select t_SHORT_MULTISET('SHORT', 'MULTISET',  cast(8934 as s...
+Function t_short_multiset is undefined or given wrong number of parameter. select t_SHORT_MULTISET('SHORT', 'MULTISET',  cast(8934 as s...
 
 ===================================================
 Error:-894
@@ -325,7 +325,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_MULTISET('BIT(8)', 'MULTISET', 0xaa ) ) ; '
-Function t_BIT_MULTISET is undefined or given wrong number of parameter. select t_BIT_MULTISET('BIT(8)', 'MULTISET', X'aa'),  typeof(...
+Function t_bit_multiset is undefined or given wrong number of parameter. select t_BIT_MULTISET('BIT(8)', 'MULTISET', X'aa'),  typeof(...
 
 ===================================================
 Error:-894
@@ -349,7 +349,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_MULT
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_MULTISET('BIT VARYING', 'MULTISET', 0x...'
-Function t_BITVARYING_MULTISET is undefined or given wrong number of parameter. select t_BITVARYING_MULTISET('BIT VARYING', 'MULTISET', X'aa...
+Function t_bitvarying_multiset is undefined or given wrong number of parameter. select t_BITVARYING_MULTISET('BIT VARYING', 'MULTISET', X'aa...
 
 ===================================================
 Error:-894
@@ -370,7 +370,7 @@ Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, B
 Error:-494
 Semantic: before ' ,
 typeof( t_CHAR_MULTISET('CHAR', 'MULTISET', {'c','c','c','b...'
-Function t_CHAR_MULTISET is undefined or given wrong number of parameter. select t_CHAR_MULTISET('CHAR', 'MULTISET'),  typeof(t_CHAR_M...
+Function t_char_multiset is undefined or given wrong number of parameter. select t_CHAR_MULTISET('CHAR', 'MULTISET'),  typeof(t_CHAR_M...
 
 ===================================================
 Error:-894
@@ -391,7 +391,7 @@ Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, B
 Error:-494
 Semantic: before ' ,
 typeof( t_VARCHAR_MULTISET('VARCHAR', 'MULTISET', {'c','c',...'
-Function t_VARCHAR_MULTISET is undefined or given wrong number of parameter. select t_VARCHAR_MULTISET('VARCHAR', 'MULTISET'),  typeof(t_...
+Function t_varchar_multiset is undefined or given wrong number of parameter. select t_VARCHAR_MULTISET('VARCHAR', 'MULTISET'),  typeof(t_...
 
 ===================================================
 Error:-894
@@ -412,7 +412,7 @@ Stored procedure compile error: no viable alternative at input 'VAR SET'
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_MULTISET('SET', 'MULTISET', {'c','c','c','b',...'
-Function t_SET_MULTISET is undefined or given wrong number of parameter. select t_SET_MULTISET('SET', 'MULTISET'),  typeof(t_SET_MULT...
+Function t_set_multiset is undefined or given wrong number of parameter. select t_SET_MULTISET('SET', 'MULTISET'),  typeof(t_SET_MULT...
 
 ===================================================
 Error:-894
@@ -433,7 +433,7 @@ Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_MULTISET('MULTISET', 'MULTISET', {'c','c...'
-Function t_MULTISET_MULTISET is undefined or given wrong number of parameter. select t_MULTISET_MULTISET('MULTISET', 'MULTISET'),  typeof(...
+Function t_multiset_multiset is undefined or given wrong number of parameter. select t_MULTISET_MULTISET('MULTISET', 'MULTISET'),  typeof(...
 
 ===================================================
 Error:-894
@@ -454,7 +454,7 @@ Stored procedure compile error: no viable alternative at input 'VAR LIST'
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_MULTISET('LIST', 'MULTISET', {'c','c','c','b...'
-Function t_LIST_MULTISET is undefined or given wrong number of parameter. select t_LIST_MULTISET('LIST', 'MULTISET'),  typeof(t_LIST_M...
+Function t_list_multiset is undefined or given wrong number of parameter. select t_LIST_MULTISET('LIST', 'MULTISET'),  typeof(t_LIST_M...
 
 ===================================================
 Error:-894
@@ -475,7 +475,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_MULTISET('ENUM', 'MULTISET', 'yellow' ) ) ; '
-Function t_ENUM_MULTISET is undefined or given wrong number of parameter. select t_ENUM_MULTISET('ENUM', 'MULTISET', 'yellow'),  typeo...
+Function t_enum_multiset is undefined or given wrong number of parameter. select t_ENUM_MULTISET('ENUM', 'MULTISET', 'yellow'),  typeo...
 
 ===================================================
 Error:-894
@@ -500,7 +500,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_MULTISET('BLOB', 'MULTISET', BIT_TO_BLOB(X'0...'
-Function t_BLOB_MULTISET is undefined or given wrong number of parameter. select t_BLOB_MULTISET('BLOB', 'MULTISET',  bit_to_blob(X'00...
+Function t_blob_multiset is undefined or given wrong number of parameter. select t_BLOB_MULTISET('BLOB', 'MULTISET',  bit_to_blob(X'00...
 
 ===================================================
 Error:-894
@@ -525,7 +525,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_MULTISET('CLOB', 'MULTISET', CHAR_TO_CLOB('T...'
-Function t_CLOB_MULTISET is undefined or given wrong number of parameter. select t_CLOB_MULTISET('CLOB', 'MULTISET',  char_to_clob('Th...
+Function t_clob_multiset is undefined or given wrong number of parameter. select t_CLOB_MULTISET('CLOB', 'MULTISET',  char_to_clob('Th...
 
 ===================================================
 Error:-894
@@ -550,7 +550,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_MULTISET('JSON', 'MULTISET', '{"a":1}' ) ) ; '
-Function t_JSON_MULTISET is undefined or given wrong number of parameter. select t_JSON_MULTISET('JSON', 'MULTISET', '{"a":1}'),  type...
+Function t_json_multiset is undefined or given wrong number of parameter. select t_JSON_MULTISET('JSON', 'MULTISET', '{"a":1}'),  type...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-21_variable_to_return_LIST.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-21_variable_to_return_LIST.answer
@@ -16,7 +16,7 @@ Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLE
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_LIST('DATETIME', 'LIST', DATETIME'2023-0...'
-Function t_DATETIME_LIST is undefined or given wrong number of parameter. select t_DATETIME_LIST('DATETIME', 'LIST', datetime '2023-02...
+Function t_datetime_list is undefined or given wrong number of parameter. select t_DATETIME_LIST('DATETIME', 'LIST', datetime '2023-02...
 
 ===================================================
 Error:-894
@@ -40,7 +40,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_LIST('DATETIMELTZ', 'LIST', datetimel...'
-Function t_DATETIMELTZ_LIST is undefined or given wrong number of parameter. select t_DATETIMELTZ_LIST('DATETIMELTZ', 'LIST', datetimeltz...
+Function t_datetimeltz_list is undefined or given wrong number of parameter. select t_DATETIMELTZ_LIST('DATETIMELTZ', 'LIST', datetimeltz...
 
 ===================================================
 Error:-894
@@ -64,7 +64,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_LIST('DATETIMETZ', 'LIST', datetimetz ...'
-Function t_DATETIMETZ_LIST is undefined or given wrong number of parameter. select t_DATETIMETZ_LIST('DATETIMETZ', 'LIST', datetimetz '0...
+Function t_datetimetz_list is undefined or given wrong number of parameter. select t_DATETIMETZ_LIST('DATETIMETZ', 'LIST', datetimetz '0...
 
 ===================================================
 Error:-894
@@ -85,7 +85,7 @@ Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLE
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_LIST('DATE', 'LIST', DATE'2008-10-31' ) ) ; '
-Function t_DATE_LIST is undefined or given wrong number of parameter. select t_DATE_LIST('DATE', 'LIST', date '2008-10-31'),  type...
+Function t_date_list is undefined or given wrong number of parameter. select t_DATE_LIST('DATE', 'LIST', date '2008-10-31'),  type...
 
 ===================================================
 Error:-894
@@ -106,7 +106,7 @@ Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLE
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_LIST('TIME', 'LIST', TIME'13:15:45' ) ) ; '
-Function t_TIME_LIST is undefined or given wrong number of parameter. select t_TIME_LIST('TIME', 'LIST', time '13:15:45'),  typeof...
+Function t_time_list is undefined or given wrong number of parameter. select t_TIME_LIST('TIME', 'LIST', time '13:15:45'),  typeof...
 
 ===================================================
 Error:-894
@@ -127,7 +127,7 @@ Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLE
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_LIST('TIMESTAMP', 'LIST', TIMESTAMP'202...'
-Function t_TIMESTAMP_LIST is undefined or given wrong number of parameter. select t_TIMESTAMP_LIST('TIMESTAMP', 'LIST', timestamp '2023...
+Function t_timestamp_list is undefined or given wrong number of parameter. select t_TIMESTAMP_LIST('TIMESTAMP', 'LIST', timestamp '2023...
 
 ===================================================
 Error:-894
@@ -151,7 +151,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_LIST('TIMESTAMPLTZ', 'LIST', timesta...'
-Function t_TIMESTAMPLTZ_LIST is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_LIST('TIMESTAMPLTZ', 'LIST', timestamp...
+Function t_timestampltz_list is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_LIST('TIMESTAMPLTZ', 'LIST', timestamp...
 
 ===================================================
 Error:-894
@@ -175,7 +175,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_LIST('TIMESTAMPTZ', 'LIST', timestamp...'
-Function t_TIMESTAMPTZ_LIST is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_LIST('TIMESTAMPTZ', 'LIST', timestamptz...
+Function t_timestamptz_list is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_LIST('TIMESTAMPTZ', 'LIST', timestamptz...
 
 ===================================================
 Error:-894
@@ -196,7 +196,7 @@ Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLE
 Error:-494
 Semantic: before ' ,
 typeof( t_DOUBLE_LIST('DOUBLE', 'LIST', cast( 1234.56789 as...'
-Function t_DOUBLE_LIST is undefined or given wrong number of parameter. select t_DOUBLE_LIST('DOUBLE', 'LIST',  cast(1234.56789 as d...
+Function t_double_list is undefined or given wrong number of parameter. select t_DOUBLE_LIST('DOUBLE', 'LIST',  cast(1234.56789 as d...
 
 ===================================================
 Error:-894
@@ -217,7 +217,7 @@ Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLE
 Error:-494
 Semantic: before ' ,
 typeof( t_FLOAT_LIST('FLOAT', 'LIST', cast( 16777.217 as fl...'
-Function t_FLOAT_LIST is undefined or given wrong number of parameter. select t_FLOAT_LIST('FLOAT', 'LIST',  cast(16777.217 as floa...
+Function t_float_list is undefined or given wrong number of parameter. select t_FLOAT_LIST('FLOAT', 'LIST',  cast(16777.217 as floa...
 
 ===================================================
 Error:-894
@@ -238,7 +238,7 @@ Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLE
 Error:-494
 Semantic: before ' ,
 typeof( t_NUMERIC_LIST('NUMERIC(8,4)', 'LIST', cast( 0.1234...'
-Function t_NUMERIC_LIST is undefined or given wrong number of parameter. select t_NUMERIC_LIST('NUMERIC(8,4)', 'LIST',  cast(0.123456...
+Function t_numeric_list is undefined or given wrong number of parameter. select t_NUMERIC_LIST('NUMERIC(8,4)', 'LIST',  cast(0.123456...
 
 ===================================================
 Error:-894
@@ -259,7 +259,7 @@ Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLE
 Error:-494
 Semantic: before ' ,
 typeof( t_BIGINT_LIST('BIGINT', 'LIST', cast( 34589012 as b...'
-Function t_BIGINT_LIST is undefined or given wrong number of parameter. select t_BIGINT_LIST('BIGINT', 'LIST',  cast(34589012 as big...
+Function t_bigint_list is undefined or given wrong number of parameter. select t_BIGINT_LIST('BIGINT', 'LIST',  cast(34589012 as big...
 
 ===================================================
 Error:-894
@@ -280,7 +280,7 @@ Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLE
 Error:-494
 Semantic: before ' ,
 typeof( t_INT_LIST('INT', 'LIST', cast( 782346 as int ) ) ) ; '
-Function t_INT_LIST is undefined or given wrong number of parameter. select t_INT_LIST('INT', 'LIST',  cast(782346 as integer)), ...
+Function t_int_list is undefined or given wrong number of parameter. select t_INT_LIST('INT', 'LIST',  cast(782346 as integer)), ...
 
 ===================================================
 Error:-894
@@ -301,7 +301,7 @@ Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLE
 Error:-494
 Semantic: before ' ,
 typeof( t_SHORT_LIST('SHORT', 'LIST', cast( 8934 as short )...'
-Function t_SHORT_LIST is undefined or given wrong number of parameter. select t_SHORT_LIST('SHORT', 'LIST',  cast(8934 as smallint)...
+Function t_short_list is undefined or given wrong number of parameter. select t_SHORT_LIST('SHORT', 'LIST',  cast(8934 as smallint)...
 
 ===================================================
 Error:-894
@@ -326,7 +326,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_LIST('BIT(8)', 'LIST', 0xaa ) ) ; '
-Function t_BIT_LIST is undefined or given wrong number of parameter. select t_BIT_LIST('BIT(8)', 'LIST', X'aa'),  typeof(t_BIT_LI...
+Function t_bit_list is undefined or given wrong number of parameter. select t_BIT_LIST('BIT(8)', 'LIST', X'aa'),  typeof(t_BIT_LI...
 
 ===================================================
 Error:-894
@@ -350,7 +350,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_LIST
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_LIST('BIT VARYING', 'LIST', 0xaa ) ) ; '
-Function t_BITVARYING_LIST is undefined or given wrong number of parameter. select t_BITVARYING_LIST('BIT VARYING', 'LIST', X'aa'),  typ...
+Function t_bitvarying_list is undefined or given wrong number of parameter. select t_BITVARYING_LIST('BIT VARYING', 'LIST', X'aa'),  typ...
 
 ===================================================
 Error:-894
@@ -371,7 +371,7 @@ Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLE
 Error:-494
 Semantic: before ' ,
 typeof( t_CHAR_LIST('CHAR', 'LIST', {'c','c','c','b','b','a...'
-Function t_CHAR_LIST is undefined or given wrong number of parameter. select t_CHAR_LIST('CHAR', 'LIST'),  typeof(t_CHAR_LIST('CHA...
+Function t_char_list is undefined or given wrong number of parameter. select t_CHAR_LIST('CHAR', 'LIST'),  typeof(t_CHAR_LIST('CHA...
 
 ===================================================
 Error:-894
@@ -392,7 +392,7 @@ Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLE
 Error:-494
 Semantic: before ' ,
 typeof( t_VARCHAR_LIST('VARCHAR', 'LIST', {'c','c','c','b',...'
-Function t_VARCHAR_LIST is undefined or given wrong number of parameter. select t_VARCHAR_LIST('VARCHAR', 'LIST'),  typeof(t_VARCHAR_...
+Function t_varchar_list is undefined or given wrong number of parameter. select t_VARCHAR_LIST('VARCHAR', 'LIST'),  typeof(t_VARCHAR_...
 
 ===================================================
 Error:-894
@@ -413,7 +413,7 @@ Stored procedure compile error: no viable alternative at input 'VAR SET'
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_LIST('SET', 'LIST', {'c','c','c','b','b','a'}...'
-Function t_SET_LIST is undefined or given wrong number of parameter. select t_SET_LIST('SET', 'LIST'),  typeof(t_SET_LIST('SET', ...
+Function t_set_list is undefined or given wrong number of parameter. select t_SET_LIST('SET', 'LIST'),  typeof(t_SET_LIST('SET', ...
 
 ===================================================
 Error:-894
@@ -434,7 +434,7 @@ Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_LIST('MULTISET', 'LIST', {'c','c','c','b...'
-Function t_MULTISET_LIST is undefined or given wrong number of parameter. select t_MULTISET_LIST('MULTISET', 'LIST'),  typeof(t_MULTIS...
+Function t_multiset_list is undefined or given wrong number of parameter. select t_MULTISET_LIST('MULTISET', 'LIST'),  typeof(t_MULTIS...
 
 ===================================================
 Error:-894
@@ -455,7 +455,7 @@ Stored procedure compile error: no viable alternative at input 'VAR LIST'
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_LIST('LIST', 'LIST', {'c','c','c','b','b', '...'
-Function t_LIST_LIST is undefined or given wrong number of parameter. select t_LIST_LIST('LIST', 'LIST'),  typeof(t_LIST_LIST('LIS...
+Function t_list_list is undefined or given wrong number of parameter. select t_LIST_LIST('LIST', 'LIST'),  typeof(t_LIST_LIST('LIS...
 
 ===================================================
 Error:-894
@@ -476,7 +476,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_LIST('ENUM', 'LIST', 'yellow' ) ) ; '
-Function t_ENUM_LIST is undefined or given wrong number of parameter. select t_ENUM_LIST('ENUM', 'LIST', 'yellow'),  typeof(t_ENUM...
+Function t_enum_list is undefined or given wrong number of parameter. select t_ENUM_LIST('ENUM', 'LIST', 'yellow'),  typeof(t_ENUM...
 
 ===================================================
 Error:-894
@@ -501,7 +501,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_LIST('BLOB', 'LIST', BIT_TO_BLOB(X'000010') ...'
-Function t_BLOB_LIST is undefined or given wrong number of parameter. select t_BLOB_LIST('BLOB', 'LIST',  bit_to_blob(X'000010')),...
+Function t_blob_list is undefined or given wrong number of parameter. select t_BLOB_LIST('BLOB', 'LIST',  bit_to_blob(X'000010')),...
 
 ===================================================
 Error:-894
@@ -526,7 +526,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_LIST('CLOB', 'LIST', CHAR_TO_CLOB('This is a...'
-Function t_CLOB_LIST is undefined or given wrong number of parameter. select t_CLOB_LIST('CLOB', 'LIST',  char_to_clob('This is a ...
+Function t_clob_list is undefined or given wrong number of parameter. select t_CLOB_LIST('CLOB', 'LIST',  char_to_clob('This is a ...
 
 ===================================================
 Error:-894
@@ -551,7 +551,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_LIST('JSON', 'LIST', '{"a":1}' ) ) ; '
-Function t_JSON_LIST is undefined or given wrong number of parameter. select t_JSON_LIST('JSON', 'LIST', '{"a":1}'),  typeof(t_JSO...
+Function t_json_list is undefined or given wrong number of parameter. select t_JSON_LIST('JSON', 'LIST', '{"a":1}'),  typeof(t_JSO...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-22_variable_to_return_ENUM.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-22_variable_to_return_ENUM.answer
@@ -16,7 +16,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_ENUM('DATETIME', 'ENUM', DATETIME'2023-0...'
-Function t_DATETIME_ENUM is undefined or given wrong number of parameter. select t_DATETIME_ENUM('DATETIME', 'ENUM', datetime '2023-02...
+Function t_datetime_enum is undefined or given wrong number of parameter. select t_DATETIME_ENUM('DATETIME', 'ENUM', datetime '2023-02...
 
 ===================================================
 Error:-894
@@ -37,7 +37,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_ENUM('DATETIMELTZ', 'ENUM', datetimel...'
-Function t_DATETIMELTZ_ENUM is undefined or given wrong number of parameter. select t_DATETIMELTZ_ENUM('DATETIMELTZ', 'ENUM', datetimeltz...
+Function t_datetimeltz_enum is undefined or given wrong number of parameter. select t_DATETIMELTZ_ENUM('DATETIMELTZ', 'ENUM', datetimeltz...
 
 ===================================================
 Error:-894
@@ -58,7 +58,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_ENUM('DATETIMETZ', 'ENUM', datetimetz ...'
-Function t_DATETIMETZ_ENUM is undefined or given wrong number of parameter. select t_DATETIMETZ_ENUM('DATETIMETZ', 'ENUM', datetimetz '0...
+Function t_datetimetz_enum is undefined or given wrong number of parameter. select t_DATETIMETZ_ENUM('DATETIMETZ', 'ENUM', datetimetz '0...
 
 ===================================================
 Error:-894
@@ -79,7 +79,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_ENUM('DATE', 'ENUM', DATE'2008-10-31' ) ) ; '
-Function t_DATE_ENUM is undefined or given wrong number of parameter. select t_DATE_ENUM('DATE', 'ENUM', date '2008-10-31'),  type...
+Function t_date_enum is undefined or given wrong number of parameter. select t_DATE_ENUM('DATE', 'ENUM', date '2008-10-31'),  type...
 
 ===================================================
 Error:-894
@@ -100,7 +100,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_ENUM('TIME', 'ENUM', TIME'13:15:45' ) ) ; '
-Function t_TIME_ENUM is undefined or given wrong number of parameter. select t_TIME_ENUM('TIME', 'ENUM', time '13:15:45'),  typeof...
+Function t_time_enum is undefined or given wrong number of parameter. select t_TIME_ENUM('TIME', 'ENUM', time '13:15:45'),  typeof...
 
 ===================================================
 Error:-894
@@ -121,7 +121,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_ENUM('TIMESTAMP', 'ENUM', TIMESTAMP'202...'
-Function t_TIMESTAMP_ENUM is undefined or given wrong number of parameter. select t_TIMESTAMP_ENUM('TIMESTAMP', 'ENUM', timestamp '2023...
+Function t_timestamp_enum is undefined or given wrong number of parameter. select t_TIMESTAMP_ENUM('TIMESTAMP', 'ENUM', timestamp '2023...
 
 ===================================================
 Error:-894
@@ -142,7 +142,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_ENUM('TIMESTAMPLTZ', 'ENUM', timesta...'
-Function t_TIMESTAMPLTZ_ENUM is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_ENUM('TIMESTAMPLTZ', 'ENUM', timestamp...
+Function t_timestampltz_enum is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_ENUM('TIMESTAMPLTZ', 'ENUM', timestamp...
 
 ===================================================
 Error:-894
@@ -163,7 +163,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_ENUM('TIMESTAMPTZ', 'ENUM', timestamp...'
-Function t_TIMESTAMPTZ_ENUM is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_ENUM('TIMESTAMPTZ', 'ENUM', timestamptz...
+Function t_timestamptz_enum is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_ENUM('TIMESTAMPTZ', 'ENUM', timestamptz...
 
 ===================================================
 Error:-894
@@ -184,7 +184,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_DOUBLE_ENUM('DOUBLE', 'ENUM', cast( 1234.56789 as...'
-Function t_DOUBLE_ENUM is undefined or given wrong number of parameter. select t_DOUBLE_ENUM('DOUBLE', 'ENUM',  cast(1234.56789 as d...
+Function t_double_enum is undefined or given wrong number of parameter. select t_DOUBLE_ENUM('DOUBLE', 'ENUM',  cast(1234.56789 as d...
 
 ===================================================
 Error:-894
@@ -205,7 +205,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_FLOAT_ENUM('FLOAT', 'ENUM', cast( 16777.217 as fl...'
-Function t_FLOAT_ENUM is undefined or given wrong number of parameter. select t_FLOAT_ENUM('FLOAT', 'ENUM',  cast(16777.217 as floa...
+Function t_float_enum is undefined or given wrong number of parameter. select t_FLOAT_ENUM('FLOAT', 'ENUM',  cast(16777.217 as floa...
 
 ===================================================
 Error:-894
@@ -226,7 +226,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_NUMERIC_ENUM('NUMERIC(8,4)', 'ENUM', cast( 0.1234...'
-Function t_NUMERIC_ENUM is undefined or given wrong number of parameter. select t_NUMERIC_ENUM('NUMERIC(8,4)', 'ENUM',  cast(0.123456...
+Function t_numeric_enum is undefined or given wrong number of parameter. select t_NUMERIC_ENUM('NUMERIC(8,4)', 'ENUM',  cast(0.123456...
 
 ===================================================
 Error:-894
@@ -247,7 +247,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_BIGINT_ENUM('BIGINT', 'ENUM', cast( 34589012 as b...'
-Function t_BIGINT_ENUM is undefined or given wrong number of parameter. select t_BIGINT_ENUM('BIGINT', 'ENUM',  cast(34589012 as big...
+Function t_bigint_enum is undefined or given wrong number of parameter. select t_BIGINT_ENUM('BIGINT', 'ENUM',  cast(34589012 as big...
 
 ===================================================
 Error:-894
@@ -268,7 +268,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_INT_ENUM('INT', 'ENUM', cast( 782346 as int ) ) ) ; '
-Function t_INT_ENUM is undefined or given wrong number of parameter. select t_INT_ENUM('INT', 'ENUM',  cast(782346 as integer)), ...
+Function t_int_enum is undefined or given wrong number of parameter. select t_INT_ENUM('INT', 'ENUM',  cast(782346 as integer)), ...
 
 ===================================================
 Error:-894
@@ -289,7 +289,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_SHORT_ENUM('SHORT', 'ENUM', cast( 8934 as short )...'
-Function t_SHORT_ENUM is undefined or given wrong number of parameter. select t_SHORT_ENUM('SHORT', 'ENUM',  cast(8934 as smallint)...
+Function t_short_enum is undefined or given wrong number of parameter. select t_SHORT_ENUM('SHORT', 'ENUM',  cast(8934 as smallint)...
 
 ===================================================
 Error:-894
@@ -310,7 +310,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_ENUM('BIT(8)', 'ENUM', 0xaa ) ) ; '
-Function t_BIT_ENUM is undefined or given wrong number of parameter. select t_BIT_ENUM('BIT(8)', 'ENUM', X'aa'),  typeof(t_BIT_EN...
+Function t_bit_enum is undefined or given wrong number of parameter. select t_BIT_ENUM('BIT(8)', 'ENUM', X'aa'),  typeof(t_BIT_EN...
 
 ===================================================
 Error:-894
@@ -331,7 +331,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_ENUM('BIT VARYING', 'ENUM', 0xaa ) ) ; '
-Function t_BITVARYING_ENUM is undefined or given wrong number of parameter. select t_BITVARYING_ENUM('BIT VARYING', 'ENUM', X'aa'),  typ...
+Function t_bitvarying_enum is undefined or given wrong number of parameter. select t_BITVARYING_ENUM('BIT VARYING', 'ENUM', X'aa'),  typ...
 
 ===================================================
 Error:-894
@@ -352,7 +352,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_CHAR_ENUM('CHAR', 'ENUM', 'yellow' ) ) ; '
-Function t_CHAR_ENUM is undefined or given wrong number of parameter. select t_CHAR_ENUM('CHAR', 'ENUM', 'yellow'),  typeof(t_CHAR...
+Function t_char_enum is undefined or given wrong number of parameter. select t_CHAR_ENUM('CHAR', 'ENUM', 'yellow'),  typeof(t_CHAR...
 
 ===================================================
 Error:-894
@@ -373,7 +373,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_VARCHAR_ENUM('VARCHAR', 'ENUM', 'yellow' ) ) ; '
-Function t_VARCHAR_ENUM is undefined or given wrong number of parameter. select t_VARCHAR_ENUM('VARCHAR', 'ENUM', 'yellow'),  typeof(...
+Function t_varchar_enum is undefined or given wrong number of parameter. select t_VARCHAR_ENUM('VARCHAR', 'ENUM', 'yellow'),  typeof(...
 
 ===================================================
 Error:-894
@@ -394,7 +394,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_ENUM('SET', 'ENUM', {'c','c','c','b','b','a'}...'
-Function t_SET_ENUM is undefined or given wrong number of parameter. select t_SET_ENUM('SET', 'ENUM'),  typeof(t_SET_ENUM('SET', ...
+Function t_set_enum is undefined or given wrong number of parameter. select t_SET_ENUM('SET', 'ENUM'),  typeof(t_SET_ENUM('SET', ...
 
 ===================================================
 Error:-894
@@ -415,7 +415,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_ENUM('MULTISET', 'ENUM', {'c','c','c','b...'
-Function t_MULTISET_ENUM is undefined or given wrong number of parameter. select t_MULTISET_ENUM('MULTISET', 'ENUM'),  typeof(t_MULTIS...
+Function t_multiset_enum is undefined or given wrong number of parameter. select t_MULTISET_ENUM('MULTISET', 'ENUM'),  typeof(t_MULTIS...
 
 ===================================================
 Error:-894
@@ -436,7 +436,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_ENUM('LIST', 'ENUM', {'c','c','c','b','b', '...'
-Function t_LIST_ENUM is undefined or given wrong number of parameter. select t_LIST_ENUM('LIST', 'ENUM'),  typeof(t_LIST_ENUM('LIS...
+Function t_list_enum is undefined or given wrong number of parameter. select t_LIST_ENUM('LIST', 'ENUM'),  typeof(t_LIST_ENUM('LIS...
 
 ===================================================
 Error:-894
@@ -457,7 +457,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_ENUM('ENUM', 'ENUM', 'yellow' ) ) ; '
-Function t_ENUM_ENUM is undefined or given wrong number of parameter. select t_ENUM_ENUM('ENUM', 'ENUM', 'yellow'),  typeof(t_ENUM...
+Function t_enum_enum is undefined or given wrong number of parameter. select t_ENUM_ENUM('ENUM', 'ENUM', 'yellow'),  typeof(t_ENUM...
 
 ===================================================
 Error:-894
@@ -478,7 +478,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_ENUM('BLOB', 'ENUM', BIT_TO_BLOB(X'000010') ...'
-Function t_BLOB_ENUM is undefined or given wrong number of parameter. select t_BLOB_ENUM('BLOB', 'ENUM',  bit_to_blob(X'000010')),...
+Function t_blob_enum is undefined or given wrong number of parameter. select t_BLOB_ENUM('BLOB', 'ENUM',  bit_to_blob(X'000010')),...
 
 ===================================================
 Error:-894
@@ -499,7 +499,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_ENUM('CLOB', 'ENUM', CHAR_TO_CLOB('This is a...'
-Function t_CLOB_ENUM is undefined or given wrong number of parameter. select t_CLOB_ENUM('CLOB', 'ENUM',  char_to_clob('This is a ...
+Function t_clob_enum is undefined or given wrong number of parameter. select t_CLOB_ENUM('CLOB', 'ENUM',  char_to_clob('This is a ...
 
 ===================================================
 Error:-894
@@ -520,7 +520,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_ENUM('JSON', 'ENUM', '{"a":1}' ) ) ; '
-Function t_JSON_ENUM is undefined or given wrong number of parameter. select t_JSON_ENUM('JSON', 'ENUM', '{"a":1}'),  typeof(t_JSO...
+Function t_json_enum is undefined or given wrong number of parameter. select t_JSON_ENUM('JSON', 'ENUM', '{"a":1}'),  typeof(t_JSO...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-23_variable_to_return_BLOB.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-23_variable_to_return_BLOB.answer
@@ -15,7 +15,7 @@ Semantic: Unsupported return type 'blob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_BLOB('DATETIME', 'BLOB', DATETIME'2023-0...'
-Function t_DATETIME_BLOB is undefined or given wrong number of parameter. select t_DATETIME_BLOB('DATETIME', 'BLOB', datetime '2023-02...
+Function t_datetime_blob is undefined or given wrong number of parameter. select t_DATETIME_BLOB('DATETIME', 'BLOB', datetime '2023-02...
 
 ===================================================
 Error:-894
@@ -39,7 +39,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_BLOB('DATETIMELTZ', 'BLOB', datetimel...'
-Function t_DATETIMELTZ_BLOB is undefined or given wrong number of parameter. select t_DATETIMELTZ_BLOB('DATETIMELTZ', 'BLOB', datetimeltz...
+Function t_datetimeltz_blob is undefined or given wrong number of parameter. select t_DATETIMELTZ_BLOB('DATETIMELTZ', 'BLOB', datetimeltz...
 
 ===================================================
 Error:-894
@@ -63,7 +63,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_BLOB('DATETIMETZ', 'BLOB', datetimetz ...'
-Function t_DATETIMETZ_BLOB is undefined or given wrong number of parameter. select t_DATETIMETZ_BLOB('DATETIMETZ', 'BLOB', datetimetz '0...
+Function t_datetimetz_blob is undefined or given wrong number of parameter. select t_DATETIMETZ_BLOB('DATETIMETZ', 'BLOB', datetimetz '0...
 
 ===================================================
 Error:-894
@@ -83,7 +83,7 @@ Semantic: Unsupported return type 'blob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_BLOB('DATE', 'BLOB', DATE'2008-10-31' ) ) ; '
-Function t_DATE_BLOB is undefined or given wrong number of parameter. select t_DATE_BLOB('DATE', 'BLOB', date '2008-10-31'),  type...
+Function t_date_blob is undefined or given wrong number of parameter. select t_DATE_BLOB('DATE', 'BLOB', date '2008-10-31'),  type...
 
 ===================================================
 Error:-894
@@ -103,7 +103,7 @@ Semantic: Unsupported return type 'blob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_BLOB('TIME', 'BLOB', TIME'13:15:45' ) ) ; '
-Function t_TIME_BLOB is undefined or given wrong number of parameter. select t_TIME_BLOB('TIME', 'BLOB', time '13:15:45'),  typeof...
+Function t_time_blob is undefined or given wrong number of parameter. select t_TIME_BLOB('TIME', 'BLOB', time '13:15:45'),  typeof...
 
 ===================================================
 Error:-894
@@ -123,7 +123,7 @@ Semantic: Unsupported return type 'blob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_BLOB('TIMESTAMP', 'BLOB', TIMESTAMP'202...'
-Function t_TIMESTAMP_BLOB is undefined or given wrong number of parameter. select t_TIMESTAMP_BLOB('TIMESTAMP', 'BLOB', timestamp '2023...
+Function t_timestamp_blob is undefined or given wrong number of parameter. select t_TIMESTAMP_BLOB('TIMESTAMP', 'BLOB', timestamp '2023...
 
 ===================================================
 Error:-894
@@ -147,7 +147,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_BLOB('TIMESTAMPLTZ', 'BLOB', timesta...'
-Function t_TIMESTAMPLTZ_BLOB is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_BLOB('TIMESTAMPLTZ', 'BLOB', timestamp...
+Function t_timestampltz_blob is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_BLOB('TIMESTAMPLTZ', 'BLOB', timestamp...
 
 ===================================================
 Error:-894
@@ -171,7 +171,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_BLOB('TIMESTAMPTZ', 'BLOB', timestamp...'
-Function t_TIMESTAMPTZ_BLOB is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_BLOB('TIMESTAMPTZ', 'BLOB', timestamptz...
+Function t_timestamptz_blob is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_BLOB('TIMESTAMPTZ', 'BLOB', timestamptz...
 
 ===================================================
 Error:-894
@@ -191,7 +191,7 @@ Semantic: Unsupported return type 'blob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_DOUBLE_BLOB('DOUBLE', 'BLOB', cast( 1234.56789 as...'
-Function t_DOUBLE_BLOB is undefined or given wrong number of parameter. select t_DOUBLE_BLOB('DOUBLE', 'BLOB',  cast(1234.56789 as d...
+Function t_double_blob is undefined or given wrong number of parameter. select t_DOUBLE_BLOB('DOUBLE', 'BLOB',  cast(1234.56789 as d...
 
 ===================================================
 Error:-894
@@ -211,7 +211,7 @@ Semantic: Unsupported return type 'blob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_FLOAT_BLOB('FLOAT', 'BLOB', cast( 16777.217 as fl...'
-Function t_FLOAT_BLOB is undefined or given wrong number of parameter. select t_FLOAT_BLOB('FLOAT', 'BLOB',  cast(16777.217 as floa...
+Function t_float_blob is undefined or given wrong number of parameter. select t_FLOAT_BLOB('FLOAT', 'BLOB',  cast(16777.217 as floa...
 
 ===================================================
 Error:-894
@@ -231,7 +231,7 @@ Semantic: Unsupported return type 'blob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_NUMERIC_BLOB('NUMERIC(8,4)', 'BLOB', cast( 0.1234...'
-Function t_NUMERIC_BLOB is undefined or given wrong number of parameter. select t_NUMERIC_BLOB('NUMERIC(8,4)', 'BLOB',  cast(0.123456...
+Function t_numeric_blob is undefined or given wrong number of parameter. select t_NUMERIC_BLOB('NUMERIC(8,4)', 'BLOB',  cast(0.123456...
 
 ===================================================
 Error:-894
@@ -251,7 +251,7 @@ Semantic: Unsupported return type 'blob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_BIGINT_BLOB('BIGINT', 'BLOB', cast( 34589012 as b...'
-Function t_BIGINT_BLOB is undefined or given wrong number of parameter. select t_BIGINT_BLOB('BIGINT', 'BLOB',  cast(34589012 as big...
+Function t_bigint_blob is undefined or given wrong number of parameter. select t_BIGINT_BLOB('BIGINT', 'BLOB',  cast(34589012 as big...
 
 ===================================================
 Error:-894
@@ -271,7 +271,7 @@ Semantic: Unsupported return type 'blob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_INT_BLOB('INT', 'BLOB', cast( 782346 as int ) ) ) ; '
-Function t_INT_BLOB is undefined or given wrong number of parameter. select t_INT_BLOB('INT', 'BLOB',  cast(782346 as integer)), ...
+Function t_int_blob is undefined or given wrong number of parameter. select t_INT_BLOB('INT', 'BLOB',  cast(782346 as integer)), ...
 
 ===================================================
 Error:-894
@@ -291,7 +291,7 @@ Semantic: Unsupported return type 'blob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_SHORT_BLOB('SHORT', 'BLOB', cast( 8934 as short )...'
-Function t_SHORT_BLOB is undefined or given wrong number of parameter. select t_SHORT_BLOB('SHORT', 'BLOB',  cast(8934 as smallint)...
+Function t_short_blob is undefined or given wrong number of parameter. select t_SHORT_BLOB('SHORT', 'BLOB',  cast(8934 as smallint)...
 
 ===================================================
 Error:-894
@@ -316,7 +316,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_BLOB('BIT(8)', 'BLOB', 0xaa ) ) ; '
-Function t_BIT_BLOB is undefined or given wrong number of parameter. select t_BIT_BLOB('BIT(8)', 'BLOB', X'aa'),  typeof(t_BIT_BL...
+Function t_bit_blob is undefined or given wrong number of parameter. select t_BIT_BLOB('BIT(8)', 'BLOB', X'aa'),  typeof(t_BIT_BL...
 
 ===================================================
 Error:-894
@@ -340,7 +340,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_BLOB
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_BLOB('BIT VARYING', 'BLOB', 0xaa ) ) ; '
-Function t_BITVARYING_BLOB is undefined or given wrong number of parameter. select t_BITVARYING_BLOB('BIT VARYING', 'BLOB', X'aa'),  typ...
+Function t_bitvarying_blob is undefined or given wrong number of parameter. select t_BITVARYING_BLOB('BIT VARYING', 'BLOB', X'aa'),  typ...
 
 ===================================================
 Error:-894
@@ -360,7 +360,7 @@ Semantic: Unsupported return type 'blob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_CHAR_BLOB('CHAR', 'BLOB', 0xaa ) ) ; '
-Function t_CHAR_BLOB is undefined or given wrong number of parameter. select t_CHAR_BLOB('CHAR', 'BLOB', X'aa'),  typeof(t_CHAR_BL...
+Function t_char_blob is undefined or given wrong number of parameter. select t_CHAR_BLOB('CHAR', 'BLOB', X'aa'),  typeof(t_CHAR_BL...
 
 ===================================================
 Error:-894
@@ -380,7 +380,7 @@ Semantic: Unsupported return type 'blob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_VARCHAR_BLOB('VARCHAR', 'BLOB', 0xaa ) ) ; '
-Function t_VARCHAR_BLOB is undefined or given wrong number of parameter. select t_VARCHAR_BLOB('VARCHAR', 'BLOB', X'aa'),  typeof(t_V...
+Function t_varchar_blob is undefined or given wrong number of parameter. select t_VARCHAR_BLOB('VARCHAR', 'BLOB', X'aa'),  typeof(t_V...
 
 ===================================================
 Error:-894
@@ -400,7 +400,7 @@ Semantic: Unsupported return type 'blob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_BLOB('SET', 'BLOB', {'c','c','c','b','b','a'}...'
-Function t_SET_BLOB is undefined or given wrong number of parameter. select t_SET_BLOB('SET', 'BLOB'),  typeof(t_SET_BLOB('SET', ...
+Function t_set_blob is undefined or given wrong number of parameter. select t_SET_BLOB('SET', 'BLOB'),  typeof(t_SET_BLOB('SET', ...
 
 ===================================================
 Error:-894
@@ -420,7 +420,7 @@ Semantic: Unsupported return type 'blob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_BLOB('MULTISET', 'BLOB', {'c','c','c','b...'
-Function t_MULTISET_BLOB is undefined or given wrong number of parameter. select t_MULTISET_BLOB('MULTISET', 'BLOB'),  typeof(t_MULTIS...
+Function t_multiset_blob is undefined or given wrong number of parameter. select t_MULTISET_BLOB('MULTISET', 'BLOB'),  typeof(t_MULTIS...
 
 ===================================================
 Error:-894
@@ -440,7 +440,7 @@ Semantic: Unsupported return type 'blob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_BLOB('LIST', 'BLOB', {'c','c','c','b','b', '...'
-Function t_LIST_BLOB is undefined or given wrong number of parameter. select t_LIST_BLOB('LIST', 'BLOB'),  typeof(t_LIST_BLOB('LIS...
+Function t_list_blob is undefined or given wrong number of parameter. select t_LIST_BLOB('LIST', 'BLOB'),  typeof(t_LIST_BLOB('LIS...
 
 ===================================================
 Error:-894
@@ -461,7 +461,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_BLOB('ENUM', 'BLOB', 'yellow' ) ) ; '
-Function t_ENUM_BLOB is undefined or given wrong number of parameter. select t_ENUM_BLOB('ENUM', 'BLOB', 'yellow'),  typeof(t_ENUM...
+Function t_enum_blob is undefined or given wrong number of parameter. select t_ENUM_BLOB('ENUM', 'BLOB', 'yellow'),  typeof(t_ENUM...
 
 ===================================================
 Error:-894
@@ -486,7 +486,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_BLOB('BLOB', 'BLOB', BIT_TO_BLOB(X'000010') ...'
-Function t_BLOB_BLOB is undefined or given wrong number of parameter. select t_BLOB_BLOB('BLOB', 'BLOB',  bit_to_blob(X'000010')),...
+Function t_blob_blob is undefined or given wrong number of parameter. select t_BLOB_BLOB('BLOB', 'BLOB',  bit_to_blob(X'000010')),...
 
 ===================================================
 Error:-894
@@ -511,7 +511,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_BLOB('CLOB', 'BLOB', CHAR_TO_CLOB('This is a...'
-Function t_CLOB_BLOB is undefined or given wrong number of parameter. select t_CLOB_BLOB('CLOB', 'BLOB',  char_to_clob('This is a ...
+Function t_clob_blob is undefined or given wrong number of parameter. select t_CLOB_BLOB('CLOB', 'BLOB',  char_to_clob('This is a ...
 
 ===================================================
 Error:-894
@@ -536,7 +536,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_BLOB('JSON', 'BLOB', '{"a":1}' ) ) ; '
-Function t_JSON_BLOB is undefined or given wrong number of parameter. select t_JSON_BLOB('JSON', 'BLOB', '{"a":1}'),  typeof(t_JSO...
+Function t_json_blob is undefined or given wrong number of parameter. select t_JSON_BLOB('JSON', 'BLOB', '{"a":1}'),  typeof(t_JSO...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-24_variable_to_return_CLOB.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-24_variable_to_return_CLOB.answer
@@ -15,7 +15,7 @@ Semantic: Unsupported return type 'clob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_CLOB('DATETIME', 'CLOB', DATETIME'2023-0...'
-Function t_DATETIME_CLOB is undefined or given wrong number of parameter. select t_DATETIME_CLOB('DATETIME', 'CLOB', datetime '2023-02...
+Function t_datetime_clob is undefined or given wrong number of parameter. select t_DATETIME_CLOB('DATETIME', 'CLOB', datetime '2023-02...
 
 ===================================================
 Error:-894
@@ -39,7 +39,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_CLOB('DATETIMELTZ', 'CLOB', datetimel...'
-Function t_DATETIMELTZ_CLOB is undefined or given wrong number of parameter. select t_DATETIMELTZ_CLOB('DATETIMELTZ', 'CLOB', datetimeltz...
+Function t_datetimeltz_clob is undefined or given wrong number of parameter. select t_DATETIMELTZ_CLOB('DATETIMELTZ', 'CLOB', datetimeltz...
 
 ===================================================
 Error:-894
@@ -63,7 +63,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_CLOB('DATETIMETZ', 'CLOB', datetimetz ...'
-Function t_DATETIMETZ_CLOB is undefined or given wrong number of parameter. select t_DATETIMETZ_CLOB('DATETIMETZ', 'CLOB', datetimetz '0...
+Function t_datetimetz_clob is undefined or given wrong number of parameter. select t_DATETIMETZ_CLOB('DATETIMETZ', 'CLOB', datetimetz '0...
 
 ===================================================
 Error:-894
@@ -83,7 +83,7 @@ Semantic: Unsupported return type 'clob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_CLOB('DATE', 'CLOB', DATE'2008-10-31' ) ) ; '
-Function t_DATE_CLOB is undefined or given wrong number of parameter. select t_DATE_CLOB('DATE', 'CLOB', date '2008-10-31'),  type...
+Function t_date_clob is undefined or given wrong number of parameter. select t_DATE_CLOB('DATE', 'CLOB', date '2008-10-31'),  type...
 
 ===================================================
 Error:-894
@@ -103,7 +103,7 @@ Semantic: Unsupported return type 'clob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_CLOB('TIME', 'CLOB', TIME'13:15:45' ) ) ; '
-Function t_TIME_CLOB is undefined or given wrong number of parameter. select t_TIME_CLOB('TIME', 'CLOB', time '13:15:45'),  typeof...
+Function t_time_clob is undefined or given wrong number of parameter. select t_TIME_CLOB('TIME', 'CLOB', time '13:15:45'),  typeof...
 
 ===================================================
 Error:-894
@@ -123,7 +123,7 @@ Semantic: Unsupported return type 'clob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_CLOB('TIMESTAMP', 'CLOB', TIMESTAMP'202...'
-Function t_TIMESTAMP_CLOB is undefined or given wrong number of parameter. select t_TIMESTAMP_CLOB('TIMESTAMP', 'CLOB', timestamp '2023...
+Function t_timestamp_clob is undefined or given wrong number of parameter. select t_TIMESTAMP_CLOB('TIMESTAMP', 'CLOB', timestamp '2023...
 
 ===================================================
 Error:-894
@@ -147,7 +147,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_CLOB('TIMESTAMPLTZ', 'CLOB', timesta...'
-Function t_TIMESTAMPLTZ_CLOB is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_CLOB('TIMESTAMPLTZ', 'CLOB', timestamp...
+Function t_timestampltz_clob is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_CLOB('TIMESTAMPLTZ', 'CLOB', timestamp...
 
 ===================================================
 Error:-894
@@ -171,7 +171,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_CLOB('TIMESTAMPTZ', 'CLOB', timestamp...'
-Function t_TIMESTAMPTZ_CLOB is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_CLOB('TIMESTAMPTZ', 'CLOB', timestamptz...
+Function t_timestamptz_clob is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_CLOB('TIMESTAMPTZ', 'CLOB', timestamptz...
 
 ===================================================
 Error:-894
@@ -191,7 +191,7 @@ Semantic: Unsupported return type 'clob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_DOUBLE_CLOB('DOUBLE', 'CLOB', cast( 1234.56789 as...'
-Function t_DOUBLE_CLOB is undefined or given wrong number of parameter. select t_DOUBLE_CLOB('DOUBLE', 'CLOB',  cast(1234.56789 as d...
+Function t_double_clob is undefined or given wrong number of parameter. select t_DOUBLE_CLOB('DOUBLE', 'CLOB',  cast(1234.56789 as d...
 
 ===================================================
 Error:-894
@@ -211,7 +211,7 @@ Semantic: Unsupported return type 'clob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_FLOAT_CLOB('FLOAT', 'CLOB', cast( 16777.217 as fl...'
-Function t_FLOAT_CLOB is undefined or given wrong number of parameter. select t_FLOAT_CLOB('FLOAT', 'CLOB',  cast(16777.217 as floa...
+Function t_float_clob is undefined or given wrong number of parameter. select t_FLOAT_CLOB('FLOAT', 'CLOB',  cast(16777.217 as floa...
 
 ===================================================
 Error:-894
@@ -231,7 +231,7 @@ Semantic: Unsupported return type 'clob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_NUMERIC_CLOB('NUMERIC(8,4)', 'CLOB', cast( 0.1234...'
-Function t_NUMERIC_CLOB is undefined or given wrong number of parameter. select t_NUMERIC_CLOB('NUMERIC(8,4)', 'CLOB',  cast(0.123456...
+Function t_numeric_clob is undefined or given wrong number of parameter. select t_NUMERIC_CLOB('NUMERIC(8,4)', 'CLOB',  cast(0.123456...
 
 ===================================================
 Error:-894
@@ -251,7 +251,7 @@ Semantic: Unsupported return type 'clob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_BIGINT_CLOB('BIGINT', 'CLOB', cast( 34589012 as b...'
-Function t_BIGINT_CLOB is undefined or given wrong number of parameter. select t_BIGINT_CLOB('BIGINT', 'CLOB',  cast(34589012 as big...
+Function t_bigint_clob is undefined or given wrong number of parameter. select t_BIGINT_CLOB('BIGINT', 'CLOB',  cast(34589012 as big...
 
 ===================================================
 Error:-894
@@ -271,7 +271,7 @@ Semantic: Unsupported return type 'clob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_INT_CLOB('INT', 'CLOB', cast( 782346 as int ) ) ) ; '
-Function t_INT_CLOB is undefined or given wrong number of parameter. select t_INT_CLOB('INT', 'CLOB',  cast(782346 as integer)), ...
+Function t_int_clob is undefined or given wrong number of parameter. select t_INT_CLOB('INT', 'CLOB',  cast(782346 as integer)), ...
 
 ===================================================
 Error:-894
@@ -291,7 +291,7 @@ Semantic: Unsupported return type 'clob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_SHORT_CLOB('SHORT', 'CLOB', cast( 8934 as short )...'
-Function t_SHORT_CLOB is undefined or given wrong number of parameter. select t_SHORT_CLOB('SHORT', 'CLOB',  cast(8934 as smallint)...
+Function t_short_clob is undefined or given wrong number of parameter. select t_SHORT_CLOB('SHORT', 'CLOB',  cast(8934 as smallint)...
 
 ===================================================
 Error:-894
@@ -316,7 +316,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_CLOB('BIT(8)', 'CLOB', 0xaa ) ) ; '
-Function t_BIT_CLOB is undefined or given wrong number of parameter. select t_BIT_CLOB('BIT(8)', 'CLOB', X'aa'),  typeof(t_BIT_CL...
+Function t_bit_clob is undefined or given wrong number of parameter. select t_BIT_CLOB('BIT(8)', 'CLOB', X'aa'),  typeof(t_BIT_CL...
 
 ===================================================
 Error:-894
@@ -340,7 +340,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_CLOB
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_CLOB('BIT VARYING', 'CLOB', 0xaa ) ) ; '
-Function t_BITVARYING_CLOB is undefined or given wrong number of parameter. select t_BITVARYING_CLOB('BIT VARYING', 'CLOB', X'aa'),  typ...
+Function t_bitvarying_clob is undefined or given wrong number of parameter. select t_BITVARYING_CLOB('BIT VARYING', 'CLOB', X'aa'),  typ...
 
 ===================================================
 Error:-894
@@ -360,7 +360,7 @@ Semantic: Unsupported return type 'clob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_CHAR_CLOB('CHAR', 'CLOB', 'CHAR CUBRID' ) ) ; '
-Function t_CHAR_CLOB is undefined or given wrong number of parameter. select t_CHAR_CLOB('CHAR', 'CLOB', 'CHAR CUBRID'),  typeof(t...
+Function t_char_clob is undefined or given wrong number of parameter. select t_CHAR_CLOB('CHAR', 'CLOB', 'CHAR CUBRID'),  typeof(t...
 
 ===================================================
 Error:-894
@@ -380,7 +380,7 @@ Semantic: Unsupported return type 'clob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_VARCHAR_CLOB('VARCHAR', 'CLOB', 'VARCHAR CUBRID' ...'
-Function t_VARCHAR_CLOB is undefined or given wrong number of parameter. select t_VARCHAR_CLOB('VARCHAR', 'CLOB', 'VARCHAR CUBRID'), ...
+Function t_varchar_clob is undefined or given wrong number of parameter. select t_VARCHAR_CLOB('VARCHAR', 'CLOB', 'VARCHAR CUBRID'), ...
 
 ===================================================
 Error:-894
@@ -400,7 +400,7 @@ Semantic: Unsupported return type 'clob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_CLOB('SET', 'CLOB', {'c','c','c','b','b','a'}...'
-Function t_SET_CLOB is undefined or given wrong number of parameter. select t_SET_CLOB('SET', 'CLOB'),  typeof(t_SET_CLOB('SET', ...
+Function t_set_clob is undefined or given wrong number of parameter. select t_SET_CLOB('SET', 'CLOB'),  typeof(t_SET_CLOB('SET', ...
 
 ===================================================
 Error:-894
@@ -420,7 +420,7 @@ Semantic: Unsupported return type 'clob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_CLOB('MULTISET', 'CLOB', {'c','c','c','b...'
-Function t_MULTISET_CLOB is undefined or given wrong number of parameter. select t_MULTISET_CLOB('MULTISET', 'CLOB'),  typeof(t_MULTIS...
+Function t_multiset_clob is undefined or given wrong number of parameter. select t_MULTISET_CLOB('MULTISET', 'CLOB'),  typeof(t_MULTIS...
 
 ===================================================
 Error:-894
@@ -440,7 +440,7 @@ Semantic: Unsupported return type 'clob' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_CLOB('LIST', 'CLOB', {'c','c','c','b','b', '...'
-Function t_LIST_CLOB is undefined or given wrong number of parameter. select t_LIST_CLOB('LIST', 'CLOB'),  typeof(t_LIST_CLOB('LIS...
+Function t_list_clob is undefined or given wrong number of parameter. select t_LIST_CLOB('LIST', 'CLOB'),  typeof(t_LIST_CLOB('LIS...
 
 ===================================================
 Error:-894
@@ -461,7 +461,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_CLOB('ENUM', 'CLOB', 'yellow' ) ) ; '
-Function t_ENUM_CLOB is undefined or given wrong number of parameter. select t_ENUM_CLOB('ENUM', 'CLOB', 'yellow'),  typeof(t_ENUM...
+Function t_enum_clob is undefined or given wrong number of parameter. select t_ENUM_CLOB('ENUM', 'CLOB', 'yellow'),  typeof(t_ENUM...
 
 ===================================================
 Error:-894
@@ -486,7 +486,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_CLOB('BLOB', 'CLOB', BIT_TO_BLOB(X'000010') ...'
-Function t_BLOB_CLOB is undefined or given wrong number of parameter. select t_BLOB_CLOB('BLOB', 'CLOB',  bit_to_blob(X'000010')),...
+Function t_blob_clob is undefined or given wrong number of parameter. select t_BLOB_CLOB('BLOB', 'CLOB',  bit_to_blob(X'000010')),...
 
 ===================================================
 Error:-894
@@ -511,7 +511,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_CLOB('CLOB', 'CLOB', CHAR_TO_CLOB('This is a...'
-Function t_CLOB_CLOB is undefined or given wrong number of parameter. select t_CLOB_CLOB('CLOB', 'CLOB',  char_to_clob('This is a ...
+Function t_clob_clob is undefined or given wrong number of parameter. select t_CLOB_CLOB('CLOB', 'CLOB',  char_to_clob('This is a ...
 
 ===================================================
 Error:-894
@@ -536,7 +536,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_CLOB('JSON', 'CLOB', '{"a":1}' ) ) ; '
-Function t_JSON_CLOB is undefined or given wrong number of parameter. select t_JSON_CLOB('JSON', 'CLOB', '{"a":1}'),  typeof(t_JSO...
+Function t_json_clob is undefined or given wrong number of parameter. select t_JSON_CLOB('JSON', 'CLOB', '{"a":1}'),  typeof(t_JSO...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-25_variable_to_return_JSON.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-25_variable_to_return_JSON.answer
@@ -15,7 +15,7 @@ Semantic: Unsupported return type 'json' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIME_JSON('DATETIME', 'JSON', DATETIME'2023-0...'
-Function t_DATETIME_JSON is undefined or given wrong number of parameter. select t_DATETIME_JSON('DATETIME', 'JSON', datetime '2023-02...
+Function t_datetime_json is undefined or given wrong number of parameter. select t_DATETIME_JSON('DATETIME', 'JSON', datetime '2023-02...
 
 ===================================================
 Error:-894
@@ -39,7 +39,7 @@ Unsupported argument type 'datetimeltz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMELTZ_JSON('DATETIMELTZ', 'JSON', datetimel...'
-Function t_DATETIMELTZ_JSON is undefined or given wrong number of parameter. select t_DATETIMELTZ_JSON('DATETIMELTZ', 'JSON', datetimeltz...
+Function t_datetimeltz_json is undefined or given wrong number of parameter. select t_DATETIMELTZ_JSON('DATETIMELTZ', 'JSON', datetimeltz...
 
 ===================================================
 Error:-894
@@ -63,7 +63,7 @@ Unsupported argument type 'datetimetz' of the stored procedure create or replace
 Error:-494
 Semantic: before ' ,
 typeof( t_DATETIMETZ_JSON('DATETIMETZ', 'JSON', datetimetz ...'
-Function t_DATETIMETZ_JSON is undefined or given wrong number of parameter. select t_DATETIMETZ_JSON('DATETIMETZ', 'JSON', datetimetz '0...
+Function t_datetimetz_json is undefined or given wrong number of parameter. select t_DATETIMETZ_JSON('DATETIMETZ', 'JSON', datetimetz '0...
 
 ===================================================
 Error:-894
@@ -83,7 +83,7 @@ Semantic: Unsupported return type 'json' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_DATE_JSON('DATE', 'JSON', DATE'2008-10-31' ) ) ; '
-Function t_DATE_JSON is undefined or given wrong number of parameter. select t_DATE_JSON('DATE', 'JSON', date '2008-10-31'),  type...
+Function t_date_json is undefined or given wrong number of parameter. select t_DATE_JSON('DATE', 'JSON', date '2008-10-31'),  type...
 
 ===================================================
 Error:-894
@@ -103,7 +103,7 @@ Semantic: Unsupported return type 'json' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIME_JSON('TIME', 'JSON', TIME'13:15:45' ) ) ; '
-Function t_TIME_JSON is undefined or given wrong number of parameter. select t_TIME_JSON('TIME', 'JSON', time '13:15:45'),  typeof...
+Function t_time_json is undefined or given wrong number of parameter. select t_TIME_JSON('TIME', 'JSON', time '13:15:45'),  typeof...
 
 ===================================================
 Error:-894
@@ -123,7 +123,7 @@ Semantic: Unsupported return type 'json' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMP_JSON('TIMESTAMP', 'JSON', TIMESTAMP'202...'
-Function t_TIMESTAMP_JSON is undefined or given wrong number of parameter. select t_TIMESTAMP_JSON('TIMESTAMP', 'JSON', timestamp '2023...
+Function t_timestamp_json is undefined or given wrong number of parameter. select t_TIMESTAMP_JSON('TIMESTAMP', 'JSON', timestamp '2023...
 
 ===================================================
 Error:-894
@@ -147,7 +147,7 @@ Unsupported argument type 'timestampltz' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPLTZ_JSON('TIMESTAMPLTZ', 'JSON', timesta...'
-Function t_TIMESTAMPLTZ_JSON is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_JSON('TIMESTAMPLTZ', 'JSON', timestamp...
+Function t_timestampltz_json is undefined or given wrong number of parameter. select t_TIMESTAMPLTZ_JSON('TIMESTAMPLTZ', 'JSON', timestamp...
 
 ===================================================
 Error:-894
@@ -171,7 +171,7 @@ Unsupported argument type 'timestamptz' of the stored procedure create or replac
 Error:-494
 Semantic: before ' ,
 typeof( t_TIMESTAMPTZ_JSON('TIMESTAMPTZ', 'JSON', timestamp...'
-Function t_TIMESTAMPTZ_JSON is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_JSON('TIMESTAMPTZ', 'JSON', timestamptz...
+Function t_timestamptz_json is undefined or given wrong number of parameter. select t_TIMESTAMPTZ_JSON('TIMESTAMPTZ', 'JSON', timestamptz...
 
 ===================================================
 Error:-894
@@ -191,7 +191,7 @@ Semantic: Unsupported return type 'json' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_DOUBLE_JSON('DOUBLE', 'JSON', cast( 1234.56789 as...'
-Function t_DOUBLE_JSON is undefined or given wrong number of parameter. select t_DOUBLE_JSON('DOUBLE', 'JSON',  cast(1234.56789 as d...
+Function t_double_json is undefined or given wrong number of parameter. select t_DOUBLE_JSON('DOUBLE', 'JSON',  cast(1234.56789 as d...
 
 ===================================================
 Error:-894
@@ -211,7 +211,7 @@ Semantic: Unsupported return type 'json' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_FLOAT_JSON('FLOAT', 'JSON', cast( 16777.217 as fl...'
-Function t_FLOAT_JSON is undefined or given wrong number of parameter. select t_FLOAT_JSON('FLOAT', 'JSON',  cast(16777.217 as floa...
+Function t_float_json is undefined or given wrong number of parameter. select t_FLOAT_JSON('FLOAT', 'JSON',  cast(16777.217 as floa...
 
 ===================================================
 Error:-894
@@ -231,7 +231,7 @@ Semantic: Unsupported return type 'json' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_NUMERIC_JSON('NUMERIC(8,4)', 'JSON', cast( 0.1234...'
-Function t_NUMERIC_JSON is undefined or given wrong number of parameter. select t_NUMERIC_JSON('NUMERIC(8,4)', 'JSON',  cast(0.123456...
+Function t_numeric_json is undefined or given wrong number of parameter. select t_NUMERIC_JSON('NUMERIC(8,4)', 'JSON',  cast(0.123456...
 
 ===================================================
 Error:-894
@@ -251,7 +251,7 @@ Semantic: Unsupported return type 'json' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_BIGINT_JSON('BIGINT', 'JSON', cast( 34589012 as b...'
-Function t_BIGINT_JSON is undefined or given wrong number of parameter. select t_BIGINT_JSON('BIGINT', 'JSON',  cast(34589012 as big...
+Function t_bigint_json is undefined or given wrong number of parameter. select t_BIGINT_JSON('BIGINT', 'JSON',  cast(34589012 as big...
 
 ===================================================
 Error:-894
@@ -271,7 +271,7 @@ Semantic: Unsupported return type 'json' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_INT_JSON('INT', 'JSON', cast( 782346 as int ) ) ) ; '
-Function t_INT_JSON is undefined or given wrong number of parameter. select t_INT_JSON('INT', 'JSON',  cast(782346 as integer)), ...
+Function t_int_json is undefined or given wrong number of parameter. select t_INT_JSON('INT', 'JSON',  cast(782346 as integer)), ...
 
 ===================================================
 Error:-894
@@ -291,7 +291,7 @@ Semantic: Unsupported return type 'json' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_SHORT_JSON('SHORT', 'JSON', cast( 8934 as short )...'
-Function t_SHORT_JSON is undefined or given wrong number of parameter. select t_SHORT_JSON('SHORT', 'JSON',  cast(8934 as smallint)...
+Function t_short_json is undefined or given wrong number of parameter. select t_SHORT_JSON('SHORT', 'JSON',  cast(8934 as smallint)...
 
 ===================================================
 Error:-894
@@ -316,7 +316,7 @@ Unsupported argument type 'bit' of the stored procedure create or replace functi
 Error:-494
 Semantic: before ' ,
 typeof( t_BIT_JSON('BIT(8)', 'JSON', 0xaa ) ) ; '
-Function t_BIT_JSON is undefined or given wrong number of parameter. select t_BIT_JSON('BIT(8)', 'JSON', X'aa'),  typeof(t_BIT_JS...
+Function t_bit_json is undefined or given wrong number of parameter. select t_BIT_JSON('BIT(8)', 'JSON', X'aa'),  typeof(t_BIT_JS...
 
 ===================================================
 Error:-894
@@ -340,7 +340,7 @@ dba.BITVARYING is not defined. create or replace function [dba.t_BITVARYING_JSON
 Error:-494
 Semantic: before ' ,
 typeof( t_BITVARYING_JSON('BIT VARYING', 'JSON', 0xaa ) ) ; '
-Function t_BITVARYING_JSON is undefined or given wrong number of parameter. select t_BITVARYING_JSON('BIT VARYING', 'JSON', X'aa'),  typ...
+Function t_bitvarying_json is undefined or given wrong number of parameter. select t_BITVARYING_JSON('BIT VARYING', 'JSON', X'aa'),  typ...
 
 ===================================================
 Error:-894
@@ -360,7 +360,7 @@ Semantic: Unsupported return type 'json' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_CHAR_JSON('CHAR', 'JSON', '{"a":1}' ) ) ; '
-Function t_CHAR_JSON is undefined or given wrong number of parameter. select t_CHAR_JSON('CHAR', 'JSON', '{"a":1}'),  typeof(t_CHA...
+Function t_char_json is undefined or given wrong number of parameter. select t_CHAR_JSON('CHAR', 'JSON', '{"a":1}'),  typeof(t_CHA...
 
 ===================================================
 Error:-894
@@ -380,7 +380,7 @@ Semantic: Unsupported return type 'json' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_VARCHAR_JSON('VARCHAR', 'JSON', '{"a":1}' ) ) ; '
-Function t_VARCHAR_JSON is undefined or given wrong number of parameter. select t_VARCHAR_JSON('VARCHAR', 'JSON', '{"a":1}'),  typeof...
+Function t_varchar_json is undefined or given wrong number of parameter. select t_VARCHAR_JSON('VARCHAR', 'JSON', '{"a":1}'),  typeof...
 
 ===================================================
 Error:-894
@@ -400,7 +400,7 @@ Semantic: Unsupported return type 'json' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_SET_JSON('SET', 'JSON', {'c','c','c','b','b','a'}...'
-Function t_SET_JSON is undefined or given wrong number of parameter. select t_SET_JSON('SET', 'JSON'),  typeof(t_SET_JSON('SET', ...
+Function t_set_json is undefined or given wrong number of parameter. select t_SET_JSON('SET', 'JSON'),  typeof(t_SET_JSON('SET', ...
 
 ===================================================
 Error:-894
@@ -420,7 +420,7 @@ Semantic: Unsupported return type 'json' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_MULTISET_JSON('MULTISET', 'JSON', {'c','c','c','b...'
-Function t_MULTISET_JSON is undefined or given wrong number of parameter. select t_MULTISET_JSON('MULTISET', 'JSON'),  typeof(t_MULTIS...
+Function t_multiset_json is undefined or given wrong number of parameter. select t_MULTISET_JSON('MULTISET', 'JSON'),  typeof(t_MULTIS...
 
 ===================================================
 Error:-894
@@ -440,7 +440,7 @@ Semantic: Unsupported return type 'json' of the stored procedure create or repla
 Error:-494
 Semantic: before ' ,
 typeof( t_LIST_JSON('LIST', 'JSON', {'c','c','c','b','b', '...'
-Function t_LIST_JSON is undefined or given wrong number of parameter. select t_LIST_JSON('LIST', 'JSON'),  typeof(t_LIST_JSON('LIS...
+Function t_list_json is undefined or given wrong number of parameter. select t_LIST_JSON('LIST', 'JSON'),  typeof(t_LIST_JSON('LIS...
 
 ===================================================
 Error:-894
@@ -461,7 +461,7 @@ Syntax: invalid create function
 Error:-494
 Semantic: before ' ,
 typeof( t_ENUM_JSON('ENUM', 'JSON', 'yellow' ) ) ; '
-Function t_ENUM_JSON is undefined or given wrong number of parameter. select t_ENUM_JSON('ENUM', 'JSON', 'yellow'),  typeof(t_ENUM...
+Function t_enum_json is undefined or given wrong number of parameter. select t_ENUM_JSON('ENUM', 'JSON', 'yellow'),  typeof(t_ENUM...
 
 ===================================================
 Error:-894
@@ -486,7 +486,7 @@ Unsupported argument type 'blob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_BLOB_JSON('BLOB', 'JSON', BIT_TO_BLOB(X'000010') ...'
-Function t_BLOB_JSON is undefined or given wrong number of parameter. select t_BLOB_JSON('BLOB', 'JSON',  bit_to_blob(X'000010')),...
+Function t_blob_json is undefined or given wrong number of parameter. select t_BLOB_JSON('BLOB', 'JSON',  bit_to_blob(X'000010')),...
 
 ===================================================
 Error:-894
@@ -511,7 +511,7 @@ Unsupported argument type 'clob' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_CLOB_JSON('CLOB', 'JSON', CHAR_TO_CLOB('This is a...'
-Function t_CLOB_JSON is undefined or given wrong number of parameter. select t_CLOB_JSON('CLOB', 'JSON',  char_to_clob('This is a ...
+Function t_clob_json is undefined or given wrong number of parameter. select t_CLOB_JSON('CLOB', 'JSON',  char_to_clob('This is a ...
 
 ===================================================
 Error:-894
@@ -536,7 +536,7 @@ Unsupported argument type 'json' of the stored procedure create or replace funct
 Error:-494
 Semantic: before ' ,
 typeof( t_JSON_JSON('JSON', 'JSON', '{"a":1}' ) ) ; '
-Function t_JSON_JSON is undefined or given wrong number of parameter. select t_JSON_JSON('JSON', 'JSON', '{"a":1}'),  typeof(t_JSO...
+Function t_json_json is undefined or given wrong number of parameter. select t_JSON_JSON('JSON', 'JSON', '{"a":1}'),  typeof(t_JSO...
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_06_authorization/answers/01_normal_grant_revoke.answer
+++ b/sql/_05_plcsql/_01_testspec/_06_authorization/answers/01_normal_grant_revoke.answer
@@ -188,8 +188,6 @@ DBA     U1     5     _db_stored_procedure     EXECUTE     0
 
 ===================================================
 grantor.name    grantee.name    object_type    object_of    auth_type    is_grantable    
-DBA     U1     5     null     EXECUTE     0     
-DBA     U1     5     null     EXECUTE     0     
 
 
 ===================================================
@@ -200,7 +198,7 @@ null
 ===================================================
 Error:-494
 Semantic: before ' ; '
-dba.sp1() is not defined. select 
+Function dba.sp1 is undefined. select [dba.sp1].[dba.sp1]()
 
 ===================================================
 Error:-894
@@ -224,8 +222,6 @@ null
 
 ===================================================
 grantor.name    grantee.name    object_type    object_of    auth_type    is_grantable    
-DBA     U1     5     null     EXECUTE     0     
-DBA     U1     5     null     EXECUTE     0     
 
 
 ===================================================
@@ -236,8 +232,6 @@ DBA     U1     5     null     EXECUTE     0
 
 ===================================================
 grantor.name    grantee.name    object_type    object_of    auth_type    is_grantable    
-DBA     U1     5     null     EXECUTE     0     
-DBA     U1     5     null     EXECUTE     0     
 
 
 ===================================================
@@ -248,7 +242,7 @@ null
 ===================================================
 Error:-494
 Semantic: before ' ; '
-dba.sp1() is not defined. select 
+Function dba.sp1 is undefined. select [dba.sp1].[dba.sp1]()
 
 ===================================================
 Error:-894


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25673

Purpose

1. 존재하지 않는 Stored procedure를 [user_schema]를 포함하여 조회(select)할 때, 기존에는 "Function [?] is undefined."로 출력되던 에러 메시지가 잘못된 형태인 "[?] is not defined."로 표시되는 문제를 수정합니다.
2. 사용자가 Class 이름을 대문자로 사용했을 때 에러 메시지에서 Class가 소문자로 출력되는 방식처럼, Stored procedure에서도 일관되게 에러 메시지가 출력되도록 수정했습니다.
```
ex)
--AS-IS
Error:-494
...
Function t_DATETIMELTZ_DATETIME is undefined or given wrong number of parameter. select t_DATETIMELTZ_DATETIME('DATETIMELTZ', 'DATETIME', dat...

--TO-BE
Error:-494
...
Function t_datetimeltz_datetime is undefined or given wrong number of parameter. select t_DATETIMELTZ_DATETIME('DATETIMELTZ', 'DATETIME', dat...
```

### TC수정 개수
### 1. test_plcsql(_05_plcsql) : 27개
* [CBRD-25673](http://jira.cubrid.org/browse/CBRD-25673) 이슈 이외에 다른 이슈에 영향을 받는 TC : sql/_01_testspec/_06_authorization/01_normal_grant_revoke.sql
  - 해당 TC는 CBRD-25673 와 CBRD-25486 이슈에 영향을 받아 수정이 필요 합니다.
    - CBRD-25673 : 존재하지 않는 Stored procedure를 [user_schema]를 포함하여 조회(select)할 때 에러 메시지가 기존과 다르게 표시되는 문제 수정
    - CBRD-25486 : 객체(Class)를 삭제하기 전에 해당 객체가 부여한 모든 권한을 먼저 회수(REVOKE)한 후 삭제합니다.

### 2. cci (_05_plcsql) : 3개

Implementation

N/A

Remarks

N/A