### PR TITLE
[CBRD-25672] Stored functions are not allowed as default values ​​for…

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_04_create_table/_01_table_col_def_func/answers/01_01_01-01_default_function_error.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_04_create_table/_01_table_col_def_func/answers/01_01_01-01_default_function_error.answer
@@ -1,0 +1,70 @@
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+Error:-494
+Semantic: before ' ); '
+'demo_hello_ret()' function can not be used in DEFAULT clause. create class [dba.col_def_test] ( id integer, def_val varcha...
+
+===================================================
+Error:-493
+Syntax: before '  VALUES (1), (2); '
+Unknown class "dba.col_def_test". insert into [dba.col_def_test] (id) values (1), (2)
+
+===================================================
+Error:-493
+Syntax: before ' ; '
+Unknown class "dba.col_def_test". select * from [dba.col_def_test]
+
+===================================================
+0
+
+===================================================
+Error:-494
+Semantic: before ' ); '
+'demo_hello_ret2(1)' function can not be used in DEFAULT clause. create class [dba.col_def_test] ( id integer, def_val varcha...
+
+===================================================
+Error:-493
+Syntax: before '  VALUES (1), (2); '
+Unknown class "dba.col_def_test". insert into [dba.col_def_test] (id) values (1), (2)
+
+===================================================
+Error:-493
+Syntax: before ' ; '
+Unknown class "dba.col_def_test". select * from [dba.col_def_test]
+
+===================================================
+Error:-494
+Semantic: before ' 
+) AS
+BEGIN
+DBMS_OUTPUT.put_line(a);
+END; '
+'demo_hello_ret()' function can not be used in DEFAULT clause. create or replace procedure [dba.test_var](a  varchar defaul...
+
+===================================================
+Error:-494
+Semantic: before ' 
+) AS
+BEGIN
+DBMS_OUTPUT.put_line(a);
+END; '
+'demo_hello_ret2(1)' function can not be used in DEFAULT clause. create or replace procedure [dba.test_var](a  varchar defaul...
+
+===================================================
+0
+
+===================================================
+Error:-894
+Stored procedure/function 'dba.test_var' does not exist.
+
+===================================================
+0
+

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_04_create_table/_01_table_col_def_func/cases/01_01_01-01_default_function_error.sql
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_04_create_table/_01_table_col_def_func/cases/01_01_01-01_default_function_error.sql
@@ -1,5 +1,5 @@
 --+ server-message on
--- Verified for CBRD-25762
+-- Verified for CBRD-25672
 -- error code :
 -- Specifying stored functions as default values for tables and stored procedures/functions is not allowed.
 

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_04_create_table/_01_table_col_def_func/cases/01_01_01-01_default_function_error.sql
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_04_create_table/_01_table_col_def_func/cases/01_01_01-01_default_function_error.sql
@@ -1,0 +1,54 @@
+--+ server-message on
+-- Verified for CBRD-25762
+-- error code :
+-- Specifying stored functions as default values for tables and stored procedures/functions is not allowed.
+
+create or replace function demo_hello_ret() return varchar as 
+begin
+    return 'hello cubrid';
+end;
+
+create or replace function demo_hello_ret2(a int) return varchar as 
+begin
+    return 'hello cubrid2';
+end;
+
+DROP TABLE IF EXISTS col_def_test;
+
+CREATE TABLE col_def_test
+(id INT, def_val VARCHAR DEFAULT demo_hello_ret());
+
+INSERT INTO col_def_test (id) VALUES (1), (2);
+
+SELECT * FROM col_def_test;
+
+DROP TABLE IF EXISTS col_def_test;
+
+CREATE TABLE col_def_test
+(id INT, def_val VARCHAR DEFAULT demo_hello_ret2(1));
+
+INSERT INTO col_def_test (id) VALUES (1), (2);
+
+SELECT * FROM col_def_test;
+
+CREATE OR REPLACE PROCEDURE test_var (
+    a VARCHAR DEFAULT demo_hello_ret()
+) AS
+BEGIN
+    DBMS_OUTPUT.put_line(a);
+END;
+
+CREATE OR REPLACE PROCEDURE test_var (
+    a VARCHAR DEFAULT demo_hello_ret2(1)
+) AS
+BEGIN
+    DBMS_OUTPUT.put_line(a);
+END;
+
+drop function demo_hello_ret, demo_hello_ret2;
+drop procedure test_var;
+
+drop table if exists col_def_test;
+
+--+ server-message off
+


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-25672

1) 테이블과 저장 프로시저/함수의 기본값에 저장 함수 지정을 허용하지 않도록 스펙을 수정
 - 테이블 컬럼과 저장 프로시저/함수 파라미터의 기본값에 저장 함수 미허용