### PR TITLE
[CUBRIDQA-1136]  revised TC to include auth_type in an order by clause to align the order of the results across Windows and Linux

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_06_authorization/answers/04_normal_grant_revoke_plcsql.answer
+++ b/sql/_05_plcsql/_01_testspec/_06_authorization/answers/04_normal_grant_revoke_plcsql.answer
@@ -25,20 +25,20 @@
 ===================================================
 grantor_name    grantee_name    object_type    object_name    owner_name    auth_type    is_grantable    
 DBA     T1     FUNCTION     sp1     DBA     EXECUTE     NO     
-DBA     T1     CLASS     test1     DBA     SELECT     NO     
-DBA     T1     CLASS     test1     DBA     INSERT     NO     
-DBA     T1     CLASS     test1     DBA     UPDATE     NO     
-DBA     T1     CLASS     test1     DBA     DELETE     NO     
 DBA     T1     CLASS     test1     DBA     ALTER     NO     
-DBA     T1     CLASS     test1     DBA     INDEX     NO     
+DBA     T1     CLASS     test1     DBA     DELETE     NO     
 DBA     T1     CLASS     test1     DBA     EXECUTE     NO     
-DBA     T1     VCLASS     view1     DBA     SELECT     NO     
-DBA     T1     VCLASS     view1     DBA     INSERT     NO     
-DBA     T1     VCLASS     view1     DBA     UPDATE     NO     
-DBA     T1     VCLASS     view1     DBA     DELETE     NO     
+DBA     T1     CLASS     test1     DBA     INDEX     NO     
+DBA     T1     CLASS     test1     DBA     INSERT     NO     
+DBA     T1     CLASS     test1     DBA     SELECT     NO     
+DBA     T1     CLASS     test1     DBA     UPDATE     NO     
 DBA     T1     VCLASS     view1     DBA     ALTER     NO     
-DBA     T1     VCLASS     view1     DBA     INDEX     NO     
+DBA     T1     VCLASS     view1     DBA     DELETE     NO     
 DBA     T1     VCLASS     view1     DBA     EXECUTE     NO     
+DBA     T1     VCLASS     view1     DBA     INDEX     NO     
+DBA     T1     VCLASS     view1     DBA     INSERT     NO     
+DBA     T1     VCLASS     view1     DBA     SELECT     NO     
+DBA     T1     VCLASS     view1     DBA     UPDATE     NO     
 
 
 ===================================================
@@ -56,20 +56,20 @@ null
 ===================================================
 grantor_name    grantee_name    object_type    object_name    owner_name    auth_type    is_grantable    
 DBA     T1     FUNCTION     sp1     DBA     EXECUTE     NO     
-DBA     T1     CLASS     test1     DBA     SELECT     NO     
-DBA     T1     CLASS     test1     DBA     INSERT     NO     
-DBA     T1     CLASS     test1     DBA     UPDATE     NO     
-DBA     T1     CLASS     test1     DBA     DELETE     NO     
 DBA     T1     CLASS     test1     DBA     ALTER     NO     
-DBA     T1     CLASS     test1     DBA     INDEX     NO     
+DBA     T1     CLASS     test1     DBA     DELETE     NO     
 DBA     T1     CLASS     test1     DBA     EXECUTE     NO     
-DBA     T1     VCLASS     view1     DBA     SELECT     NO     
-DBA     T1     VCLASS     view1     DBA     INSERT     NO     
-DBA     T1     VCLASS     view1     DBA     UPDATE     NO     
-DBA     T1     VCLASS     view1     DBA     DELETE     NO     
+DBA     T1     CLASS     test1     DBA     INDEX     NO     
+DBA     T1     CLASS     test1     DBA     INSERT     NO     
+DBA     T1     CLASS     test1     DBA     SELECT     NO     
+DBA     T1     CLASS     test1     DBA     UPDATE     NO     
 DBA     T1     VCLASS     view1     DBA     ALTER     NO     
-DBA     T1     VCLASS     view1     DBA     INDEX     NO     
+DBA     T1     VCLASS     view1     DBA     DELETE     NO     
 DBA     T1     VCLASS     view1     DBA     EXECUTE     NO     
+DBA     T1     VCLASS     view1     DBA     INDEX     NO     
+DBA     T1     VCLASS     view1     DBA     INSERT     NO     
+DBA     T1     VCLASS     view1     DBA     SELECT     NO     
+DBA     T1     VCLASS     view1     DBA     UPDATE     NO     
 
 
 ===================================================

