### PR TITLE
[CBRD-25303] modified and enabled a sql test case for Call of ADDTIME() results in Invalid XASL tree node content (feature/plcsql-p1)

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_05_datetime_function/cases/04_04_03_05_bfn_datetime_addtime.sql
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_05_datetime_function/cases/04_04_03_05_bfn_datetime_addtime.sql
@@ -1,5 +1,6 @@
 --+ server-message on
-
+-- Verified for CBRD-25303
+-- Ensures that the calling of ADDTIME does not result in a runtime error
 -- normal: basic usage of a builtin function call
 
 create or replace procedure t () as


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-25303


Edited the file name of: 04_04_03_05_bfn_datetime_addtime.sql.todo -> 04_04_03_05_bfn_datetime_addtime.sql

Note: The answer file already exists and does not require any modification.
