### PR TITLE
[CBRD-25800] The TC answer sheet in 05_plcsql has been modified to display [user_schema] in lowercase to reflect changes in the SHOW GRANTS syntax.

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_06_authorization/answers/04_normal_grant_revoke_plcsql.answer
+++ b/sql/_05_plcsql/_01_testspec/_06_authorization/answers/04_normal_grant_revoke_plcsql.answer
@@ -43,9 +43,9 @@ DBA     T1     VCLASS     view1     DBA     EXECUTE     NO
 
 ===================================================
 Grants for T1    
-GRANT ALTER, DELETE, EXECUTE, INDEX, INSERT, SELECT, UPDATE ON DBA.test1 TO T1     
-GRANT ALTER, DELETE, EXECUTE, INDEX, INSERT, SELECT, UPDATE ON DBA.view1 TO T1     
-GRANT EXECUTE ON PROCEDURE DBA.sp1 TO T1     
+GRANT ALTER, DELETE, EXECUTE, INDEX, INSERT, SELECT, UPDATE ON dba.test1 TO T1     
+GRANT ALTER, DELETE, EXECUTE, INDEX, INSERT, SELECT, UPDATE ON dba.view1 TO T1     
+GRANT EXECUTE ON PROCEDURE dba.sp1 TO T1     
 
 
 ===================================================
@@ -74,9 +74,9 @@ DBA     T1     VCLASS     view1     DBA     EXECUTE     NO
 
 ===================================================
 Grants for T1    
-GRANT ALTER, DELETE, EXECUTE, INDEX, INSERT, SELECT, UPDATE ON DBA.test1 TO T1     
-GRANT ALTER, DELETE, EXECUTE, INDEX, INSERT, SELECT, UPDATE ON DBA.view1 TO T1     
-GRANT EXECUTE ON PROCEDURE DBA.sp1 TO T1     
+GRANT ALTER, DELETE, EXECUTE, INDEX, INSERT, SELECT, UPDATE ON dba.test1 TO T1     
+GRANT ALTER, DELETE, EXECUTE, INDEX, INSERT, SELECT, UPDATE ON dba.view1 TO T1     
+GRANT EXECUTE ON PROCEDURE dba.sp1 TO T1     
 
 
 ===================================================
@@ -92,7 +92,7 @@ null
 
 ===================================================
 Grants for DBA    
-GRANT EXECUTE ON PROCEDURE T1.sp2 TO DBA     
+GRANT EXECUTE ON PROCEDURE t1.sp2 TO DBA     
 
 
 ===================================================

--- a/sql/_05_plcsql/_01_testspec/_06_authorization/answers/05_normal_grant_revoke_javasp.answer
+++ b/sql/_05_plcsql/_01_testspec/_06_authorization/answers/05_normal_grant_revoke_javasp.answer
@@ -20,7 +20,7 @@ DBA     T1     FUNCTION     test1     DBA     EXECUTE     NO
 
 ===================================================
 Grants for T1    
-GRANT EXECUTE ON PROCEDURE DBA.test1 TO T1     
+GRANT EXECUTE ON PROCEDURE dba.test1 TO T1     
 
 
 ===================================================
@@ -39,7 +39,7 @@ DBA     T1     FUNCTION     test1     DBA     EXECUTE     NO
 
 ===================================================
 Grants for T1    
-GRANT EXECUTE ON PROCEDURE DBA.test1 TO T1     
+GRANT EXECUTE ON PROCEDURE dba.test1 TO T1     
 
 
 ===================================================


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25800

Purpose

매뉴얼 작성 중 다른 SHOW 구문과의 일관성을 위해, SHOW GRANTS 구문에서 [user_schema]가 소문자로 출력되도록 변경됨에 따라 TC 답안지가 수정되었습니다.

이전 PR (https://github.com/CUBRID/cubrid-testcases/pull/2032) 에서 05_plcsql 관련된 TC를 깜빡하여 다시 답안지를 수정 했습니다. 

Implementation

N/A

Remarks

N/A