### PR TITLE
[CBRD-25801]Backport from develop to 11.3 for Problems that occur when a hidden column is generated due to ORDER BY clause in a subquery(#2047)

### DIFF
--- a/sql/_13_issues/_25_1h/answers/cbrd_25801.answer
+++ b/sql/_13_issues/_25_1h/answers/cbrd_25801.answer
@@ -1,0 +1,51 @@
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+1
+===================================================
+1
+===================================================
+0
+===================================================
+1
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tb)
+
+  rewritten query: (select [dba.tb].ca, [dba.tb].cb, [dba.tb].cc from [dba.tb] [dba.tb] order by ?, ? for orderby_num()<= ?:? )
+
+  TABLE SCAN (d?)
+
+  rewritten query: (select d?.ca from (select [dba.tb].ca, [dba.tb].cb, [dba.tb].cc from [dba.tb] [dba.tb] order by ?, ? for orderby_num()<= ?:? ) d? (ca, cb, cc))
+
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select [dba.ta],class [dba.ta], ?:?  as [ta.cb] from [dba.ta] [dba.ta] where [dba.ta].ca=(select d?.ca from (select [dba.tb].ca, [dba.tb].cb, [dba.tb].cc from [dba.tb] [dba.tb] order by ?, ? for orderby_num()<= ?:? ) d? (ca, cb, cc))
+
+
+Trace Statistics:
+  UPDATE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SUBQUERY (uncorrelated)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+            SUBQUERY (uncorrelated)
+              SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+                SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+                ORDERBY (time: ?, topnsort: true)
+     
+
+===================================================
+0
+===================================================
+0

--- a/sql/_13_issues/_25_1h/cases/cbrd_25801.sql
+++ b/sql/_13_issues/_25_1h/cases/cbrd_25801.sql
@@ -1,0 +1,21 @@
+-- This issue verified CBRD-25801
+-- This issue was regression of CBRD-24181.
+-- Before fix :
+-- Hidden columns were redundantly added, causing the rewriting process to run twice.
+-- After fix :
+-- If the original select list has no hidden attribute, remove the hidden property so that the rewriting process runs only once.
+
+drop table if exists ta, tb;
+
+create table ta (ca int, cb int);
+create table tb (ca int, cb int, cc int);
+
+insert into ta values (1, 2);
+insert into tb values (1, 2, 3);
+
+set trace on;
+update /*+ recompile */ ta set cb = 1 where ca = (select ca from tb order by cb, cc limit 1);
+show trace;
+set trace off;
+
+drop table if exists ta, tb;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25801