### PR TITLE
[CBRD-25184] Update answer for PL/CSQL phase-1 internal release

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_05_bug_fix/answers/13_false_rewriting.answer
+++ b/sql/_05_plcsql/_01_testspec/_05_bug_fix/answers/13_false_rewriting.answer
@@ -23,17 +23,15 @@ null
 
 
 ===================================================
-Error:-493
-Syntax: Precision cannot be specified for argument types and return types ​​of stored procedures and functions. 
+0
 
 ===================================================
-Error:-494
-Semantic: before ' ; '
-Function foo is undefined. select foo(30)
+foo(30)    
+cub     
+
 
 ===================================================
-Error:-894
-Stored procedure/function 'dba.foo' does not exist.
+0
 
 ===================================================
 0


### PR DESCRIPTION
On previous PR https://github.com/CUBRID/cubrid-testcases/pull/2004, the answer for sql/_05_plcsql/_01_testspec/_05_bug_fix/cases/13_false_rewriting.sql hasn't updated. 

Refer to http://jira.cubrid.org//browse/CBRD-25184