### PR TITLE
[CBRD-25801] remove fetch_time on answer.

### DIFF
--- a/sql/_13_issues/_25_1h/answers/cbrd_25801.answer
+++ b/sql/_13_issues/_25_1h/answers/cbrd_25801.answer
@@ -31,16 +31,16 @@ Query Plan:
 
 
 Trace Statistics:
-  UPDATE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  UPDATE (time: ?, fetch: ?, ioread: ?)
     SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     SUBQUERY (uncorrelated)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, ioread: ?)
         SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         SUBQUERY (uncorrelated)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
             SUBQUERY (uncorrelated)
-              SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+              SELECT (time: ?, fetch: ?, ioread: ?)
                 SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
                 ORDERBY (time: ?, topnsort: true)
      


### PR DESCRIPTION
#2050 에서 백포트할때 11.3에는 포함되지 않는 fetch_time 이 answer 에 포함되어 circleci 에서 fail 됨.
이에따라 answer 에서 fetch_time 삭제.