### PR TITLE
[CBRD-1136] Modified a grant revoke TC to ensure correct ordering (added ORDER BY clauses to SELECT queries) 

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_06_authorization/cases/01_normal_grant_revoke.sql
+++ b/sql/_05_plcsql/_01_testspec/_06_authorization/cases/01_normal_grant_revoke.sql
@@ -7,7 +7,7 @@ CREATE OR REPLACE FUNCTION sp1() return varchar as begin return 'hello'; end;
 CREATE OR REPLACE PROCEDURE sp2() as begin dbms_output.put_line('call sp2'); end;
 CREATE USER u1;
 SELECT grantor.name, grantee.name, object_type, object_of, auth_type, is_grantable FROM _db_auth where grantee.name = 'U1';
-SELECT unique_name, sp_name, sp_type, return_type, arg_count, target_method, owner.name FROM _db_stored_procedure where sp_name like 'sp%';
+SELECT unique_name, sp_name, sp_type, return_type, arg_count, target_method, owner.name FROM _db_stored_procedure where sp_name like 'sp%' ORDER BY unique_name;
 
 call login('u1','') on class db_user;
 SELECT dba.sp1();
@@ -25,7 +25,7 @@ call login('u1','') on class db_user;
 evaluate 'CUBRID does not support synonyms for procedures.';
 CREATE SYNONYM u1.sp1 FOR dba.sp1;
 CREATE SYNONYM u1.sp2 FOR dba.sp2;
-select * from db_synonym where synonym_owner_name='U1';
+select * from db_synonym where synonym_owner_name='U1' ORDER BY synonym_name;
 
 evaluate '2-1. error-synonym.( SELECt sp1(); )'; 
 SELECT sp1();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1136

Added order by clauses to SELECT queries with 2> unique results to prevent unstable test cases. 

note: Regresion에서 fail한 unstable TC에 ORDER BY문을 추가 후 답지 변경없이 sql 및 sql_by_cci 결과는 pass가 나오는 것을 확인했습니다. 