--- a/sql/_05_plcsql/_01_testspec/_06_authorization/cases/04_normal_grant_revoke_plcsql.sql
+++ b/sql/_05_plcsql/_01_testspec/_06_authorization/cases/04_normal_grant_revoke_plcsql.sql
@@ -18,13 +18,13 @@ create view view1 as select * from test1;
 GRANT ALL PRIVILEGES ON test1 TO t1;
 GRANT ALL PRIVILEGES ON view1 TO t1;
 
-SELECT * FROM db_auth WHERE grantee_name = 'T1' ORDER BY object_name;
+SELECT * FROM db_auth WHERE grantee_name = 'T1' ORDER BY object_name, auth_type;
 SHOW GRANTS FOR T1;
 
 call login('t1','') on class db_user;
 
 -- in t1
-SELECT * FROM db_auth WHERE grantee_name = 'T1' ORDER BY object_name;
+SELECT * FROM db_auth WHERE grantee_name = 'T1' ORDER BY object_name, auth_type;
 SHOW GRANTS;
 
 CREATE OR REPLACE FUNCTION t1.sp2() return varchar as

--- a/sql/_35_fig_cake/grant_revoke_redefine/answers/cbrd_25582.answer
+++ b/sql/_35_fig_cake/grant_revoke_redefine/answers/cbrd_25582.answer
@@ -239,13 +239,13 @@ null
 0
 ===================================================
 grantor_name    grantee_name    object_type    object_name    owner_name    auth_type    is_grantable    
-U1     U2     CLASS     tbl     U1     SELECT     YES     
-U1     U2     CLASS     tbl     U1     INSERT     YES     
-U1     U2     CLASS     tbl     U1     UPDATE     YES     
-U1     U2     CLASS     tbl     U1     DELETE     YES     
 U1     U2     CLASS     tbl     U1     ALTER     YES     
-U1     U2     CLASS     tbl     U1     INDEX     YES     
+U1     U2     CLASS     tbl     U1     DELETE     YES     
 U1     U2     CLASS     tbl     U1     EXECUTE     YES     
+U1     U2     CLASS     tbl     U1     INDEX     YES     
+U1     U2     CLASS     tbl     U1     INSERT     YES     
+U1     U2     CLASS     tbl     U1     SELECT     YES     
+U1     U2     CLASS     tbl     U1     UPDATE     YES     
 U2     U3     CLASS     tbl     U1     SELECT     YES     
 U3     U4     CLASS     tbl     U1     SELECT     YES     
 U4     U5     CLASS     tbl     U1     SELECT     YES     
@@ -262,13 +262,13 @@ null
 0
 ===================================================
 grantor_name    grantee_name    object_type    object_name    owner_name    auth_type    is_grantable    
-U1     U2     CLASS     tbl     U1     SELECT     YES     
-U1     U2     CLASS     tbl     U1     INSERT     YES     
-U1     U2     CLASS     tbl     U1     UPDATE     YES     
-U1     U2     CLASS     tbl     U1     DELETE     YES     
 U1     U2     CLASS     tbl     U1     ALTER     YES     
-U1     U2     CLASS     tbl     U1     INDEX     YES     
+U1     U2     CLASS     tbl     U1     DELETE     YES     
 U1     U2     CLASS     tbl     U1     EXECUTE     YES     
+U1     U2     CLASS     tbl     U1     INDEX     YES     
+U1     U2     CLASS     tbl     U1     INSERT     YES     
+U1     U2     CLASS     tbl     U1     SELECT     YES     
+U1     U2     CLASS     tbl     U1     UPDATE     YES     
 
 ===================================================
     
@@ -292,24 +292,24 @@ grant SELECT, UPDATE, INSERT, DELETE on u1.tbl to u4
 0
 ===================================================
 grantor_name    grantee_name    object_type    object_name    owner_name    auth_type    is_grantable    
-U1     U2     CLASS     tbl     U1     SELECT     YES     
-U1     U2     CLASS     tbl     U1     INSERT     YES     
-U1     U2     CLASS     tbl     U1     UPDATE     YES     
-U1     U2     CLASS     tbl     U1     DELETE     YES     
 U1     U2     CLASS     tbl     U1     ALTER     YES     
