### PR TITLE
[CBRD-24941] update 5 TCs: change % with MOD

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_03_statement/_06_continue/_01_with_label/cases/03_06_01-01_normal_basic.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_06_continue/_01_with_label/cases/03_06_01-01_normal_basic.sql
@@ -12,8 +12,8 @@ begin
         <<inner>>
         for j in 1 .. 3 loop
             dbms_output.put_line('j=' || j);
-            continue outer when j % 2 = 0;
-            continue inner when j % 2 = 1;
+            continue outer when j mod 2 = 0;
+            continue inner when j mod 2 = 1;
             dbms_output.put_line('unreachable');
         end loop;
 

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_06_continue/_02_with_when_clause/cases/03_06_02-01_normal_basic.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_06_continue/_02_with_when_clause/cases/03_06_02-01_normal_basic.sql
@@ -6,7 +6,7 @@
 create or replace procedure t(i int) as
 begin
     for i in 1 .. 5 loop
-        continue when i % 2 = 0;
+        continue when i mod 2 = 0;
         dbms_output.put_line('i=' || i);
     end loop;
 end;

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_06_continue/_03_common/cases/03_06_03-02_normal_innermost_loop.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_06_continue/_03_common/cases/03_06_03-02_normal_innermost_loop.sql
@@ -9,7 +9,7 @@ begin
     for i in 1 .. 5 loop
 
         for j in 1 .. 5 loop
-            continue when j % 2 = 0;
+            continue when j mod 2 = 0;
             dbms_output.put_line('j=' || j);
         end loop;
 

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_07_exit/_02_with_when_clause/cases/03_07_02-01_normal_basic.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_07_exit/_02_with_when_clause/cases/03_07_02-01_normal_basic.sql
@@ -6,7 +6,7 @@
 create or replace procedure t(i int) as
 begin
     for i in 1 .. 5 loop
-        exit when i % 2 = 0;
+        exit when i mod 2 = 0;
         dbms_output.put_line('i=' || i);
     end loop;
     dbms_output.put_line('done');

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_07_exit/_03_common/cases/03_07_03-02_normal_innermost_loop.sql
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_07_exit/_03_common/cases/03_07_03-02_normal_innermost_loop.sql
@@ -9,7 +9,7 @@ begin
     for i in 1 .. 5 loop
 
         for j in 1 .. 5 loop
-            exit when j % 2 = 0;
+            exit when j mod 2 = 0;
             dbms_output.put_line('j=' || j);
         end loop;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24941

%를 나머지 연산자로 사용하지 않는 것으로 수정이 될 예정이라 (참고: https://github.com/CUBRID/cubrid/pull/5706)
관련 TC 5건을 수정하였습니다. 