### PR TITLE
[CBRD-25280] update one answer

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_06_information_function/answers/04_04_03_06_bfn_info_inet.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_06_information_function/answers/04_04_03_06_bfn_info_inet.answer
@@ -1,7 +1,10 @@
 ===================================================
-Error:-1360
-In line 4, column 22
-Stored procedure compile error: function INET_NTOA is undefined or given wrong number or types of arguments
+0
+
+===================================================
+count(*)    
+1     
+
 
 ===================================================
 count(*)    
@@ -9,15 +12,12 @@ count(*)
 
 
 ===================================================
-count(*)    
-0     
+    
+null     
 
 
+3232300543
+192.168.253.255
 ===================================================
-Error:-894
-Stored procedure/function 'dba.t' does not exist.
-
-===================================================
-Error:-894
-Stored procedure/function 'dba.t' does not exist.
+0
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25280

PL/CSQL의 Static SQL에 대한 시맨틱 검사 중에 constant folding 을 하던 것을 하지 않도록 수정했습니다. 
constant folding 중에 발생하던 에러가 사라져서 답지 결과가 바뀐 것을 반영했습니다. 
inet_ntoa 에 null 인자를 주었을 때 에러가 났던 것은 inet_ntoa의 기존 constant folding 로직의 버그로 보입니다. 
(참고: 이슈 http://jira.cubrid.org/browse/CBRD-25880)