### PR TITLE
[CBRD-25518] There's a typo in the answer sheet, so I will correct it.

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_04_expression/_22_grant/answers/03_public_permission.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_22_grant/answers/03_public_permission.answer
@@ -20,7 +20,7 @@ null
 null     
 
 
-onwer is public
+owner is public
 ===================================================
 Error:-907
 The owner or a member of DBA group can drop stored procedure.


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25518

### 답안지에 오타가 있어 수정합니다.

Repro
```sql
create user t1;

create or replace procedure public.test() as
begin
    dbms_output.put_line('owner is public');
end;

call login('t1','') on class db_user;

call public.test();
```

Answer
```
null     

onwer is public
```

Result
```
  Result              
======================
  NULL                

<DBMS_OUTPUT>
====
owner is public
```