### PR TITLE
[CBRD-1136] Modified test case to ensure correct ordering (added a column to an order by clause)

### DIFF
--- a/sql/_35_fig_cake/grant_revoke_redefine/cases/cbrd_25486_04.sql
+++ b/sql/_35_fig_cake/grant_revoke_redefine/cases/cbrd_25486_04.sql
@@ -24,7 +24,7 @@ GRANT ALTER ON u1.tbl2 TO u3 WITH GRANT OPTION;
 
 evaluate 'connect to dba';
 call login('dba','') on class db_user;
-select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name;
+select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, object_name;
 
 select owner.name, grants from db_authorization where owner.name != 'PUBLIC' order by owner.name;
 


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-25486

grantor_name 칼럼의 U1이 같은 행이 두개가 있어서 결과의 순서가 바뀌는 경우가 있습니다. 이 쿼리에 object_name을 추가해 순서를 보장할수 있도록 수정하였습니다.

===================================================
```
grantor_name grantee_name object_type object_name owner_name auth_type is_grantable
U1 U2 CLASS tbl U1 ALTER NO
U1 U2 CLASS tbl2 U1 ALTER YES
U2 U3 CLASS tbl2 U1 ALTER YES
```

===================================================