### PR TITLE
[CUBRIDQA-1136] revised test case to include order by to ensure correct order

### DIFF
--- a/sql/_34_fig/cbrd_24252/answers/cbrd_24252_9.answer
+++ b/sql/_34_fig/cbrd_24252/answers/cbrd_24252_9.answer
@@ -53,13 +53,15 @@ col_a    col_b
 trace    
 
 Query Plan:
-  TABLE SCAN (c)
+  SORT (order by)
+    TABLE SCAN (c)
 
-  rewritten query: select c.col_a, c.col_b from [dba.t_child] c where c.col_b= ?:?  and c.parent_col_a is not null 
+  rewritten query: select c.col_a, c.col_b from [dba.t_child] c where c.col_b= ?:?  and c.parent_col_a is not null  order by ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (table: dba.t_child), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
 ===================================================
@@ -73,13 +75,15 @@ col_a    col_b
 trace    
 
 Query Plan:
-  TABLE SCAN (c)
+  SORT (order by)
+    TABLE SCAN (c)
 
-  rewritten query: select c.col_a, c.col_b from [dba.t_child] c where c.col_b= ?:?  and c.parent_col_a is not null 
+  rewritten query: select c.col_a, c.col_b from [dba.t_child] c where c.col_b= ?:?  and c.parent_col_a is not null  order by ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (table: dba.t_child), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
 ===================================================

--- a/sql/_34_fig/cbrd_24252/cases/cbrd_24252_9.sql
+++ b/sql/_34_fig/cbrd_24252/cases/cbrd_24252_9.sql
@@ -49,7 +49,8 @@ from
     inner join t_parent as p on c.parent_col_a = p.col_a
     inner join t_super_parent as s on p.super_parent_col_a = s.col_a
 where
-    c.col_b = -1;
+    c.col_b = -1
+order by c.col_a;
 show trace;
 
 select /*+ recompile */
@@ -62,7 +63,8 @@ from
 where
     c.parent_col_a = p.col_a
     and p.super_parent_col_a = s.col_a
-    and c.col_b = -1;
+    and c.col_b = -1
+order by c.col_a;
 show trace;
 
 drop table if exists t_child;


### PR DESCRIPTION
Refer to: http://jira.cubrid.org/browse/CBRD-24252

Test case is unstable and fails occasionally because order by is not in the query.