### PR TITLE
[CUBRIDQA-1136] fix a TC: drop the created procedure at last

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-08_normal_dup_column_name.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-08_normal_dup_column_name.sql
@@ -10,5 +10,6 @@ end;
 select count(*) from db_stored_procedure where sp_name = 't';
 select count(*) from db_stored_procedure_args where sp_name = 't';
 
+drop procedure t;
 
 --+ server-message off


### PR DESCRIPTION
생성한 procedure t 를 drop 하지 않아 이후 TC 가 실패하는 문제가 있었습니다. 
drop procedure t; 를 추가했습니다. 


이상한 현상은 제 개인 개발 장비에서는 아래와 같이 정상 순서(TC path의 사전식 배열)로 실행되는데, 
```
TestCase: sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-02_error_no_into_clause.sql    :OK:32
TestCase: sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-03_error_into_unupdatable.sql  :OK:33
TestCase: sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-03_error_into_unupdatable_2.sql    :OK:33
TestCase: sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-04_error_into_length_mismatch.sql  :OK:32
TestCase: sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-05_error_into_type_mismatch.sql    :OK:26
TestCase: sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-06_normal_no_data.sql  :OK:53
TestCase: sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-07_normal_too_many_rows.sql    :OK:78
TestCase: sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-08_normal_dup_column_name.sql  :OK:48

```

QA 테스트 장비에서는 아래와 같이 실행된 로그가 (summary.info) 가 남아 있습니다. 
```
TestCase: sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-02_error_no_into_clause.sql	:OK:34
TestCase: sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-03_error_into_unupdatable.sql	:OK:35
TestCase: sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-05_error_into_type_mismatch.sql	:OK:38
TestCase: sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-06_normal_no_data.sql	:OK:79
TestCase: sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-07_normal_too_many_rows.sql	:OK:95
TestCase: sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-08_normal_dup_column_name.sql	:OK:65
TestCase: sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-03_error_into_unupdatable_2.sql	:NOK:37
TestCase: sql/_05_plcsql/_01_testspec/_03_statement/_02_static_sql/_01_select/cases/03_02_01-04_error_into_length_mismatch.sql	:NOK:38
```
그래서, 11.4.0.1492-2b1a584 의 sql_by_cci 테스트에서 

- 03_02_01-03_error_into_unupdatable_2.sql 
- 03_02_01-04_error_into_length_mismatch.sql 

가 실패했으나 제 자리에서는 재현되지 않았습니다. 