-U1     U2     CLASS     tbl     U1     INDEX     YES     
+U1     U2     CLASS     tbl     U1     DELETE     YES     
 U1     U2     CLASS     tbl     U1     EXECUTE     YES     
-U2     U3     CLASS     tbl     U1     SELECT     YES     
-U2     U3     CLASS     tbl     U1     INSERT     YES     
-U2     U3     CLASS     tbl     U1     UPDATE     YES     
-U2     U3     CLASS     tbl     U1     DELETE     YES     
+U1     U2     CLASS     tbl     U1     INDEX     YES     
+U1     U2     CLASS     tbl     U1     INSERT     YES     
+U1     U2     CLASS     tbl     U1     SELECT     YES     
+U1     U2     CLASS     tbl     U1     UPDATE     YES     
 U2     U3     CLASS     tbl     U1     ALTER     YES     
-U2     U3     CLASS     tbl     U1     INDEX     YES     
-U2     U3     CLASS     tbl     U1     EXECUTE     YES     
+U2     U3     CLASS     tbl     U1     DELETE     YES     
 U2     U4     CLASS     tbl     U1     DELETE     YES     
+U2     U3     CLASS     tbl     U1     EXECUTE     YES     
+U2     U3     CLASS     tbl     U1     INDEX     YES     
+U2     U3     CLASS     tbl     U1     INSERT     YES     
 U2     U4     CLASS     tbl     U1     INSERT     YES     
-U2     U4     CLASS     tbl     U1     UPDATE     YES     
+U2     U3     CLASS     tbl     U1     SELECT     YES     
 U2     U4     CLASS     tbl     U1     SELECT     YES     
+U2     U3     CLASS     tbl     U1     UPDATE     YES     
+U2     U4     CLASS     tbl     U1     UPDATE     YES     
 
 ===================================================
     
@@ -323,20 +323,20 @@ null
 0
 ===================================================
 grantor_name    grantee_name    object_type    object_name    owner_name    auth_type    is_grantable    
+U1     U2     CLASS     tbl     U1     ALTER     YES     
+U1     U2     CLASS     tbl     U1     DELETE     YES     
+U1     U2     CLASS     tbl     U1     EXECUTE     YES     
+U1     U2     CLASS     tbl     U1     INDEX     YES     
 U1     U2     CLASS     tbl     U1     INSERT     YES     
 U1     U2     CLASS     tbl     U1     UPDATE     YES     
-U1     U2     CLASS     tbl     U1     DELETE     YES     
-U1     U2     CLASS     tbl     U1     ALTER     YES     
-U1     U2     CLASS     tbl     U1     INDEX     YES     
-U1     U2     CLASS     tbl     U1     EXECUTE     YES     
-U2     U3     CLASS     tbl     U1     INSERT     YES     
-U2     U3     CLASS     tbl     U1     UPDATE     YES     
-U2     U3     CLASS     tbl     U1     DELETE     YES     
 U2     U3     CLASS     tbl     U1     ALTER     YES     
-U2     U3     CLASS     tbl     U1     INDEX     YES     
-U2     U3     CLASS     tbl     U1     EXECUTE     YES     
+U2     U3     CLASS     tbl     U1     DELETE     YES     
 U2     U4     CLASS     tbl     U1     DELETE     YES     
+U2     U3     CLASS     tbl     U1     EXECUTE     YES     
+U2     U3     CLASS     tbl     U1     INDEX     YES     
+U2     U3     CLASS     tbl     U1     INSERT     YES     
 U2     U4     CLASS     tbl     U1     INSERT     YES     
+U2     U3     CLASS     tbl     U1     UPDATE     YES     
 U2     U4     CLASS     tbl     U1     UPDATE     YES     
 
 ===================================================

--- a/sql/_35_fig_cake/grant_revoke_redefine/cases/cbrd_25582.sql
+++ b/sql/_35_fig_cake/grant_revoke_redefine/cases/cbrd_25582.sql
@@ -36,7 +36,7 @@ evaluate 'connect to u4, u1.tbl grant to u5';
 call login('u4','') on class db_user;
 GRANT SELECT ON u1.TBL TO u5 WITH GRANT OPTION;
 
-select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name;
+select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, grantee_name;
 
 
 evaluate 'connect to dba';
