### PR TITLE
[CBRD-25872] updated 10 answers

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_02_all_types/answers/02_01_05-05_float_param_value.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_01_parameter/_02_all_types/answers/02_01_05-05_float_param_value.answer
@@ -4,7 +4,7 @@
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 7, column 12) data overflow on data type FLOAT: -3.402823466E39
+  (line 7, column 12) data overflow on data type FLOAT: -3.402823466000000e+39
 
 i_min=-3.402823e+38
 i_max=3.402823e+38
@@ -21,12 +21,12 @@ i_max=3.402823e+38
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  data overflow on data type FLOAT: -3.402823466E39
+  data overflow on data type FLOAT: -3.402823466000000e+39
 
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  data overflow on data type FLOAT: 3.402823466E39
+  data overflow on data type FLOAT: 3.402823466000000e+39
 
 ===================================================
 Error:-427

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/01_error_percent_type_variable.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/01_error_percent_type_variable.answer
@@ -148,7 +148,7 @@ ERROR : Data overflow on data type "float".
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 4, column 17) data overflow on data type FLOAT: -3.402823466E39
+  (line 4, column 17) data overflow on data type FLOAT: -3.402823466000000e+39
 
 ===================================================
     
@@ -161,7 +161,7 @@ ERROR : Data overflow on data type "float".
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 4, column 17) data overflow on data type FLOAT: 3.402823466E39
+  (line 4, column 17) data overflow on data type FLOAT: 3.402823466000000e+39
 
 ===================================================
     

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/02_error_percent_type_constant.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/02_error_percent_type_constant.answer
@@ -148,7 +148,7 @@ ERROR : Data overflow on data type "float".
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 2, column 52) data overflow on data type FLOAT: -3.402823466E39
+  (line 2, column 52) data overflow on data type FLOAT: -3.402823466000000e+39
 
 ===================================================
     
@@ -161,7 +161,7 @@ ERROR : Data overflow on data type "float".
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 2, column 52) data overflow on data type FLOAT: 3.402823466E39
+  (line 2, column 52) data overflow on data type FLOAT: 3.402823466000000e+39
 
 ===================================================
     

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/04_error_percent_type_parameter.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/04_error_percent_type_parameter.answer
@@ -164,12 +164,12 @@ T_FLOAT
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  data overflow on data type FLOAT: -3.402823466E39
+  data overflow on data type FLOAT: -3.402823466000000e+39
 
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  data overflow on data type FLOAT: 3.402823466E39
+  data overflow on data type FLOAT: 3.402823466000000e+39
 
 ===================================================
     

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/05_error_percent_type_return.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/05_error_percent_type_return.answer
@@ -165,7 +165,7 @@ Stored procedure execute error:
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 1, column 111) data overflow on data type FLOAT: -3.402823466E39
+  (line 1, column 111) data overflow on data type FLOAT: -3.402823466000000e+39
 
 ===================================================
 0
@@ -173,7 +173,7 @@ Stored procedure execute error:
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 1, column 112) data overflow on data type FLOAT: 3.402823466E39
+  (line 1, column 112) data overflow on data type FLOAT: 3.402823466000000e+39
 
 ===================================================
     
@@ -186,7 +186,7 @@ Stored procedure execute error:
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 1, column 111) data overflow on data type FLOAT: -3.402823466E39
+  (line 1, column 111) data overflow on data type FLOAT: -3.402823466000000e+39
 
 ===================================================
 0
@@ -194,7 +194,7 @@ Stored procedure execute error:
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 1, column 112) data overflow on data type FLOAT: 3.402823466E39
+  (line 1, column 112) data overflow on data type FLOAT: 3.402823466000000e+39
 
 ===================================================
     

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/21_error_viewtable_percent_type_variable.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/21_error_viewtable_percent_type_variable.answer
@@ -142,7 +142,7 @@ ERROR : Data overflow on data type "float".
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 4, column 17) data overflow on data type FLOAT: -3.402823466E39
+  (line 4, column 17) data overflow on data type FLOAT: -3.402823466000000e+39
 
 ===================================================
     
@@ -155,7 +155,7 @@ ERROR : Data overflow on data type "float".
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 4, column 17) data overflow on data type FLOAT: 3.402823466E39
+  (line 4, column 17) data overflow on data type FLOAT: 3.402823466000000e+39
 
 ===================================================
     

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/22_error_viewtable_percent_type_constant.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/22_error_viewtable_percent_type_constant.answer
@@ -142,7 +142,7 @@ ERROR : Data overflow on data type "float".
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 2, column 52) data overflow on data type FLOAT: -3.402823466E39
+  (line 2, column 52) data overflow on data type FLOAT: -3.402823466000000e+39
 
 ===================================================
     
@@ -155,7 +155,7 @@ ERROR : Data overflow on data type "float".
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 2, column 52) data overflow on data type FLOAT: 3.402823466E39
+  (line 2, column 52) data overflow on data type FLOAT: 3.402823466000000e+39
 
 ===================================================
     

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/24_error_viewtable_percent_type_parameter.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/24_error_viewtable_percent_type_parameter.answer
@@ -158,12 +158,12 @@ T_FLOAT
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  data overflow on data type FLOAT: -3.402823466E39
+  data overflow on data type FLOAT: -3.402823466000000e+39
 
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  data overflow on data type FLOAT: 3.402823466E39
+  data overflow on data type FLOAT: 3.402823466000000e+39
 
 ===================================================
     

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/25_error_viewtable_percent_type_return.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/25_error_viewtable_percent_type_return.answer
@@ -159,7 +159,7 @@ Stored procedure execute error:
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 1, column 111) data overflow on data type FLOAT: -3.402823466E39
+  (line 1, column 111) data overflow on data type FLOAT: -3.402823466000000e+39
 
 ===================================================
 0
@@ -167,7 +167,7 @@ Stored procedure execute error:
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 1, column 112) data overflow on data type FLOAT: 3.402823466E39
+  (line 1, column 112) data overflow on data type FLOAT: 3.402823466000000e+39
 
 ===================================================
     
@@ -180,7 +180,7 @@ Stored procedure execute error:
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 1, column 111) data overflow on data type FLOAT: -3.402823466E39
+  (line 1, column 111) data overflow on data type FLOAT: -3.402823466000000e+39
 
 ===================================================
 0
@@ -188,7 +188,7 @@ Stored procedure execute error:
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 1, column 112) data overflow on data type FLOAT: 3.402823466E39
+  (line 1, column 112) data overflow on data type FLOAT: 3.402823466000000e+39
 
 ===================================================
     

--- a/sql/_05_plcsql/_01_testspec/_05_bug_fix/answers/17_float_double_overflow.answer
+++ b/sql/_05_plcsql/_01_testspec/_05_bug_fix/answers/17_float_double_overflow.answer
@@ -4,7 +4,7 @@
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 2, column 19) data overflow on data type FLOAT: 3.402823466E39
+  (line 2, column 19) data overflow on data type FLOAT: 3.402823466000000e+39
 
 ===================================================
 0
@@ -15,7 +15,7 @@ Stored procedure execute error:
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 2, column 19) data overflow on data type FLOAT: -3.402823466E39
+  (line 2, column 19) data overflow on data type FLOAT: -3.402823466000000e+39
 
 ===================================================
 0


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25872

수정 과정에서 에러 메시지 안에 소수가 포함된 경우 Java 의 출력 방식을 사용하던 것을 
큐브리드의 출력 방식으로 변경하여 결과가 수정되었습니다. 

10건 모두 double literal 을 출력하는 건이고 
큐브리드에서처럼 소수점 이하 15자리까지 출력하도록 변경되었습니다. 