### PR TITLE
[CBRD-25189] Revised Test Case for Compile-Time Error Fix in STR_TO_DATE Function

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_04_type_convert_function/answers/04_04_03_04_bfn_type_str_to_date.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_04_type_convert_function/answers/04_04_03_04_bfn_type_str_to_date.answer
@@ -1,7 +1,23 @@
 ===================================================
 Error:-1360
-In line 5, column 22
-Stored procedure compile error: function STR_TO_DATE is undefined or given wrong number or types of arguments
+In line 3, column 40
+Stored procedure compile error: second argument to STR_TO_DATE function must be a string literal
+
+===================================================
+Error:-894
+Stored procedure/function 'dba.t1' does not exist.
+
+===================================================
+Error:-894
+Stored procedure/function 'dba.t1' does not exist.
+
+===================================================
+0
+
+===================================================
+count(*)    
+1     
+
 
 ===================================================
 count(*)    
@@ -9,15 +25,26 @@ count(*)
 
 
 ===================================================
-count(*)    
-0     
+    
+null     
 
 
+12:00:00 PM
+12:00:00 AM
+11:30:34.000 AM 05/01/1999
+11:30:34.000 AM 05/01/1999
+11:30:34.000 AM 05/01/1999
+11:30:34.000 AM 05/01/1999
+11:30:34.000 PM 05/01/1999
+11:30:34.000 PM 05/01/1999
+11:30:34 AM
+11:30:34 AM
+11:30:34 AM
+11:49:59.123 PM 10/31/1999
+11:49:59.100 PM 10/31/1999
+11:49:59.001 PM 10/31/1999
+11:49:59.000 PM 10/31/1999
+11:49:59.000 PM 10/31/1999
 ===================================================
-Error:-894
-Stored procedure/function 'dba.t' does not exist.
-
-===================================================
-Error:-894
-Stored procedure/function 'dba.t' does not exist.
+0
 

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_04_type_convert_function/cases/04_04_03_04_bfn_type_str_to_date.sql
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_04_type_convert_function/cases/04_04_03_04_bfn_type_str_to_date.sql
@@ -2,11 +2,19 @@
 
 -- normal: basic usage of a builtin function call
 
-create or replace procedure t () as
+create or replace procedure t1 () as
 begin
     -- STR_TO_DATE() parse error
     dbms_output.put_line(STR_TO_DATE(NULL, NULL));
     dbms_output.put_line(STR_TO_DATE('00:00:00 AM', NULL));
+end;
+
+call t1();
+drop procedure t1;
+
+-- [Revised] The bug in the built-in function STR_TO_DATE('12:00:00 AM', '%r') was fixed by CBRD-25189.
+create or replace procedure t2 () as
+begin
     dbms_output.put_line(STR_TO_DATE('12:00:00 PM', '%r'));
     dbms_output.put_line(STR_TO_DATE('12:00:00 AM', '%r'));
 
@@ -28,11 +36,11 @@ begin
     dbms_output.put_line(STR_TO_DATE('1999-10-31 23:49:59.000', '%Y-%m-%d %H:%i:%s.%f'));
 end;
 
-select count(*) from db_stored_procedure where sp_name = 't';
-select count(*) from db_stored_procedure_args where sp_name = 't';
+select count(*) from db_stored_procedure where sp_name = 't2';
+select count(*) from db_stored_procedure_args where sp_name = 't2';
 
-call t();
+call t2();
 
-drop procedure t;
+drop procedure t2;
 
 --+ server-message off


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-25189

에러가 발생했던 구문이 bug fix되어 정상 수행되도록 바뀌었습니다.
` dbms_output.put_line(STR_TO_DATE('12:00:00 PM', '%r'));`
` dbms_output.put_line(STR_TO_DATE('12:00:00 AM', '%r'));`

하나의 프로시저로 모든 시나리오를 테스트하면 초기 에러 때문에 뒷부분이 제대로 테스트되지 않습니다.
따라서 에러가 발생하는 케이스를 제외하고 나머지는 다른 프로시저로 생성하여 테스트하도록 수정합니다.