### PR TITLE
[CBRD-25266] (bugfix) CSQL core dump when an undefined column name in a Static SQL Insert statement

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_05_bug_fix/answers/21_insert_column_name_undefined.answer
+++ b/sql/_05_plcsql/_01_testspec/_05_bug_fix/answers/21_insert_column_name_undefined.answer
@@ -1,0 +1,15 @@
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+Error:-1360
+In line 3, column 1
+Stored procedure compile error: Semantic: before '  values(1, 2)'
+Class of [dba.ttt] does not have attribute j. insert into [dba.ttt] (i,  ?:0 ) values (1, 2)
+
+===================================================
+0
+

--- a/sql/_05_plcsql/_01_testspec/_05_bug_fix/cases/21_insert_column_name_undefined.sql
+++ b/sql/_05_plcsql/_01_testspec/_05_bug_fix/cases/21_insert_column_name_undefined.sql
@@ -1,0 +1,17 @@
+--+ server-message on
+-- Verified for CBRD-25266
+-- The column name undefined use in a Static SQL Insert statement.
+-- error code :
+-- [err] Stored procedure compile error: does not have attribute j
+
+drop table if exists ttt;
+
+create table ttt (i int);
+create or replace procedure poo as
+begin
+    insert into ttt(i, j) values(1, 2);
+end;
+
+drop table ttt;
+
+--+ server-message off


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-25266

CSQL core dump when an undefined column name in a Static SQL Insert statement