### PR TITLE
[CUBRIDQA-1136] Revised test case that selects _db_stored_procedure_args to include more columns in the order by clause to ensure correct ordering

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_14_system_catalog/cases/01_check_package_info.sql
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_14_system_catalog/cases/01_check_package_info.sql
@@ -32,7 +32,7 @@ end;
 call test_proc1();
 select sp_name, pkg_name, is_system_generated from _db_stored_procedure where is_system_generated=0 order by sp_name;
 -- no result, because test_proc1 does not need parameter
-select * from _db_stored_procedure_args where is_system_generated=0 order by sp_of;
+select * from _db_stored_procedure_args where is_system_generated=0 order by sp_of, default_value, is_optional, comment;
 
 
 create or replace procedure test_proc2(a int) as

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_14_system_catalog/cases/01_check_package_info.sql
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_14_system_catalog/cases/01_check_package_info.sql
@@ -32,7 +32,7 @@ end;
 call test_proc1();
 select sp_name, pkg_name, is_system_generated from _db_stored_procedure where is_system_generated=0 order by sp_name;
 -- no result, because test_proc1 does not need parameter
-select * from _db_stored_procedure_args where is_system_generated=0 order by sp_of, default_value, is_optional, comment;
+select * from _db_stored_procedure_args where is_system_generated=0 order by sp_of;
 
 
 create or replace procedure test_proc2(a int) as
@@ -54,7 +54,7 @@ comment 'procedure comment';
 
 call test_proc3();
 select sp_name, pkg_name, is_system_generated, comment from _db_stored_procedure where is_system_generated=0 order by sp_name;
-select * from _db_stored_procedure_args where is_system_generated=0 order by sp_of;
+select * from _db_stored_procedure_args where is_system_generated=0 order by sp_of, default_value, is_optional, comment;
 
 
 drop procedure test_proc1;


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-25077 for the original test case.

This is an effort made to stabilize test cases, as defined in http://jira.cubrid.org/browse/CUBRIDQA-1136


In this TC, a select query selects the _db_stored_procedure_args catalogue table. The order of this query's results cannot be ensured without a more precise order by clause; the sp_of column is not unique, therefore the test case fails occasionally as the ordering may change from time to time. 

The columns _default_value, is_optional_ and _comment_ were added to ensure correct ordering.