### PR TITLE
[CBRD-25755] Revert "[CBRD-25416] Add temporary exclusion case to Ha_repl test"

### DIFF
--- a/sql/config/daily_regression_test_exclude_list_ha_repl.conf
+++ b/sql/config/daily_regression_test_exclude_list_ha_repl.conf
@@ -305,6 +305,3 @@ sql/_27_banana_qa/issue_8909_unquoted_keywords/cases/_004_update.test
 
 #[PERMANENT] don't support 'call' on HA.
 sql/_33_elderberry/cbrd_23845/cases/_02_permission_check.test
-
-#[temporary] CBRD-25416 , If the problem is resolved, this case should be removed from this exclude file.
-sql/_08_javasp/cases/case_cte_01.test


### PR DESCRIPTION
Reverts CUBRID/cubrid-testcases#1916
http://jira.cubrid.org/browse/CBRD-25755 에서 해결되어 TC를 regression test에서 다시 수행하도록 합니다.