### PR TITLE
[CUBRIDMAN-251] update two answers

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_11_common/answers/01_01_11-05_error_unreachable_after_raise_application_error.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_11_common/answers/01_01_11-05_error_unreachable_after_raise_application_error.answer
@@ -4,7 +4,7 @@
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 3, column 1) hello
+  (line 3, column 1) exception codes below 1001 are reserved
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_19_sqlcode_errm/answers/user_exception.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_19_sqlcode_errm/answers/user_exception.answer
@@ -6,7 +6,7 @@
 null     
 
 
-error code: 99
+error code: 1000
 error msg: user defined exception
 ===================================================
 0


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-251

사용자 정의 에러 코드를 99에서 1000으로 변경하고 
이 값보다 작은 값을 raise_application_exception() 에 사용했을 때는 에러 처리했습니다. 
이 값보다 작은 코드는 빌트인 exception을 위해 예약된 코드들인데, 99는 너무 작은 것 같아서 입니다. 

작성 중인 사용자매뉴얼의 관련 내용은 해당 이슈의 댓글에서 참고하실 수 있습니다. 