@@ -47,7 +47,7 @@ GRANT SELECT ON u1.TBL TO u1 WITH GRANT OPTION;
 evaluate 'init test';
 REVOKE SELECT ON u1.TBL FROM u2;
 
-select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name;
+select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, grantee_name;
 
 
 
@@ -74,19 +74,19 @@ evaluate 'connect to u4, u1.tbl grant to u5';
 call login('u4','') on class db_user;
 GRANT SELECT ON u1.TBL TO u5 WITH GRANT OPTION;
 
-select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name;
+select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, grantee_name;
 
 
 evaluate 'connect to u1, revoke to u1.tbl from u2';
 call login('u1','') on class db_user;
 REVOKE SELECT ON u1.TBL FROM u2;
 
-select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name;
+select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, grantee_name;
 
 evaluate 'init test, connect to dba';
 REVOKE SELECT ON u1.TBL FROM u3;
 
-select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name;
+select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, grantee_name;
 
 call login('dba','') on class db_user;
 
@@ -109,14 +109,14 @@ evaluate 'connect to u4, u1.tbl grant to u5';
 call login('u4','') on class db_user;
 GRANT SELECT ON u1.TBL TO u5 WITH GRANT OPTION;
 
-select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name;
+select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, auth_type;
 
 
 evaluate 'connect to u2, revoke to u1.tbl from u3';
 call login('u2','') on class db_user;
 REVOKE SELECT ON u1.TBL FROM u3;
 
-select * from db_auth where grantee_name != 'PUBLIC'  order by grantor_name;
+select * from db_auth where grantee_name != 'PUBLIC'  order by grantor_name, auth_type;
 
 
 evaluate 'connect to u1, test for cascade';
@@ -126,19 +126,19 @@ GRANT ALL PRIVILEGES ON u1.TBL TO u3 WITH GRANT OPTION;
 evaluate 'grant SELECT, UPDATE, INSERT, DELETE on u1.tbl to u4';
 GRANT SELECT, UPDATE, INSERT, DELETE ON u1.TBL TO u4 WITH GRANT OPTION;
 
-select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name;
+select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, auth_type;
 
 
 evaluate 'connect to dba, revoke to u1.tbl(SELECT) from u2 (cascade test)';
 call login('dba','') on class db_user;
 REVOKE SELECT ON u1.TBL FROM u2;
 
-select * from db_auth where grantee_name != 'PUBLIC'  order by grantor_name;
+select * from db_auth where grantee_name != 'PUBLIC'  order by grantor_name, auth_type;
 
 evaluate 'init test: revoke to u1.tbl(ALL PRIVILEGES) from u2 (cascade test)';
 REVOKE ALL PRIVILEGES ON u1.TBL FROM u2;
 
-select * from db_auth where grantee_name != 'PUBLIC'  order by grantor_name;
+select * from db_auth where grantee_name != 'PUBLIC'  order by grantor_name, auth_type;
 
 
 
@@ -194,7 +194,7 @@ GRANT SELECT ON u1.TBL TO u2 WITH GRANT OPTION;
 GRANT SELECT ON u1.TBL TO u3 WITH GRANT OPTION;
 GRANT SELECT ON u1.TBL TO u4 WITH GRANT OPTION;
 
-select * from db_auth where grantee_name != 'PUBLIC';
+select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, grantee_name;
 
 
 
@@ -204,12 +204,12 @@ REVOKE SELECT ON u1.TBL FROM u2;
 REVOKE SELECT ON u1.TBL FROM u3;
 REVOKE SELECT ON u1.TBL FROM u4;
 
-select * from db_auth where grantee_name != 'PUBLIC';
+select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, grantee_name;
 
 evaluate 'connect to u1 and revoke u5';
 REVOKE SELECT ON u1.TBL FROM u5;
 
-select * from db_auth where grantee_name != 'PUBLIC';
+select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, grantee_name;
 
 
 evaluate 'test done';


### PR DESCRIPTION
This is an effort made to stabilize test cases, as defined in http://jira.cubrid.org/browse/CUBRIDQA-1136

현재 윈도우에서 order by 문의 정렬이 다르게 출력되어 fail하고 있습니다. object_name이 같은 경우 매번 같은 정렬을 보장할수 없기에 auth_type을 order by절에 추가하였습니다.

SELECT * FROM db_auth WHERE grantee_name = 'T1' ORDER BY object_name, **auth_type**;

