### PR TITLE
[CBRD-25805] The users authorized to execute the ALTER PROCEDURE .. [COMMENT|COMPILE] statement have been expanded, resulting in changes to behavior and error messages

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_04_expression/_23_alter/answers/01_alter_compile.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_23_alter/answers/01_alter_compile.answer
@@ -47,8 +47,8 @@ null
 
 
 ===================================================
-Error:-140
-Operation "change stored procedure owner" can only be performed by the DBA or a DBA group member.
+Error:-894
+Stored procedure/function 'public.test_tbl' does not exist.
 
 ===================================================
     


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25805

SP의 소유자를 변경하는 SQL 구문과 메서드를 리팩토링하는 과정에서 ALTER PROCEDURE의 COMMENT 및 COMPILE 구문에 버그가 있어 이를 수정했습니다.
- ALTER [PROCEDURE|FUNCTION] .. OWNER TO 구문은 DBA 및 DBA 멤버만 사용할 수 있습니다.
- OWNER TO 외에도 COMMENT, COMPILE 구문을 각각 독립적으로 사용할 수 있으나, 동일한 함수를 사용하므로 기본적으로 DBA 및 DBA 멤버만 실행 가능했습니다.

수정된 코드에서는 COMMENT 및 COMPILE 구문의 실행 사용자를 확장하여 에러 메시지가 변경되었습니다.
- AS-IS: DBA, DBA 멤버
- TO-BE: DBA, DBA 멤버, 소유자, 소유자 멤버

`* OWNER TO 구문은 기존과 동일하게 DBA 및 DBA 멤버만 사용할 수 있습니다.

따라서, 수정된 TC에서는 test_tbl의 SP 소유자가 dba인 상태에서 public 사용자가 test_tbl SP에 대해 COMPILE 구문을 실행하려 했습니다. 
이때 **[user_schema]** 가 생략되어 public.test_tbl SP를 찾았으나 존재하지 않아 에러 메시지가 변경되었습니다.
