### PR TITLE
[CUBRIDQA-1136] Revised test case to ensure correct ordering (corrected order by column)

### DIFF
--- a/sql/_35_fig_cake/grant_revoke_redefine/cases/cbrd_25627_04.sql
+++ b/sql/_35_fig_cake/grant_revoke_redefine/cases/cbrd_25627_04.sql
@@ -26,7 +26,7 @@ GRANT ALTER ON u1.tbl2 TO u3 WITH GRANT OPTION;
 
 evaluate 'connect to dba';
 call login('dba','') on class db_user;
-select grantor_name, grantee_name, owner_name, object_type, object_name, auth_type, is_grantable from db_auth where grantee_name != 'PUBLIC' order by grantor_name, object_type;
+select grantor_name, grantee_name, owner_name, object_type, object_name, auth_type, is_grantable from db_auth where grantee_name != 'PUBLIC' order by grantor_name, object_name;
 
 
 evaluate 'connect to u3 & changed owner u1.tbl, u1.tbl2 -> u3.tbl, u3.tbl2, ERROR: can only be performed by the DBA or a DBA group member';


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-25627 for the original test case.

This is an effort made to stabilize test cases, as defined in http://jira.cubrid.org/browse/CUBRIDQA-1136

Before changes, the "order by grantor_name, object_type" does not do anything as they are always the same (i.e. object_type = CLASS for all results in the answer file, and grantor_name is also not unique). The first column with a visible difference (other than “grantor_name”) is "object_name", where the value "tbl" should come prior to "tbl2", but occasionally fails to do so because the order by checks for "object_type" instead of "object_name". 


_In https://github.com/CUBRID/cubrid-testcases/blob/develop/sql/_35_fig_cake/grant_revoke_redefine/answers/cbrd_25627_04.answer_
```
grantor_name    grantee_name    owner_name    object_type    object_name    auth_type    is_grantable    
U1     U2     U1     CLASS     tbl     ALTER     NO     
U1     U2     U1     CLASS     tbl2     ALTER     YES     
U2     U3     U1     CLASS     tbl2     ALTER     YES     
```


Thus, the query's order by has been adjusted to "order by grantor_name, object_name". 
