### PR TITLE
[CBRD-25744] Revised test case for updated spec where DBA members act as owners when granting/revoking privileges

### DIFF
--- a/isolation/_01_ReadCommitted/authorization/granting_authorization/answer/revoke_authorization_04.answer
+++ b/isolation/_01_ReadCommitted/authorization/granting_authorization/answer/revoke_authorization_04.answer
@@ -1,6 +1,4 @@
 | 7 rows affected
-| ERROR RETURNED: GRANT not found. 
-|    on statement number: 20
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -25,12 +23,8 @@
 |    6  
 |    9  
 | 2 rows selected
-| =================   Q U E R Y   R E S U L T S   =================
-| 
-| 
-|    6  
-|    9  
-| 2 rows selected
+| ERROR RETURNED: Semantic: Select is not authorized on dba.t1_view. select [dba.t1_view].id from [dba.t1_view] [dba.t1_view] 
+|    on statement number: 6
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -55,12 +49,8 @@
 |    6  
 |    9  
 | 2 rows selected
-| =================   Q U E R Y   R E S U L T S   =================
-| 
-| 
-|    6  
-|    9  
-| 2 rows selected
+| ERROR RETURNED: Semantic: Select is not authorized on dba.t1_view. select [dba.t1_view].id from [dba.t1_view] [dba.t1_view] 
+|    on statement number: 11
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/authorization/granting_authorization/revoke_authorization_04.ctl
+++ b/isolation/_01_ReadCommitted/authorization/granting_authorization/revoke_authorization_04.ctl
@@ -83,6 +83,8 @@ C2: set transaction lock timeout INFINITE;
 C2: set transaction isolation level read committed;
 C2: select * from dba.t1_view order by 1;
 C2: COMMIT;
+C2: login as 'dba';
+C2: COMMIT;
 MC: wait until C2 ready;
 
 C1: login as 'dba';


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-25744


수정 이전에 granter와 revoke를 실행한 유저가 동일해야 권한을 회수할 수 있었습니다.
하지만, 수정 후 DBA와 DBA 멤버가 권한을 부여/회수 할 때, 소유자로 동작하도록 변경되어 brown 사용자가 revoke 실행이 성공하게되며, t1_view에 대한 company의 권한이 제거됩니다.

따라서 C2에서 dba.t1_view 에 대한 권한 관련 에러가 발생하는 것이 맞습니다.

또한, 마지막에 C2가 company 유저로 접속되어있기 때문에 
C1에서 clean작업을 할 때
ERROR: Dropping an active user 'company' is not allowed. 라는 에러와 함께 company 유저가 drop되지 않고 있었습니다.
따라서 이도 함께 수정합니다.