### PR TITLE
[CBRD-25680] When using a correlated subquery that includes columns from an outer table in the select clause, it is not selected as a cache key

### DIFF
--- a/sql/_13_issues/_23_1h/answers/cbrd_24843_4.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24843_4.answer
@@ -616,7 +616,6 @@ Trace Statistics:
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t_parent), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
           SCAN (index: dba.t_child.pk_t_child_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-        SUBQUERY_CACHE (hit: ?, miss: ?, size: ?, status: enabled)
      
 
 ===================================================
@@ -645,7 +644,6 @@ Trace Statistics:
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t_parent), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
           SCAN (index: dba.t_child.pk_t_child_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-        SUBQUERY_CACHE (hit: ?, miss: ?, size: ?, status: enabled)
      
 
 ===================================================


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25680

select 절에서 외부 테이블 컬럼을 포함한 correlated subquery를 사용할 때, subquery cache가 해당 컬럼을 키로 사용하지 않아 캐싱이 제대로 이루어지지 않습니다. 이로 인해 예상되는 miss 상황에서도 cache hit가 발생하는 문제가 확인되었습니다. 이를 해결하기 위해 xasl outptr_list에 포함된 regu_var도 캐싱 키에 포함시키도록 수정했습니다. 또한 pred와는 다르게 xasl outptr_list는 조인 시 outer 테이블을 constant regu var로 사용하기 때문에 외부 컬럼이 아니더라도 캐시 키로 잘못 사용될 가능성이 있어, subquery 내부 테이블 중 스펙에 해당하는 테이블이 없는 경우에만 캐싱하도록 코드를 수정하였습니다.

When using a correlated subquery that includes columns from an outer table in the select clause, the subquery cache does not use those columns as keys, resulting in improper caching. Consequently, cache hits occur even in situations where cache misses are expected. To address this, we modified the code to include regu_var from xasl outptr_list as part of the caching key. Additionally, unlike pred, xasl outptr_list uses the outer table as a constant regu_var during joins, which could mistakenly utilize even non-outer columns as cache keys. Therefore, we adjusted the code to only enable caching when there is no table from the subquery that matches the specification.

