### PR TITLE
[CBRD-25830] update two TCs according to the engine update

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_04_expression/_17_string_concat/_01_concat/cases/04_17_01-03_op_strcc_err.sql
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_17_string_concat/_01_concat/cases/04_17_01-03_op_strcc_err.sql
@@ -6,7 +6,7 @@
 
 create or replace procedure t() as
 begin
-    dbms_output.put_line( 10. || null);
+    dbms_output.put_line( 10.0 || null);
 end;
 
 select count(*) from db_stored_procedure where sp_name = 't';

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_17_string_concat/_01_concat/cases/04_17_01-03_op_strcc_err2.sql
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_17_string_concat/_01_concat/cases/04_17_01-03_op_strcc_err2.sql
@@ -6,8 +6,8 @@
 
 create or replace procedure t() as
 begin
-    dbms_output.put_line( 10. || .5);
-    dbms_output.put_line( 10. );
+    dbms_output.put_line( 10.0 || .5);
+    dbms_output.put_line( 10.0 );
     dbms_output.put_line( .5 );
 end;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25830

PL/CSQL FOR 문에서 <int> .. <int> 구문에 공백없이 붙여 썼을 때 파싱 에러가 발생하는 문제를 해결하기 위해 
큐브리드 엔진과는 달리 <int>.  모양의 (소수점 오른쪽에 자리수가 없는 형태) 소수 리터럴을 허용하지 않도록 
PL/CSQL 스펙을 수정했습니다. 

관려해서 TC 두 건의 수정이 필요합니다. 