### PR TITLE
[CUBVEC-19] CODEOWNERS를 cubvec-team로 설정

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,8 +17,5 @@
 
 # assign reviewers about all files
 
-# required default reviewer 
-/sql/ @tw-kang @kwonhoil @ssihil
-/sql/_05_plcsql/ @kwonhoil @ssihil
-/medium/ @tw-kang @kwonhoil @ssihil
-/isolation/ @zionyun @kwonhoil @ssihil
+# required default reviewer
+* @CUBRID/cubvec-team


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-19

### Purpose
* cubvec 브랜치의 코드 소유자 변경

### Remarks
* @mhoh3963 cubvec-team에 쓰기 권한 요청드립니다.
* sql에 벡터DB 테스트 시나리오를 추가하고, 리뷰는 cubvec-team에서 수행할 예정입니다.