### PR TITLE
[CBRD-25746] added a sql javasp test case for If the SP of GROUP BY of WITH ROLLUP insert fails, the array will be marked as NULL

### DIFF
--- a/sql/_08_javasp/cases/cbrd_25746.sql
+++ b/sql/_08_javasp/cases/cbrd_25746.sql
@@ -17,7 +17,7 @@ CREATE TABLE sales_tbl
 INSERT INTO sales_tbl VALUES (201, 'George', 1, 450);
 INSERT INTO sales_tbl VALUES (202, 'Alice', 1, 550);
 
-evaluate 'Test Case 1: Using ROUND function in GROUP BY with WITH ROLLUP';
+evaluate 'Test Case 1: Using ROUND function and NO SP execution in GROUP BY with WITH ROLLUP';
 SELECT ROUND(dept_no), name, AVG(sales_amount)
 FROM sales_tbl
 WHERE sales_amount > 100

--- a/sql/_08_javasp/cases/cbrd_25746.sql
+++ b/sql/_08_javasp/cases/cbrd_25746.sql
@@ -1,0 +1,60 @@
+-- This test case verifies the following issue: CBRD-25746.
+-- When a stored procedure is included in the GROUP BY clause with rollup (e.g., GROUP BY test_fc(dept_no), name WITH ROLLUP),
+-- ensure that the aggregated rows for some grouping levels no longer show NULL values instead of the expected aggregated values.
+
+CREATE OR REPLACE FUNCTION test_fc_int(i INT) RETURN INT AS LANGUAGE JAVA NAME 'SpTest7.typetestint(int) return int';
+CREATE OR REPLACE FUNCTION test_fc_str(i string) RETURN string as language java name 'SpTest7.typeteststring(java.lang.String) return java.lang.String';
+
+CREATE TABLE sales_tbl
+(
+    dept_no INT,
+    name VARCHAR(20),
+    sales_month INT,
+    sales_amount INT DEFAULT 100,
+    PRIMARY KEY (dept_no, name, sales_month)
+);
+
+INSERT INTO sales_tbl VALUES (201, 'George', 1, 450);
+INSERT INTO sales_tbl VALUES (202, 'Alice', 1, 550);
+
+evaluate 'Test Case 1: Using ROUND function in GROUP BY with WITH ROLLUP';
+SELECT ROUND(dept_no), name, AVG(sales_amount)
+FROM sales_tbl
+WHERE sales_amount > 100
+GROUP BY dept_no, name WITH ROLLUP;
+
+evaluate 'Test Case 2: Using stored procedure in GROUP BY with WITH ROLLUP';
+SELECT dept_no, name, AVG(sales_amount)
+FROM sales_tbl
+WHERE sales_amount > 100
+GROUP BY test_fc_int(dept_no), name WITH ROLLUP;
+
+evaluate 'Test Case 3: Including non-numeric columns in GROUP BY';
+SELECT dept_no, name, AVG(sales_amount)
+FROM sales_tbl
+WHERE sales_amount > 100
+GROUP BY dept_no, test_fc_str(name) WITH ROLLUP;
+
+evaluate 'Test Case 4: Using stored procedure in WHERE clause';
+SELECT dept_no, name, AVG(sales_amount)
+FROM sales_tbl
+WHERE test_fc_int(dept_no) > 200
+GROUP BY test_fc_int(dept_no), name WITH ROLLUP;
+
+evaluate 'Test Case 5: Using multiple stored procedures in GROUP BY';
+SELECT dept_no, AVG(sales_month), SUM(sales_amount)
+FROM sales_tbl
+WHERE sales_amount > 100
+GROUP BY test_fc_int(dept_no), test_fc_int(sales_month) WITH ROLLUP;
+
+evaluate 'Test Case 6: Using HAVING clause with stored procedure';
+SELECT dept_no, name, AVG(sales_amount)
+FROM sales_tbl
+WHERE sales_amount > 100
+GROUP BY test_fc_int(dept_no), name WITH ROLLUP
+HAVING AVG(sales_amount) > 100;
+
+evaluate 'Cleanup';
+DROP FUNCTION test_fc_int;
+DROP FUNCTION test_fc_str;
+DROP TABLE sales_tbl;


### PR DESCRIPTION
Refer to: http://jira.cubrid.org/browse/CBRD-25746

Note: .answer 파일은 본 이슈가 머지가 된 이후에 추가될 예정입니다. 올바르게 반환되어야 할 해당 집계 행의 값이 NULL로 표시만 안되면 되므로 TC 리뷰를 하는데 큰 영향을 끼치지는 않다고 생각이 들어서 미리 리뷰 요청드립니다.