### PR TITLE
Revert "[CBRD-25416] Add temporary exclusion case to Ha_repl test"

### DIFF
--- a/sql/config/daily_regression_test_exclude_list_ha_repl.conf
+++ b/sql/config/daily_regression_test_exclude_list_ha_repl.conf
@@ -305,6 +305,3 @@ sql/_27_banana_qa/issue_8909_unquoted_keywords/cases/_004_update.test
 
 #[PERMANENT] don't support 'call' on HA.
 sql/_33_elderberry/cbrd_23845/cases/_02_permission_check.test
-
-#[temporary] CBRD-25416 , If the problem is resolved, this case should be removed from this exclude file.
-sql/_08_javasp/cases/case_cte_01.test


### PR DESCRIPTION
Reverts CUBRID/cubrid-testcases#1916

CBRD-25416이 머지되었으므로 ha_repl 제외 리스트에 추가한 TC를 다시 삭제합니다.