### PR TITLE
[CBRD-25866] cut 'expecting' clauses in PL/CSQL syntax error messages

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_06_with_decl_part/answers/01_01_06-02_error_keyword_decl_name.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_06_with_decl_part/answers/01_01_06-02_error_keyword_decl_name.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'while' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'while'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-01_error_begin_end.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-01_error_begin_end.answer
@@ -1,10 +1,10 @@
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'dbms_output' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'dbms_output'
 
 ===================================================
 Error:-1360
 In line 2, column 6
-Stored procedure compile error: extraneous input ';' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: extraneous input ';'
 

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_constant.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_constant.answer
@@ -6,7 +6,7 @@ AND
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'AND' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'AND'
 
 ===================================================
 'AS'    
@@ -16,7 +16,7 @@ AS
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'AS' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'AS'
 
 ===================================================
 'BETWEEN'    
@@ -26,7 +26,7 @@ BETWEEN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'BETWEEN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'BETWEEN'
 
 ===================================================
 'BIGINT'    
@@ -36,7 +36,7 @@ BIGINT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'BIGINT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'BIGINT'
 
 ===================================================
 'BOOLEAN'    
@@ -46,7 +46,7 @@ BOOLEAN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'BOOLEAN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'BOOLEAN'
 
 ===================================================
 'BY'    
@@ -56,7 +56,7 @@ BY
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'BY' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'BY'
 
 ===================================================
 'CHAR'    
@@ -66,7 +66,7 @@ CHAR
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'CHAR' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'CHAR'
 
 ===================================================
 'CLOSE'    
@@ -76,7 +76,7 @@ CLOSE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'CLOSE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'CLOSE'
 
 ===================================================
 'COMMIT'    
@@ -86,7 +86,7 @@ COMMIT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'COMMIT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'COMMIT'
 
 ===================================================
 'CONSTANT'    
@@ -96,7 +96,7 @@ CONSTANT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'CONSTANT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'CONSTANT'
 
 ===================================================
 'CONTINUE'    
@@ -106,7 +106,7 @@ CONTINUE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'CONTINUE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'CONTINUE'
 
 ===================================================
 'CREATE'    
@@ -116,7 +116,7 @@ CREATE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'CREATE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'CREATE'
 
 ===================================================
 'CURSOR'    
@@ -126,7 +126,7 @@ CURSOR
 ===================================================
 Error:-1360
 In line 2, column 8
-Stored procedure compile error: mismatched input 'CONSTANT' expecting {REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'CONSTANT'
 
 ===================================================
 'DATE'    
@@ -136,7 +136,7 @@ DATE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DATE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATE'
 
 ===================================================
 'DATETIME'    
@@ -146,7 +146,7 @@ DATETIME
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DATETIME' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATETIME'
 
 ===================================================
 'DATETIMELTZ'    
@@ -156,7 +156,7 @@ DATETIMELTZ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DATETIMELTZ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATETIMELTZ'
 
 ===================================================
 'DATETIMETZ'    
@@ -166,7 +166,7 @@ DATETIMETZ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DATETIMETZ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATETIMETZ'
 
 ===================================================
 'DEC'    
@@ -176,7 +176,7 @@ DEC
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DEC' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DEC'
 
 ===================================================
 'DECIMAL'    
@@ -186,7 +186,7 @@ DECIMAL
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DECIMAL' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DECIMAL'
 
 ===================================================
 'DECLARE'    
@@ -196,7 +196,7 @@ DECLARE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DECLARE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DECLARE'
 
 ===================================================
 'DEFAULT'    
@@ -206,7 +206,7 @@ DEFAULT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DEFAULT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DEFAULT'
 
 ===================================================
 'DIV'    
@@ -216,7 +216,7 @@ DIV
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DIV' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DIV'
 
 ===================================================
 'DOUBLE'    
@@ -226,7 +226,7 @@ DOUBLE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DOUBLE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DOUBLE'
 
 ===================================================
 'ELSE'    
@@ -236,7 +236,7 @@ ELSE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'ELSE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'ELSE'
 
 ===================================================
 'ELSIF'    
@@ -246,7 +246,7 @@ ELSIF
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'ELSIF' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'ELSIF'
 
 ===================================================
 'END'    
@@ -277,7 +277,7 @@ ESCAPE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'ESCAPE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'ESCAPE'
 
 ===================================================
 'EXCEPTION'    
@@ -287,7 +287,7 @@ EXCEPTION
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'EXCEPTION' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'EXCEPTION'
 
 ===================================================
 'EXECUTE'    
@@ -297,7 +297,7 @@ EXECUTE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'EXECUTE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'EXECUTE'
 
 ===================================================
 'EXIT'    
@@ -307,7 +307,7 @@ EXIT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'EXIT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'EXIT'
 
 ===================================================
 'FALSE'    
@@ -317,7 +317,7 @@ FALSE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'FALSE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'FALSE'
 
 ===================================================
 'FETCH'    
@@ -327,7 +327,7 @@ FETCH
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'FETCH' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'FETCH'
 
 ===================================================
 'FLOAT'    
@@ -337,7 +337,7 @@ FLOAT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'FLOAT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'FLOAT'
 
 ===================================================
 'FOR'    
@@ -347,7 +347,7 @@ FOR
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'FOR' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'FOR'
 
 ===================================================
 'IMMEDIATE'    
@@ -357,7 +357,7 @@ IMMEDIATE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'IMMEDIATE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'IMMEDIATE'
 
 ===================================================
 'IN'    
@@ -367,7 +367,7 @@ IN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'IN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'IN'
 
 ===================================================
 'INT'    
@@ -377,7 +377,7 @@ INT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'INT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'INT'
 
 ===================================================
 'INTEGER'    
@@ -387,7 +387,7 @@ INTEGER
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'INTEGER' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'INTEGER'
 
 ===================================================
 'INTO'    
@@ -397,7 +397,7 @@ INTO
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'INTO' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'INTO'
 
 ===================================================
 'IS'    
@@ -407,7 +407,7 @@ IS
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'IS' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'IS'
 
 ===================================================
 'LIKE'    
@@ -417,7 +417,7 @@ LIKE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'LIKE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIKE'
 
 ===================================================
 'LIST'    
@@ -427,7 +427,7 @@ LIST
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'LIST' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIST'
 
 ===================================================
 'MOD'    
@@ -437,7 +437,7 @@ MOD
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'MOD' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'MOD'
 
 ===================================================
 'MULTISET'    
@@ -447,7 +447,7 @@ MULTISET
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'MULTISET' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'MULTISET'
 
 ===================================================
 'NOT'    
@@ -457,7 +457,7 @@ NOT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'NOT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'NOT'
 
 ===================================================
 'NULL'    
@@ -467,7 +467,7 @@ NULL
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'NULL' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'NULL'
 
 ===================================================
 'NUMERIC'    
@@ -477,7 +477,7 @@ NUMERIC
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'NUMERIC' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'NUMERIC'
 
 ===================================================
 'OPEN'    
@@ -487,7 +487,7 @@ OPEN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'OPEN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'OPEN'
 
 ===================================================
 'OR'    
@@ -497,7 +497,7 @@ OR
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'OR' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'OR'
 
 ===================================================
 'OUT'    
@@ -507,7 +507,7 @@ OUT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'OUT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'OUT'
 
 ===================================================
 'PRAGMA'    
@@ -527,7 +527,7 @@ RAISE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'RAISE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'RAISE'
 
 ===================================================
 'REAL'    
@@ -537,7 +537,7 @@ REAL
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'REAL' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'REAL'
 
 ===================================================
 'REPLACE'    
@@ -547,7 +547,7 @@ REPLACE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'REPLACE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'REPLACE'
 
 ===================================================
 'RETURN'    
@@ -557,7 +557,7 @@ RETURN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'RETURN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'RETURN'
 
 ===================================================
 'REVERSE'    
@@ -575,7 +575,7 @@ ROLLBACK
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'ROLLBACK' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'ROLLBACK'
 
 ===================================================
 'SEQUENCE'    
@@ -585,7 +585,7 @@ SEQUENCE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SEQUENCE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SEQUENCE'
 
 ===================================================
 'SET'    
@@ -595,7 +595,7 @@ SET
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SET' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SET'
 
 ===================================================
 'SETEQ'    
@@ -605,7 +605,7 @@ SETEQ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SETEQ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SETEQ'
 
 ===================================================
 'SETNEQ'    
@@ -615,7 +615,7 @@ SETNEQ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SETNEQ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SETNEQ'
 
 ===================================================
 'SHORT'    
@@ -625,7 +625,7 @@ SHORT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SHORT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SHORT'
 
 ===================================================
 'SMALLINT'    
@@ -635,7 +635,7 @@ SMALLINT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SMALLINT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SMALLINT'
 
 ===================================================
 'SQL'    
@@ -645,7 +645,7 @@ SQL
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SQL' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SQL'
 
 ===================================================
 'STRING'    
@@ -655,7 +655,7 @@ STRING
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'STRING' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'STRING'
 
 ===================================================
 'SUBSET'    
@@ -665,7 +665,7 @@ SUBSET
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SUBSET' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUBSET'
 
 ===================================================
 'SUBSETEQ'    
@@ -675,7 +675,7 @@ SUBSETEQ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SUBSETEQ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUBSETEQ'
 
 ===================================================
 'SUPERSET'    
@@ -685,7 +685,7 @@ SUPERSET
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SUPERSET' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUPERSET'
 
 ===================================================
 'SUPERSETEQ'    
@@ -695,7 +695,7 @@ SUPERSETEQ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SUPERSETEQ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUPERSETEQ'
 
 ===================================================
 'SYS_REFCURSOR'    
@@ -705,7 +705,7 @@ SYS_REFCURSOR
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SYS_REFCURSOR' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SYS_REFCURSOR'
 
 ===================================================
 'THEN'    
@@ -715,7 +715,7 @@ THEN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'THEN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'THEN'
 
 ===================================================
 'TIME'    
@@ -725,7 +725,7 @@ TIME
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'TIME' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIME'
 
 ===================================================
 'TIMESTAMP'    
@@ -735,7 +735,7 @@ TIMESTAMP
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'TIMESTAMP' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIMESTAMP'
 
 ===================================================
 'TIMESTAMPLTZ'    
@@ -745,7 +745,7 @@ TIMESTAMPLTZ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'TIMESTAMPLTZ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIMESTAMPLTZ'
 
 ===================================================
 'TIMESTAMPTZ'    
@@ -755,7 +755,7 @@ TIMESTAMPTZ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'TIMESTAMPTZ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIMESTAMPTZ'
 
 ===================================================
 'TRUE'    
@@ -765,7 +765,7 @@ TRUE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'TRUE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'TRUE'
 
 ===================================================
 'USING'    
@@ -775,7 +775,7 @@ USING
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'USING' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'USING'
 
 ===================================================
 'VARCHAR'    
@@ -785,7 +785,7 @@ VARCHAR
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'VARCHAR' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'VARCHAR'
 
 ===================================================
 'WHEN'    
@@ -795,7 +795,7 @@ WHEN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'WHEN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'WHEN'
 
 ===================================================
 'WHILE'    
@@ -805,7 +805,7 @@ WHILE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'WHILE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'WHILE'
 
 ===================================================
 'WORK'    
@@ -815,7 +815,7 @@ WORK
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'WORK' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'WORK'
 
 ===================================================
 'XOR'    
@@ -825,7 +825,7 @@ XOR
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'XOR' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'XOR'
 
 ===================================================
 'INSERT'    
@@ -835,7 +835,7 @@ INSERT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'INSERT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'INSERT'
 
 ===================================================
 'TRUNCATE'    
@@ -845,7 +845,7 @@ TRUNCATE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'TRUNCATE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'TRUNCATE'
 
 ===================================================
 'AUTONOMOUS_TRANSACTION'    
@@ -855,7 +855,7 @@ AUTONOMOUS_TRANSACTION
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'AUTONOMOUS_TRANSACTION' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'AUTONOMOUS_TRANSACTION'
 
 ===================================================
 'BEGIN'    
@@ -865,7 +865,7 @@ BEGIN
 ===================================================
 Error:-1360
 In line 3, column 1
-Stored procedure compile error: mismatched input 'begin' expecting {<EOF>, COMMENT}
+Stored procedure compile error: mismatched input 'begin'
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_constant.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_constant.answer
@@ -517,7 +517,7 @@ PRAGMA
 ===================================================
 Error:-1360
 In line 2, column 8
-Stored procedure compile error: mismatched input 'CONSTANT' expecting AUTONOMOUS_TRANSACTION
+Stored procedure compile error: mismatched input 'CONSTANT'
 
 ===================================================
 'RAISE'    

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_exception.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_exception.answer
@@ -6,7 +6,7 @@ AND
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'AND' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'AND'
 
 ===================================================
 'AS'    
@@ -16,7 +16,7 @@ AS
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'AS' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'AS'
 
 ===================================================
 'BETWEEN'    
@@ -26,7 +26,7 @@ BETWEEN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'BETWEEN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'BETWEEN'
 
 ===================================================
 'BIGINT'    
@@ -36,7 +36,7 @@ BIGINT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'BIGINT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'BIGINT'
 
 ===================================================
 'BOOLEAN'    
@@ -46,7 +46,7 @@ BOOLEAN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'BOOLEAN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'BOOLEAN'
 
 ===================================================
 'BY'    
@@ -56,7 +56,7 @@ BY
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'BY' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'BY'
 
 ===================================================
 'CHAR'    
@@ -66,7 +66,7 @@ CHAR
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'CHAR' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'CHAR'
 
 ===================================================
 'CLOSE'    
@@ -76,7 +76,7 @@ CLOSE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'CLOSE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'CLOSE'
 
 ===================================================
 'COMMIT'    
@@ -86,7 +86,7 @@ COMMIT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'COMMIT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'COMMIT'
 
 ===================================================
 'CONSTANT'    
@@ -96,7 +96,7 @@ CONSTANT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'CONSTANT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'CONSTANT'
 
 ===================================================
 'CONTINUE'    
@@ -106,7 +106,7 @@ CONTINUE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'CONTINUE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'CONTINUE'
 
 ===================================================
 'CREATE'    
@@ -116,7 +116,7 @@ CREATE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'CREATE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'CREATE'
 
 ===================================================
 'CURSOR'    
@@ -126,7 +126,7 @@ CURSOR
 ===================================================
 Error:-1360
 In line 7, column 19
-Stored procedure compile error: mismatched input 'CURSOR' expecting {REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'CURSOR'
 
 ===================================================
 'DATE'    
@@ -136,7 +136,7 @@ DATE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DATE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATE'
 
 ===================================================
 'DATETIME'    
@@ -146,7 +146,7 @@ DATETIME
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DATETIME' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATETIME'
 
 ===================================================
 'DATETIMELTZ'    
@@ -156,7 +156,7 @@ DATETIMELTZ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DATETIMELTZ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATETIMELTZ'
 
 ===================================================
 'DATETIMETZ'    
@@ -166,7 +166,7 @@ DATETIMETZ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DATETIMETZ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATETIMETZ'
 
 ===================================================
 'DEC'    
@@ -176,7 +176,7 @@ DEC
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DEC' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DEC'
 
 ===================================================
 'DECIMAL'    
@@ -186,7 +186,7 @@ DECIMAL
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DECIMAL' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DECIMAL'
 
 ===================================================
 'DECLARE'    
@@ -196,7 +196,7 @@ DECLARE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DECLARE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DECLARE'
 
 ===================================================
 'DEFAULT'    
@@ -206,7 +206,7 @@ DEFAULT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DEFAULT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DEFAULT'
 
 ===================================================
 'DIV'    
@@ -216,7 +216,7 @@ DIV
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DIV' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DIV'
 
 ===================================================
 'DOUBLE'    
@@ -226,7 +226,7 @@ DOUBLE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DOUBLE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DOUBLE'
 
 ===================================================
 'ELSE'    
@@ -236,7 +236,7 @@ ELSE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'ELSE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'ELSE'
 
 ===================================================
 'ELSIF'    
@@ -246,7 +246,7 @@ ELSIF
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'ELSIF' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'ELSIF'
 
 ===================================================
 'END'    
@@ -256,7 +256,7 @@ END
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'END' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'END'
 
 ===================================================
 Error:-493
@@ -289,7 +289,7 @@ ESCAPE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'ESCAPE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'ESCAPE'
 
 ===================================================
 'EXCEPTION'    
@@ -299,7 +299,7 @@ EXCEPTION
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'EXCEPTION' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'EXCEPTION'
 
 ===================================================
 'EXECUTE'    
@@ -309,7 +309,7 @@ EXECUTE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'EXECUTE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'EXECUTE'
 
 ===================================================
 'EXIT'    
@@ -319,7 +319,7 @@ EXIT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'EXIT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'EXIT'
 
 ===================================================
 'FALSE'    
@@ -329,7 +329,7 @@ FALSE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'FALSE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'FALSE'
 
 ===================================================
 'FETCH'    
@@ -339,7 +339,7 @@ FETCH
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'FETCH' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'FETCH'
 
 ===================================================
 'FLOAT'    
@@ -349,7 +349,7 @@ FLOAT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'FLOAT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'FLOAT'
 
 ===================================================
 'FOR'    
@@ -359,7 +359,7 @@ FOR
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'FOR' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'FOR'
 
 ===================================================
 'IMMEDIATE'    
@@ -369,7 +369,7 @@ IMMEDIATE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'IMMEDIATE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'IMMEDIATE'
 
 ===================================================
 'IN'    
@@ -379,7 +379,7 @@ IN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'IN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'IN'
 
 ===================================================
 'INT'    
@@ -389,7 +389,7 @@ INT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'INT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'INT'
 
 ===================================================
 'INTEGER'    
@@ -399,7 +399,7 @@ INTEGER
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'INTEGER' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'INTEGER'
 
 ===================================================
 'INTO'    
@@ -409,7 +409,7 @@ INTO
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'INTO' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'INTO'
 
 ===================================================
 'IS'    
@@ -419,7 +419,7 @@ IS
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'IS' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'IS'
 
 ===================================================
 'LIKE'    
@@ -429,7 +429,7 @@ LIKE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'LIKE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIKE'
 
 ===================================================
 'LIST'    
@@ -439,7 +439,7 @@ LIST
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'LIST' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIST'
 
 ===================================================
 'MOD'    
@@ -449,7 +449,7 @@ MOD
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'MOD' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'MOD'
 
 ===================================================
 'MULTISET'    
@@ -459,7 +459,7 @@ MULTISET
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'MULTISET' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'MULTISET'
 
 ===================================================
 'NOT'    
@@ -469,7 +469,7 @@ NOT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'NOT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'NOT'
 
 ===================================================
 'NULL'    
@@ -479,7 +479,7 @@ NULL
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'NULL' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'NULL'
 
 ===================================================
 'NUMERIC'    
@@ -489,7 +489,7 @@ NUMERIC
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'NUMERIC' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'NUMERIC'
 
 ===================================================
 'OPEN'    
@@ -499,7 +499,7 @@ OPEN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'OPEN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'OPEN'
 
 ===================================================
 'OR'    
@@ -509,7 +509,7 @@ OR
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'OR' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'OR'
 
 ===================================================
 'OUT'    
@@ -519,7 +519,7 @@ OUT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'OUT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'OUT'
 
 ===================================================
 'PRAGMA'    
@@ -529,7 +529,7 @@ PRAGMA
 ===================================================
 Error:-1360
 In line 7, column 19
-Stored procedure compile error: mismatched input 'PRAGMA' expecting {REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'PRAGMA'
 
 ===================================================
 'RAISE'    
@@ -539,7 +539,7 @@ RAISE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'RAISE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'RAISE'
 
 ===================================================
 'REAL'    
@@ -549,7 +549,7 @@ REAL
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'REAL' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'REAL'
 
 ===================================================
 'REPLACE'    
@@ -559,7 +559,7 @@ REPLACE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'REPLACE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'REPLACE'
 
 ===================================================
 'RETURN'    
@@ -569,7 +569,7 @@ RETURN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'RETURN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'RETURN'
 
 ===================================================
 'REVERSE'    
@@ -587,7 +587,7 @@ ROLLBACK
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'ROLLBACK' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'ROLLBACK'
 
 ===================================================
 'SEQUENCE'    
@@ -597,7 +597,7 @@ SEQUENCE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SEQUENCE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SEQUENCE'
 
 ===================================================
 'SET'    
@@ -607,7 +607,7 @@ SET
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SET' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SET'
 
 ===================================================
 'SETEQ'    
@@ -617,7 +617,7 @@ SETEQ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SETEQ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SETEQ'
 
 ===================================================
 'SETNEQ'    
@@ -627,7 +627,7 @@ SETNEQ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SETNEQ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SETNEQ'
 
 ===================================================
 'SHORT'    
@@ -637,7 +637,7 @@ SHORT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SHORT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SHORT'
 
 ===================================================
 'SMALLINT'    
@@ -647,7 +647,7 @@ SMALLINT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SMALLINT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SMALLINT'
 
 ===================================================
 'SQL'    
@@ -657,7 +657,7 @@ SQL
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SQL' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SQL'
 
 ===================================================
 'STRING'    
@@ -667,7 +667,7 @@ STRING
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'STRING' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'STRING'
 
 ===================================================
 'SUBSET'    
@@ -677,7 +677,7 @@ SUBSET
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SUBSET' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUBSET'
 
 ===================================================
 'SUBSETEQ'    
@@ -687,7 +687,7 @@ SUBSETEQ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SUBSETEQ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUBSETEQ'
 
 ===================================================
 'SUPERSET'    
@@ -697,7 +697,7 @@ SUPERSET
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SUPERSET' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUPERSET'
 
 ===================================================
 'SUPERSETEQ'    
@@ -707,7 +707,7 @@ SUPERSETEQ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SUPERSETEQ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUPERSETEQ'
 
 ===================================================
 'SYS_REFCURSOR'    
@@ -717,7 +717,7 @@ SYS_REFCURSOR
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SYS_REFCURSOR' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SYS_REFCURSOR'
 
 ===================================================
 'THEN'    
@@ -727,7 +727,7 @@ THEN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'THEN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'THEN'
 
 ===================================================
 'TIME'    
@@ -737,7 +737,7 @@ TIME
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'TIME' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIME'
 
 ===================================================
 'TIMESTAMP'    
@@ -747,7 +747,7 @@ TIMESTAMP
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'TIMESTAMP' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIMESTAMP'
 
 ===================================================
 'TIMESTAMPLTZ'    
@@ -757,7 +757,7 @@ TIMESTAMPLTZ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'TIMESTAMPLTZ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIMESTAMPLTZ'
 
 ===================================================
 'TIMESTAMPTZ'    
@@ -767,7 +767,7 @@ TIMESTAMPTZ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'TIMESTAMPTZ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIMESTAMPTZ'
 
 ===================================================
 'TRUE'    
@@ -777,7 +777,7 @@ TRUE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'TRUE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'TRUE'
 
 ===================================================
 'USING'    
@@ -787,7 +787,7 @@ USING
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'USING' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'USING'
 
 ===================================================
 'VARCHAR'    
@@ -797,7 +797,7 @@ VARCHAR
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'VARCHAR' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'VARCHAR'
 
 ===================================================
 'WHEN'    
@@ -807,7 +807,7 @@ WHEN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'WHEN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'WHEN'
 
 ===================================================
 'WHILE'    
@@ -817,7 +817,7 @@ WHILE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'WHILE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'WHILE'
 
 ===================================================
 'WORK'    
@@ -827,7 +827,7 @@ WORK
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'WORK' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'WORK'
 
 ===================================================
 'XOR'    
@@ -837,7 +837,7 @@ XOR
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'XOR' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'XOR'
 
 ===================================================
 'INSERT'    
@@ -847,7 +847,7 @@ INSERT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'INSERT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'INSERT'
 
 ===================================================
 'TRUNCATE'    
@@ -857,7 +857,7 @@ TRUNCATE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'TRUNCATE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'TRUNCATE'
 
 ===================================================
 'AUTONOMOUS_TRANSACTION'    
@@ -867,7 +867,7 @@ AUTONOMOUS_TRANSACTION
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'AUTONOMOUS_TRANSACTION' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'AUTONOMOUS_TRANSACTION'
 
 ===================================================
 'BEGIN'    
@@ -877,7 +877,7 @@ BEGIN
 ===================================================
 Error:-1360
 In line 3, column 1
-Stored procedure compile error: mismatched input 'begin' expecting {<EOF>, COMMENT}
+Stored procedure compile error: mismatched input 'begin'
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_local_function.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_local_function.answer
@@ -6,7 +6,7 @@ AND
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'AND' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'AND'
 
 ===================================================
 'AS'    
@@ -16,7 +16,7 @@ AS
 ===================================================
 Error:-1360
 In line 6, column 1
-Stored procedure compile error: mismatched input 'begin' expecting {<EOF>, COMMENT}
+Stored procedure compile error: mismatched input 'begin'
 
 ===================================================
 'BETWEEN'    
@@ -26,7 +26,7 @@ BETWEEN
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'BETWEEN' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'BETWEEN'
 
 ===================================================
 'BIGINT'    
@@ -36,7 +36,7 @@ BIGINT
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'BIGINT' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'BIGINT'
 
 ===================================================
 'BOOLEAN'    
@@ -46,7 +46,7 @@ BOOLEAN
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'BOOLEAN' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'BOOLEAN'
 
 ===================================================
 'BY'    
@@ -56,7 +56,7 @@ BY
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'BY' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'BY'
 
 ===================================================
 'CHAR'    
@@ -66,7 +66,7 @@ CHAR
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'CHAR' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'CHAR'
 
 ===================================================
 'CLOSE'    
@@ -76,7 +76,7 @@ CLOSE
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'CLOSE' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'CLOSE'
 
 ===================================================
 'COMMIT'    
@@ -86,7 +86,7 @@ COMMIT
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'COMMIT' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'COMMIT'
 
 ===================================================
 'CONSTANT'    
@@ -96,7 +96,7 @@ CONSTANT
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'CONSTANT' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'CONSTANT'
 
 ===================================================
 'CONTINUE'    
@@ -106,7 +106,7 @@ CONTINUE
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'CONTINUE' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'CONTINUE'
 
 ===================================================
 'CREATE'    
@@ -116,7 +116,7 @@ CREATE
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'CREATE' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'CREATE'
 
 ===================================================
 'CURSOR'    
@@ -126,7 +126,7 @@ CURSOR
 ===================================================
 Error:-1360
 In line 6, column 1
-Stored procedure compile error: mismatched input 'begin' expecting {<EOF>, COMMENT}
+Stored procedure compile error: mismatched input 'begin'
 
 ===================================================
 'DATE'    
@@ -136,7 +136,7 @@ DATE
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'DATE' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATE'
 
 ===================================================
 'DATETIME'    
@@ -146,7 +146,7 @@ DATETIME
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'DATETIME' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATETIME'
 
 ===================================================
 'DATETIMELTZ'    
@@ -156,7 +156,7 @@ DATETIMELTZ
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'DATETIMELTZ' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATETIMELTZ'
 
 ===================================================
 'DATETIMETZ'    
@@ -166,7 +166,7 @@ DATETIMETZ
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'DATETIMETZ' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATETIMETZ'
 
 ===================================================
 'DEC'    
@@ -176,7 +176,7 @@ DEC
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'DEC' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DEC'
 
 ===================================================
 'DECIMAL'    
@@ -186,7 +186,7 @@ DECIMAL
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'DECIMAL' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DECIMAL'
 
 ===================================================
 'DECLARE'    
@@ -196,7 +196,7 @@ DECLARE
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'DECLARE' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DECLARE'
 
 ===================================================
 'DEFAULT'    
@@ -206,7 +206,7 @@ DEFAULT
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'DEFAULT' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DEFAULT'
 
 ===================================================
 'DIV'    
@@ -216,7 +216,7 @@ DIV
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'DIV' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DIV'
 
 ===================================================
 'DOUBLE'    
@@ -226,7 +226,7 @@ DOUBLE
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'DOUBLE' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DOUBLE'
 
 ===================================================
 'ELSE'    
@@ -236,7 +236,7 @@ ELSE
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'ELSE' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'ELSE'
 
 ===================================================
 'ELSIF'    
@@ -246,7 +246,7 @@ ELSIF
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'ELSIF' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'ELSIF'
 
 ===================================================
 'END'    
@@ -256,7 +256,7 @@ END
 ===================================================
 Error:-1360
 In line 5, column 4
-Stored procedure compile error: mismatched input '<EOF>' expecting {BEGIN, CURSOR, FUNCTION, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input '<EOF>'
 
 ===================================================
 Error:-493
@@ -277,7 +277,7 @@ ESCAPE
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'ESCAPE' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'ESCAPE'
 
 ===================================================
 'EXCEPTION'    
@@ -287,7 +287,7 @@ EXCEPTION
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'EXCEPTION' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'EXCEPTION'
 
 ===================================================
 'EXECUTE'    
@@ -297,7 +297,7 @@ EXECUTE
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'EXECUTE' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'EXECUTE'
 
 ===================================================
 'EXIT'    
@@ -307,7 +307,7 @@ EXIT
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'EXIT' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'EXIT'
 
 ===================================================
 'FALSE'    
@@ -317,7 +317,7 @@ FALSE
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'FALSE' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'FALSE'
 
 ===================================================
 'FETCH'    
@@ -327,7 +327,7 @@ FETCH
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'FETCH' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'FETCH'
 
 ===================================================
 'FLOAT'    
@@ -337,7 +337,7 @@ FLOAT
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'FLOAT' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'FLOAT'
 
 ===================================================
 'FOR'    
@@ -347,7 +347,7 @@ FOR
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'FOR' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'FOR'
 
 ===================================================
 'IMMEDIATE'    
@@ -357,7 +357,7 @@ IMMEDIATE
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'IMMEDIATE' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'IMMEDIATE'
 
 ===================================================
 'IN'    
@@ -367,7 +367,7 @@ IN
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'IN' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'IN'
 
 ===================================================
 'INT'    
@@ -377,7 +377,7 @@ INT
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'INT' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'INT'
 
 ===================================================
 'INTEGER'    
@@ -387,7 +387,7 @@ INTEGER
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'INTEGER' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'INTEGER'
 
 ===================================================
 'INTO'    
@@ -397,7 +397,7 @@ INTO
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'INTO' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'INTO'
 
 ===================================================
 'IS'    
@@ -407,7 +407,7 @@ IS
 ===================================================
 Error:-1360
 In line 6, column 1
-Stored procedure compile error: mismatched input 'begin' expecting {<EOF>, COMMENT}
+Stored procedure compile error: mismatched input 'begin'
 
 ===================================================
 'LIKE'    
@@ -417,7 +417,7 @@ LIKE
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'LIKE' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIKE'
 
 ===================================================
 'LIST'    
@@ -427,7 +427,7 @@ LIST
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'LIST' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIST'
 
 ===================================================
 'MOD'    
@@ -437,7 +437,7 @@ MOD
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'MOD' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'MOD'
 
 ===================================================
 'MULTISET'    
@@ -447,7 +447,7 @@ MULTISET
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'MULTISET' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'MULTISET'
 
 ===================================================
 'NOT'    
@@ -457,7 +457,7 @@ NOT
 ===================================================
 Error:-1360
 In line 6, column 1
-Stored procedure compile error: mismatched input 'begin' expecting {<EOF>, COMMENT}
+Stored procedure compile error: mismatched input 'begin'
 
 ===================================================
 'NULL'    
@@ -467,7 +467,7 @@ NULL
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'NULL' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'NULL'
 
 ===================================================
 'NUMERIC'    
@@ -477,7 +477,7 @@ NUMERIC
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'NUMERIC' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'NUMERIC'
 
 ===================================================
 'OPEN'    
@@ -487,7 +487,7 @@ OPEN
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'OPEN' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'OPEN'
 
 ===================================================
 'OR'    
@@ -497,7 +497,7 @@ OR
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'OR' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'OR'
 
 ===================================================
 'OUT'    
@@ -507,7 +507,7 @@ OUT
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'OUT' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'OUT'
 
 ===================================================
 'PRAGMA'    
@@ -517,7 +517,7 @@ PRAGMA
 ===================================================
 Error:-1360
 In line 6, column 1
-Stored procedure compile error: mismatched input 'begin' expecting {<EOF>, COMMENT}
+Stored procedure compile error: mismatched input 'begin'
 
 ===================================================
 'RAISE'    
@@ -527,7 +527,7 @@ RAISE
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'RAISE' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'RAISE'
 
 ===================================================
 'REAL'    
@@ -537,7 +537,7 @@ REAL
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'REAL' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'REAL'
 
 ===================================================
 'REPLACE'    
@@ -547,7 +547,7 @@ REPLACE
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'REPLACE' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'REPLACE'
 
 ===================================================
 'RETURN'    
@@ -557,7 +557,7 @@ RETURN
 ===================================================
 Error:-1360
 In line 2, column 17
-Stored procedure compile error: extraneous input 'return' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: extraneous input 'return'
 
 ===================================================
 'REVERSE'    
@@ -575,7 +575,7 @@ ROLLBACK
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'ROLLBACK' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'ROLLBACK'
 
 ===================================================
 'SEQUENCE'    
@@ -585,7 +585,7 @@ SEQUENCE
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'SEQUENCE' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SEQUENCE'
 
 ===================================================
 'SET'    
@@ -595,7 +595,7 @@ SET
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'SET' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SET'
 
 ===================================================
 'SETEQ'    
@@ -605,7 +605,7 @@ SETEQ
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'SETEQ' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SETEQ'
 
 ===================================================
 'SETNEQ'    
@@ -615,7 +615,7 @@ SETNEQ
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'SETNEQ' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SETNEQ'
 
 ===================================================
 'SHORT'    
@@ -625,7 +625,7 @@ SHORT
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'SHORT' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SHORT'
 
 ===================================================
 'SMALLINT'    
@@ -635,7 +635,7 @@ SMALLINT
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'SMALLINT' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SMALLINT'
 
 ===================================================
 'SQL'    
@@ -645,7 +645,7 @@ SQL
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'SQL' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SQL'
 
 ===================================================
 'STRING'    
@@ -655,7 +655,7 @@ STRING
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'STRING' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'STRING'
 
 ===================================================
 'SUBSET'    
@@ -665,7 +665,7 @@ SUBSET
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'SUBSET' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUBSET'
 
 ===================================================
 'SUBSETEQ'    
@@ -675,7 +675,7 @@ SUBSETEQ
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'SUBSETEQ' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUBSETEQ'
 
 ===================================================
 'SUPERSET'    
@@ -685,7 +685,7 @@ SUPERSET
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'SUPERSET' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUPERSET'
 
 ===================================================
 'SUPERSETEQ'    
@@ -695,7 +695,7 @@ SUPERSETEQ
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'SUPERSETEQ' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUPERSETEQ'
 
 ===================================================
 'SYS_REFCURSOR'    
@@ -705,7 +705,7 @@ SYS_REFCURSOR
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'SYS_REFCURSOR' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SYS_REFCURSOR'
 
 ===================================================
 'THEN'    
@@ -715,7 +715,7 @@ THEN
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'THEN' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'THEN'
 
 ===================================================
 'TIME'    
@@ -725,7 +725,7 @@ TIME
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'TIME' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIME'
 
 ===================================================
 'TIMESTAMP'    
@@ -735,7 +735,7 @@ TIMESTAMP
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'TIMESTAMP' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIMESTAMP'
 
 ===================================================
 'TIMESTAMPLTZ'    
@@ -745,7 +745,7 @@ TIMESTAMPLTZ
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'TIMESTAMPLTZ' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIMESTAMPLTZ'
 
 ===================================================
 'TIMESTAMPTZ'    
@@ -755,7 +755,7 @@ TIMESTAMPTZ
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'TIMESTAMPTZ' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIMESTAMPTZ'
 
 ===================================================
 'TRUE'    
@@ -765,7 +765,7 @@ TRUE
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'TRUE' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'TRUE'
 
 ===================================================
 'USING'    
@@ -775,7 +775,7 @@ USING
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'USING' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'USING'
 
 ===================================================
 'VARCHAR'    
@@ -785,7 +785,7 @@ VARCHAR
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'VARCHAR' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'VARCHAR'
 
 ===================================================
 'WHEN'    
@@ -795,7 +795,7 @@ WHEN
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'WHEN' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'WHEN'
 
 ===================================================
 'WHILE'    
@@ -805,7 +805,7 @@ WHILE
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'WHILE' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'WHILE'
 
 ===================================================
 'WORK'    
@@ -815,7 +815,7 @@ WORK
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'WORK' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'WORK'
 
 ===================================================
 'XOR'    
@@ -825,7 +825,7 @@ XOR
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'XOR' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'XOR'
 
 ===================================================
 'INSERT'    
@@ -835,7 +835,7 @@ INSERT
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'INSERT' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'INSERT'
 
 ===================================================
 'TRUNCATE'    
@@ -845,7 +845,7 @@ TRUNCATE
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'TRUNCATE' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'TRUNCATE'
 
 ===================================================
 'AUTONOMOUS_TRANSACTION'    
@@ -855,7 +855,7 @@ AUTONOMOUS_TRANSACTION
 ===================================================
 Error:-1360
 In line 2, column 10
-Stored procedure compile error: mismatched input 'AUTONOMOUS_TRANSACTION' expecting {REVERSE, DELIMITED_ID, '[', REGULAR_ID}
+Stored procedure compile error: mismatched input 'AUTONOMOUS_TRANSACTION'
 
 ===================================================
 'BEGIN'    
@@ -865,7 +865,7 @@ BEGIN
 ===================================================
 Error:-1360
 In line 6, column 1
-Stored procedure compile error: mismatched input 'begin' expecting {<EOF>, COMMENT}
+Stored procedure compile error: mismatched input 'begin'
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_local_procedure.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_local_procedure.answer
@@ -6,7 +6,7 @@ AND
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'AND' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'AND'
 
 ===================================================
 'AS'    
@@ -16,7 +16,7 @@ AS
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'AS' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'AS'
 
 ===================================================
 'BETWEEN'    
@@ -26,7 +26,7 @@ BETWEEN
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'BETWEEN' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'BETWEEN'
 
 ===================================================
 'BIGINT'    
@@ -36,7 +36,7 @@ BIGINT
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'BIGINT' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'BIGINT'
 
 ===================================================
 'BOOLEAN'    
@@ -46,7 +46,7 @@ BOOLEAN
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'BOOLEAN' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'BOOLEAN'
 
 ===================================================
 'BY'    
@@ -56,7 +56,7 @@ BY
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'BY' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'BY'
 
 ===================================================
 'CHAR'    
@@ -66,7 +66,7 @@ CHAR
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'CHAR' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'CHAR'
 
 ===================================================
 'CLOSE'    
@@ -76,7 +76,7 @@ CLOSE
 ===================================================
 Error:-1360
 In line 7, column 6
-Stored procedure compile error: mismatched input '(' expecting {REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input '('
 
 ===================================================
 'COMMIT'    
@@ -86,7 +86,7 @@ COMMIT
 ===================================================
 Error:-1360
 In line 7, column 7
-Stored procedure compile error: mismatched input '(' expecting {WORK, SEMICOLON}
+Stored procedure compile error: mismatched input '('
 
 ===================================================
 'CONSTANT'    
@@ -96,7 +96,7 @@ CONSTANT
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'CONSTANT' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'CONSTANT'
 
 ===================================================
 'CONTINUE'    
@@ -106,7 +106,7 @@ CONTINUE
 ===================================================
 Error:-1360
 In line 7, column 9
-Stored procedure compile error: mismatched input '(' expecting {REVERSE, WHEN, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input '('
 
 ===================================================
 'CREATE'    
@@ -116,7 +116,7 @@ CREATE
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'CREATE' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'CREATE'
 
 ===================================================
 'CURSOR'    
@@ -126,7 +126,7 @@ CURSOR
 ===================================================
 Error:-1360
 In line 6, column 1
-Stored procedure compile error: mismatched input 'begin' expecting {<EOF>, COMMENT}
+Stored procedure compile error: mismatched input 'begin'
 
 ===================================================
 'DATE'    
@@ -136,7 +136,7 @@ DATE
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'DATE' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATE'
 
 ===================================================
 'DATETIME'    
@@ -146,7 +146,7 @@ DATETIME
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'DATETIME' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATETIME'
 
 ===================================================
 'DATETIMELTZ'    
@@ -156,7 +156,7 @@ DATETIMELTZ
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'DATETIMELTZ' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATETIMELTZ'
 
 ===================================================
 'DATETIMETZ'    
@@ -166,7 +166,7 @@ DATETIMETZ
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'DATETIMETZ' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATETIMETZ'
 
 ===================================================
 'DEC'    
@@ -176,7 +176,7 @@ DEC
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'DEC' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DEC'
 
 ===================================================
 'DECIMAL'    
@@ -186,7 +186,7 @@ DECIMAL
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'DECIMAL' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DECIMAL'
 
 ===================================================
 'DECLARE'    
@@ -196,7 +196,7 @@ DECLARE
 ===================================================
 Error:-1360
 In line 7, column 8
-Stored procedure compile error: mismatched input '(' expecting {CURSOR, FUNCTION, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input '('
 
 ===================================================
 'DEFAULT'    
@@ -206,7 +206,7 @@ DEFAULT
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'DEFAULT' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DEFAULT'
 
 ===================================================
 'DIV'    
@@ -216,7 +216,7 @@ DIV
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'DIV' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DIV'
 
 ===================================================
 'DOUBLE'    
@@ -226,7 +226,7 @@ DOUBLE
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'DOUBLE' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'DOUBLE'
 
 ===================================================
 'ELSE'    
@@ -236,7 +236,7 @@ ELSE
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'ELSE' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'ELSE'
 
 ===================================================
 'ELSIF'    
@@ -246,7 +246,7 @@ ELSIF
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'ELSIF' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'ELSIF'
 
 ===================================================
 'END'    
@@ -256,7 +256,7 @@ END
 ===================================================
 Error:-1360
 In line 5, column 4
-Stored procedure compile error: mismatched input '<EOF>' expecting {BEGIN, CURSOR, FUNCTION, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input '<EOF>'
 
 ===================================================
 Error:-493
@@ -277,7 +277,7 @@ ESCAPE
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'ESCAPE' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'ESCAPE'
 
 ===================================================
 'EXCEPTION'    
@@ -297,7 +297,7 @@ EXECUTE
 ===================================================
 Error:-1360
 In line 7, column 9
-Stored procedure compile error: mismatched input ')' expecting {INSERT, REPLACE, TRUNCATE, CASE, CURRENT_USER, DATE, DATETIME, DEFAULT, FALSE, IF, MOD, NOT, NULL_, REVERSE, SQL, SQLCODE, SQLERRM, TIMESTAMP, TIME, TRUE, FLOATING_POINT_NUM, UNSIGNED_INTEGER, DELIMITED_ID, CHAR_STRING, LPAREN, '+', '-', '~', REGULAR_ID}
+Stored procedure compile error: mismatched input ')'
 
 ===================================================
 'EXIT'    
@@ -307,7 +307,7 @@ EXIT
 ===================================================
 Error:-1360
 In line 7, column 5
-Stored procedure compile error: mismatched input '(' expecting {REVERSE, WHEN, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input '('
 
 ===================================================
 'FALSE'    
@@ -317,7 +317,7 @@ FALSE
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'FALSE' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'FALSE'
 
 ===================================================
 'FETCH'    
@@ -327,7 +327,7 @@ FETCH
 ===================================================
 Error:-1360
 In line 7, column 6
-Stored procedure compile error: mismatched input '(' expecting {REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input '('
 
 ===================================================
 'FLOAT'    
@@ -337,7 +337,7 @@ FLOAT
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'FLOAT' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'FLOAT'
 
 ===================================================
 'FOR'    
@@ -357,7 +357,7 @@ IMMEDIATE
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'IMMEDIATE' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'IMMEDIATE'
 
 ===================================================
 'IN'    
@@ -367,7 +367,7 @@ IN
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'IN' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'IN'
 
 ===================================================
 'INT'    
@@ -377,7 +377,7 @@ INT
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'INT' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'INT'
 
 ===================================================
 'INTEGER'    
@@ -387,7 +387,7 @@ INTEGER
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'INTEGER' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'INTEGER'
 
 ===================================================
 'INTO'    
@@ -397,7 +397,7 @@ INTO
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'INTO' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'INTO'
 
 ===================================================
 'IS'    
@@ -407,7 +407,7 @@ IS
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'IS' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'IS'
 
 ===================================================
 'LIKE'    
@@ -417,7 +417,7 @@ LIKE
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'LIKE' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIKE'
 
 ===================================================
 'LIST'    
@@ -427,7 +427,7 @@ LIST
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'LIST' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIST'
 
 ===================================================
 'MOD'    
@@ -437,7 +437,7 @@ MOD
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'MOD' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'MOD'
 
 ===================================================
 'MULTISET'    
@@ -447,7 +447,7 @@ MULTISET
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'MULTISET' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'MULTISET'
 
 ===================================================
 'NOT'    
@@ -457,7 +457,7 @@ NOT
 ===================================================
 Error:-1360
 In line 6, column 1
-Stored procedure compile error: mismatched input 'begin' expecting {<EOF>, COMMENT}
+Stored procedure compile error: mismatched input 'begin'
 
 ===================================================
 'NULL'    
@@ -477,7 +477,7 @@ NUMERIC
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'NUMERIC' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'NUMERIC'
 
 ===================================================
 'OPEN'    
@@ -497,7 +497,7 @@ OR
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'OR' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'OR'
 
 ===================================================
 'OUT'    
@@ -507,7 +507,7 @@ OUT
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'OUT' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'OUT'
 
 ===================================================
 'PRAGMA'    
@@ -517,7 +517,7 @@ PRAGMA
 ===================================================
 Error:-1360
 In line 6, column 1
-Stored procedure compile error: mismatched input 'begin' expecting {<EOF>, COMMENT}
+Stored procedure compile error: mismatched input 'begin'
 
 ===================================================
 'RAISE'    
@@ -527,7 +527,7 @@ RAISE
 ===================================================
 Error:-1360
 In line 7, column 6
-Stored procedure compile error: mismatched input '(' expecting {REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input '('
 
 ===================================================
 'REAL'    
@@ -537,7 +537,7 @@ REAL
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'REAL' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'REAL'
 
 ===================================================
 'REPLACE'    
@@ -547,7 +547,7 @@ REPLACE
 ===================================================
 Error:-1360
 In line 7, column 8
-Stored procedure compile error: mismatched input '(' expecting {SS_STR, SS_WS, SS_NON_STR}
+Stored procedure compile error: mismatched input '('
 
 ===================================================
 'RETURN'    
@@ -557,7 +557,7 @@ RETURN
 ===================================================
 Error:-1360
 In line 7, column 8
-Stored procedure compile error: mismatched input ')' expecting {INSERT, REPLACE, TRUNCATE, CASE, CURRENT_USER, DATE, DATETIME, DEFAULT, FALSE, IF, MOD, NOT, NULL_, REVERSE, SQL, SQLCODE, SQLERRM, TIMESTAMP, TIME, TRUE, FLOATING_POINT_NUM, UNSIGNED_INTEGER, DELIMITED_ID, CHAR_STRING, LPAREN, '+', '-', '~', REGULAR_ID}
+Stored procedure compile error: mismatched input ')'
 
 ===================================================
 'REVERSE'    
@@ -575,7 +575,7 @@ ROLLBACK
 ===================================================
 Error:-1360
 In line 7, column 9
-Stored procedure compile error: mismatched input '(' expecting {WORK, SEMICOLON}
+Stored procedure compile error: mismatched input '('
 
 ===================================================
 'SEQUENCE'    
@@ -585,7 +585,7 @@ SEQUENCE
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'SEQUENCE' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SEQUENCE'
 
 ===================================================
 'SET'    
@@ -595,7 +595,7 @@ SET
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'SET' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SET'
 
 ===================================================
 'SETEQ'    
@@ -605,7 +605,7 @@ SETEQ
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'SETEQ' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SETEQ'
 
 ===================================================
 'SETNEQ'    
@@ -615,7 +615,7 @@ SETNEQ
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'SETNEQ' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SETNEQ'
 
 ===================================================
 'SHORT'    
@@ -625,7 +625,7 @@ SHORT
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'SHORT' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SHORT'
 
 ===================================================
 'SMALLINT'    
@@ -635,7 +635,7 @@ SMALLINT
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'SMALLINT' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SMALLINT'
 
 ===================================================
 'SQL'    
@@ -645,7 +645,7 @@ SQL
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'SQL' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SQL'
 
 ===================================================
 'STRING'    
@@ -655,7 +655,7 @@ STRING
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'STRING' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'STRING'
 
 ===================================================
 'SUBSET'    
@@ -665,7 +665,7 @@ SUBSET
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'SUBSET' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUBSET'
 
 ===================================================
 'SUBSETEQ'    
@@ -675,7 +675,7 @@ SUBSETEQ
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'SUBSETEQ' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUBSETEQ'
 
 ===================================================
 'SUPERSET'    
@@ -685,7 +685,7 @@ SUPERSET
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'SUPERSET' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUPERSET'
 
 ===================================================
 'SUPERSETEQ'    
@@ -695,7 +695,7 @@ SUPERSETEQ
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'SUPERSETEQ' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUPERSETEQ'
 
 ===================================================
 'SYS_REFCURSOR'    
@@ -705,7 +705,7 @@ SYS_REFCURSOR
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'SYS_REFCURSOR' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'SYS_REFCURSOR'
 
 ===================================================
 'THEN'    
@@ -715,7 +715,7 @@ THEN
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'THEN' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'THEN'
 
 ===================================================
 'TIME'    
@@ -725,7 +725,7 @@ TIME
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'TIME' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIME'
 
 ===================================================
 'TIMESTAMP'    
@@ -735,7 +735,7 @@ TIMESTAMP
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'TIMESTAMP' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIMESTAMP'
 
 ===================================================
 'TIMESTAMPLTZ'    
@@ -745,7 +745,7 @@ TIMESTAMPLTZ
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'TIMESTAMPLTZ' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIMESTAMPLTZ'
 
 ===================================================
 'TIMESTAMPTZ'    
@@ -755,7 +755,7 @@ TIMESTAMPTZ
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'TIMESTAMPTZ' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIMESTAMPTZ'
 
 ===================================================
 'TRUE'    
@@ -765,7 +765,7 @@ TRUE
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'TRUE' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'TRUE'
 
 ===================================================
 'USING'    
@@ -775,7 +775,7 @@ USING
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'USING' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'USING'
 
 ===================================================
 'VARCHAR'    
@@ -785,7 +785,7 @@ VARCHAR
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'VARCHAR' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'VARCHAR'
 
 ===================================================
 'WHEN'    
@@ -795,7 +795,7 @@ WHEN
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'WHEN' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'WHEN'
 
 ===================================================
 'WHILE'    
@@ -805,7 +805,7 @@ WHILE
 ===================================================
 Error:-1360
 In line 7, column 8
-Stored procedure compile error: mismatched input ';' expecting {AND, BETWEEN, DIV, IN, IS, LIKE, LOOP, MOD, NOT, OR, XOR, '<=>', '>=', '<=', '||', '<<', '>>', '*', '+', '-', '/', NOT_EQUAL_OP, '&', '^', '>', '<', '|', '='}
+Stored procedure compile error: mismatched input ';'
 
 ===================================================
 'WORK'    
@@ -815,7 +815,7 @@ WORK
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'WORK' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'WORK'
 
 ===================================================
 'XOR'    
@@ -825,7 +825,7 @@ XOR
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'XOR' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'XOR'
 
 ===================================================
 'INSERT'    
@@ -835,7 +835,7 @@ INSERT
 ===================================================
 Error:-1360
 In line 7, column 7
-Stored procedure compile error: mismatched input '(' expecting {SS_STR, SS_WS, SS_NON_STR}
+Stored procedure compile error: mismatched input '('
 
 ===================================================
 'TRUNCATE'    
@@ -845,7 +845,7 @@ TRUNCATE
 ===================================================
 Error:-1360
 In line 7, column 9
-Stored procedure compile error: mismatched input '(' expecting {SS_STR, SS_WS, SS_NON_STR}
+Stored procedure compile error: mismatched input '('
 
 ===================================================
 'AUTONOMOUS_TRANSACTION'    
@@ -855,7 +855,7 @@ AUTONOMOUS_TRANSACTION
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'AUTONOMOUS_TRANSACTION' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'AUTONOMOUS_TRANSACTION'
 
 ===================================================
 'BEGIN'    

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_local_procedure.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_local_procedure.answer
@@ -467,7 +467,7 @@ NULL
 ===================================================
 Error:-1360
 In line 7, column 5
-Stored procedure compile error: mismatched input '(' expecting SEMICOLON
+Stored procedure compile error: mismatched input '('
 
 ===================================================
 'NUMERIC'    

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_variable.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_variable.answer
@@ -517,7 +517,7 @@ PRAGMA
 ===================================================
 Error:-1360
 In line 2, column 8
-Stored procedure compile error: mismatched input 'varchar' expecting AUTONOMOUS_TRANSACTION
+Stored procedure compile error: mismatched input 'varchar'
 
 ===================================================
 'RAISE'    

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_variable.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_variable.answer
@@ -6,7 +6,7 @@ AND
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'AND' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'AND'
 
 ===================================================
 'AS'    
@@ -16,7 +16,7 @@ AS
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'AS' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'AS'
 
 ===================================================
 'BETWEEN'    
@@ -26,7 +26,7 @@ BETWEEN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'BETWEEN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'BETWEEN'
 
 ===================================================
 'BIGINT'    
@@ -36,7 +36,7 @@ BIGINT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'BIGINT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'BIGINT'
 
 ===================================================
 'BOOLEAN'    
@@ -46,7 +46,7 @@ BOOLEAN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'BOOLEAN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'BOOLEAN'
 
 ===================================================
 'BY'    
@@ -56,7 +56,7 @@ BY
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'BY' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'BY'
 
 ===================================================
 'CHAR'    
@@ -66,7 +66,7 @@ CHAR
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'CHAR' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'CHAR'
 
 ===================================================
 'CLOSE'    
@@ -76,7 +76,7 @@ CLOSE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'CLOSE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'CLOSE'
 
 ===================================================
 'COMMIT'    
@@ -86,7 +86,7 @@ COMMIT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'COMMIT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'COMMIT'
 
 ===================================================
 'CONSTANT'    
@@ -96,7 +96,7 @@ CONSTANT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'CONSTANT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'CONSTANT'
 
 ===================================================
 'CONTINUE'    
@@ -106,7 +106,7 @@ CONTINUE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'CONTINUE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'CONTINUE'
 
 ===================================================
 'CREATE'    
@@ -116,7 +116,7 @@ CREATE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'CREATE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'CREATE'
 
 ===================================================
 'CURSOR'    
@@ -126,7 +126,7 @@ CURSOR
 ===================================================
 Error:-1360
 In line 2, column 8
-Stored procedure compile error: mismatched input 'varchar' expecting {REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'varchar'
 
 ===================================================
 'DATE'    
@@ -136,7 +136,7 @@ DATE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DATE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATE'
 
 ===================================================
 'DATETIME'    
@@ -146,7 +146,7 @@ DATETIME
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DATETIME' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATETIME'
 
 ===================================================
 'DATETIMELTZ'    
@@ -156,7 +156,7 @@ DATETIMELTZ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DATETIMELTZ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATETIMELTZ'
 
 ===================================================
 'DATETIMETZ'    
@@ -166,7 +166,7 @@ DATETIMETZ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DATETIMETZ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DATETIMETZ'
 
 ===================================================
 'DEC'    
@@ -176,7 +176,7 @@ DEC
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DEC' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DEC'
 
 ===================================================
 'DECIMAL'    
@@ -186,7 +186,7 @@ DECIMAL
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DECIMAL' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DECIMAL'
 
 ===================================================
 'DECLARE'    
@@ -196,7 +196,7 @@ DECLARE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DECLARE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DECLARE'
 
 ===================================================
 'DEFAULT'    
@@ -206,7 +206,7 @@ DEFAULT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DEFAULT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DEFAULT'
 
 ===================================================
 'DIV'    
@@ -216,7 +216,7 @@ DIV
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DIV' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DIV'
 
 ===================================================
 'DOUBLE'    
@@ -226,7 +226,7 @@ DOUBLE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'DOUBLE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'DOUBLE'
 
 ===================================================
 'ELSE'    
@@ -236,7 +236,7 @@ ELSE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'ELSE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'ELSE'
 
 ===================================================
 'ELSIF'    
@@ -246,7 +246,7 @@ ELSIF
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'ELSIF' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'ELSIF'
 
 ===================================================
 'END'    
@@ -256,7 +256,7 @@ END
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'END' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'END'
 
 ===================================================
 Error:-493
@@ -277,7 +277,7 @@ ESCAPE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'ESCAPE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'ESCAPE'
 
 ===================================================
 'EXCEPTION'    
@@ -287,7 +287,7 @@ EXCEPTION
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'EXCEPTION' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'EXCEPTION'
 
 ===================================================
 'EXECUTE'    
@@ -297,7 +297,7 @@ EXECUTE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'EXECUTE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'EXECUTE'
 
 ===================================================
 'EXIT'    
@@ -307,7 +307,7 @@ EXIT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'EXIT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'EXIT'
 
 ===================================================
 'FALSE'    
@@ -317,7 +317,7 @@ FALSE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'FALSE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'FALSE'
 
 ===================================================
 'FETCH'    
@@ -327,7 +327,7 @@ FETCH
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'FETCH' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'FETCH'
 
 ===================================================
 'FLOAT'    
@@ -337,7 +337,7 @@ FLOAT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'FLOAT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'FLOAT'
 
 ===================================================
 'FOR'    
@@ -347,7 +347,7 @@ FOR
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'FOR' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'FOR'
 
 ===================================================
 'IMMEDIATE'    
@@ -357,7 +357,7 @@ IMMEDIATE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'IMMEDIATE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'IMMEDIATE'
 
 ===================================================
 'IN'    
@@ -367,7 +367,7 @@ IN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'IN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'IN'
 
 ===================================================
 'INT'    
@@ -377,7 +377,7 @@ INT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'INT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'INT'
 
 ===================================================
 'INTEGER'    
@@ -387,7 +387,7 @@ INTEGER
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'INTEGER' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'INTEGER'
 
 ===================================================
 'INTO'    
@@ -397,7 +397,7 @@ INTO
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'INTO' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'INTO'
 
 ===================================================
 'IS'    
@@ -407,7 +407,7 @@ IS
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'IS' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'IS'
 
 ===================================================
 'LIKE'    
@@ -417,7 +417,7 @@ LIKE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'LIKE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIKE'
 
 ===================================================
 'LIST'    
@@ -427,7 +427,7 @@ LIST
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'LIST' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIST'
 
 ===================================================
 'MOD'    
@@ -437,7 +437,7 @@ MOD
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'MOD' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'MOD'
 
 ===================================================
 'MULTISET'    
@@ -447,7 +447,7 @@ MULTISET
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'MULTISET' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'MULTISET'
 
 ===================================================
 'NOT'    
@@ -457,7 +457,7 @@ NOT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'NOT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'NOT'
 
 ===================================================
 'NULL'    
@@ -467,7 +467,7 @@ NULL
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'NULL' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'NULL'
 
 ===================================================
 'NUMERIC'    
@@ -477,7 +477,7 @@ NUMERIC
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'NUMERIC' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'NUMERIC'
 
 ===================================================
 'OPEN'    
@@ -487,7 +487,7 @@ OPEN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'OPEN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'OPEN'
 
 ===================================================
 'OR'    
@@ -497,7 +497,7 @@ OR
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'OR' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'OR'
 
 ===================================================
 'OUT'    
@@ -507,7 +507,7 @@ OUT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'OUT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'OUT'
 
 ===================================================
 'PRAGMA'    
@@ -527,7 +527,7 @@ RAISE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'RAISE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'RAISE'
 
 ===================================================
 'REAL'    
@@ -537,7 +537,7 @@ REAL
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'REAL' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'REAL'
 
 ===================================================
 'REPLACE'    
@@ -547,7 +547,7 @@ REPLACE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'REPLACE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'REPLACE'
 
 ===================================================
 'RETURN'    
@@ -557,7 +557,7 @@ RETURN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'RETURN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'RETURN'
 
 ===================================================
 'REVERSE'    
@@ -575,7 +575,7 @@ ROLLBACK
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'ROLLBACK' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'ROLLBACK'
 
 ===================================================
 'SEQUENCE'    
@@ -585,7 +585,7 @@ SEQUENCE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SEQUENCE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SEQUENCE'
 
 ===================================================
 'SET'    
@@ -595,7 +595,7 @@ SET
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SET' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SET'
 
 ===================================================
 'SETEQ'    
@@ -605,7 +605,7 @@ SETEQ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SETEQ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SETEQ'
 
 ===================================================
 'SETNEQ'    
@@ -615,7 +615,7 @@ SETNEQ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SETNEQ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SETNEQ'
 
 ===================================================
 'SHORT'    
@@ -625,7 +625,7 @@ SHORT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SHORT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SHORT'
 
 ===================================================
 'SMALLINT'    
@@ -635,7 +635,7 @@ SMALLINT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SMALLINT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SMALLINT'
 
 ===================================================
 'SQL'    
@@ -645,7 +645,7 @@ SQL
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SQL' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SQL'
 
 ===================================================
 'STRING'    
@@ -655,7 +655,7 @@ STRING
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'STRING' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'STRING'
 
 ===================================================
 'SUBSET'    
@@ -665,7 +665,7 @@ SUBSET
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SUBSET' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUBSET'
 
 ===================================================
 'SUBSETEQ'    
@@ -675,7 +675,7 @@ SUBSETEQ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SUBSETEQ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUBSETEQ'
 
 ===================================================
 'SUPERSET'    
@@ -685,7 +685,7 @@ SUPERSET
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SUPERSET' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUPERSET'
 
 ===================================================
 'SUPERSETEQ'    
@@ -695,7 +695,7 @@ SUPERSETEQ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SUPERSETEQ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SUPERSETEQ'
 
 ===================================================
 'SYS_REFCURSOR'    
@@ -705,7 +705,7 @@ SYS_REFCURSOR
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'SYS_REFCURSOR' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SYS_REFCURSOR'
 
 ===================================================
 'THEN'    
@@ -715,7 +715,7 @@ THEN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'THEN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'THEN'
 
 ===================================================
 'TIME'    
@@ -725,7 +725,7 @@ TIME
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'TIME' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIME'
 
 ===================================================
 'TIMESTAMP'    
@@ -735,7 +735,7 @@ TIMESTAMP
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'TIMESTAMP' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIMESTAMP'
 
 ===================================================
 'TIMESTAMPLTZ'    
@@ -745,7 +745,7 @@ TIMESTAMPLTZ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'TIMESTAMPLTZ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIMESTAMPLTZ'
 
 ===================================================
 'TIMESTAMPTZ'    
@@ -755,7 +755,7 @@ TIMESTAMPTZ
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'TIMESTAMPTZ' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'TIMESTAMPTZ'
 
 ===================================================
 'TRUE'    
@@ -765,7 +765,7 @@ TRUE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'TRUE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'TRUE'
 
 ===================================================
 'USING'    
@@ -775,7 +775,7 @@ USING
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'USING' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'USING'
 
 ===================================================
 'VARCHAR'    
@@ -785,7 +785,7 @@ VARCHAR
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'VARCHAR' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'VARCHAR'
 
 ===================================================
 'WHEN'    
@@ -795,7 +795,7 @@ WHEN
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'WHEN' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'WHEN'
 
 ===================================================
 'WHILE'    
@@ -805,7 +805,7 @@ WHILE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'WHILE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'WHILE'
 
 ===================================================
 'WORK'    
@@ -815,7 +815,7 @@ WORK
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'WORK' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'WORK'
 
 ===================================================
 'XOR'    
@@ -825,7 +825,7 @@ XOR
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'XOR' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'XOR'
 
 ===================================================
 'INSERT'    
@@ -835,7 +835,7 @@ INSERT
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'INSERT' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'INSERT'
 
 ===================================================
 'TRUNCATE'    
@@ -845,7 +845,7 @@ TRUNCATE
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'TRUNCATE' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'TRUNCATE'
 
 ===================================================
 'AUTONOMOUS_TRANSACTION'    
@@ -855,7 +855,7 @@ AUTONOMOUS_TRANSACTION
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'AUTONOMOUS_TRANSACTION' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'AUTONOMOUS_TRANSACTION'
 
 ===================================================
 'BEGIN'    
@@ -865,7 +865,7 @@ BEGIN
 ===================================================
 Error:-1360
 In line 3, column 1
-Stored procedure compile error: mismatched input 'begin' expecting {<EOF>, COMMENT}
+Stored procedure compile error: mismatched input 'begin'
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_11_common/answers/01_01_11-03_error_no_statements.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_11_common/answers/01_01_11-03_error_no_statements.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 3, column 1
-Stored procedure compile error: mismatched input 'end' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, TRUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, RAISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
+Stored procedure compile error: mismatched input 'end'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_01_initialized/answers/02_02_01-04_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_01_initialized/answers/02_02_01-04_error_typo.answer
@@ -6,17 +6,17 @@ Stored procedure compile error: mismatched input 'NOLL' expecting NULL_
 ===================================================
 Error:-1360
 In line 2, column 7
-Stored procedure compile error: mismatched input 'NUT' expecting {DEFAULT, NOT, ':=', SEMICOLON}
+Stored procedure compile error: mismatched input 'NUT'
 
 ===================================================
 Error:-1360
 In line 2, column 8
-Stored procedure compile error: mismatched input 'DEFAULTS' expecting {DEFAULT, NOT, ':=', SEMICOLON}
+Stored procedure compile error: mismatched input 'DEFAULTS'
 
 ===================================================
 Error:-1360
 In line 2, column 7
-Stored procedure compile error: mismatched input '3' expecting {DEFAULT, NOT, ':=', SEMICOLON}
+Stored procedure compile error: mismatched input '3'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_01_initialized/answers/02_02_01-04_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_01_initialized/answers/02_02_01-04_error_typo.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 2, column 11
-Stored procedure compile error: mismatched input 'NOLL' expecting NULL_
+Stored procedure compile error: mismatched input 'NOLL'
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_deeping/_02_char/answers/02_char_limit.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_deeping/_02_char/answers/02_char_limit.answer
@@ -11,7 +11,7 @@ Stored procedure compile error: length must be one of the integers 1 to 26843545
 ===================================================
 Error:-1360
 In line 2, column 16
-Stored procedure compile error: extraneous input '-' expecting UNSIGNED_INTEGER
+Stored procedure compile error: extraneous input '-'
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_deeping/_03_varchar/answers/02_varchar_limit.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_deeping/_03_varchar/answers/02_varchar_limit.answer
@@ -11,7 +11,7 @@ Stored procedure compile error: length must be one of the integers 1 to 10737418
 ===================================================
 Error:-1360
 In line 2, column 19
-Stored procedure compile error: extraneous input '-' expecting UNSIGNED_INTEGER
+Stored procedure compile error: extraneous input '-'
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_01_initialized/answers/02_03_01-03_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_01_initialized/answers/02_03_01-03_error_typo.answer
@@ -6,7 +6,7 @@ Stored procedure compile error: no viable alternative at input 'a INT'
 ===================================================
 Error:-1360
 In line 2, column 20
-Stored procedure compile error: mismatched input 'NOLL' expecting NULL_
+Stored procedure compile error: mismatched input 'NOLL'
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_01_initialized/answers/02_03_01-03_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_01_initialized/answers/02_03_01-03_error_typo.answer
@@ -11,15 +11,15 @@ Stored procedure compile error: mismatched input 'NOLL' expecting NULL_
 ===================================================
 Error:-1360
 In line 2, column 16
-Stored procedure compile error: mismatched input 'NUT' expecting {DEFAULT, NOT, ':=', SEMICOLON}
+Stored procedure compile error: mismatched input 'NUT'
 
 ===================================================
 Error:-1360
 In line 2, column 17
-Stored procedure compile error: mismatched input 'DEFAULTS' expecting {DEFAULT, NOT, ':=', SEMICOLON}
+Stored procedure compile error: mismatched input 'DEFAULTS'
 
 ===================================================
 Error:-1360
 In line 2, column 16
-Stored procedure compile error: mismatched input '3' expecting {DEFAULT, NOT, ':=', SEMICOLON}
+Stored procedure compile error: mismatched input '3'
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_01_initialized/answers/02_03_01-06_error_function.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_01_initialized/answers/02_03_01-06_error_function.answer
@@ -9,7 +9,7 @@ Stored procedure execute error:
 ===================================================
 Error:-1360
 In line 2, column 17
-Stored procedure compile error: mismatched input ';' expecting {DEFAULT, NOT, ':='}
+Stored procedure compile error: mismatched input ';'
 
 ===================================================
 Error:-889
@@ -27,7 +27,7 @@ Stored procedure execute error:
 ===================================================
 Error:-1360
 In line 2, column 19
-Stored procedure compile error: mismatched input ';' expecting {DEFAULT, NOT, ':='}
+Stored procedure compile error: mismatched input ';'
 
 ===================================================
 Error:-889
@@ -42,7 +42,7 @@ Stored procedure compile error: function LPAD is undefined or given wrong number
 ===================================================
 Error:-1360
 In line 2, column 19
-Stored procedure compile error: mismatched input ';' expecting {DEFAULT, NOT, ':='}
+Stored procedure compile error: mismatched input ';'
 
 ===================================================
 Error:-1360
@@ -52,7 +52,7 @@ Stored procedure compile error: Stored procedure/function 'dba.user_a' does not 
 ===================================================
 Error:-1360
 In line 2, column 19
-Stored procedure compile error: mismatched input ';' expecting {DEFAULT, NOT, ':='}
+Stored procedure compile error: mismatched input ';'
 
 ===================================================
 Error:-889

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_02_uninitialized/answers/02_03_02-01_error_no_init.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_02_uninitialized/answers/02_03_02-01_error_no_init.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 2, column 15
-Stored procedure compile error: mismatched input ';' expecting {DEFAULT, NOT, ':='}
+Stored procedure compile error: mismatched input ';'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_03_common/answers/02_03_03-03_error_constant_with_same_name.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_03_common/answers/02_03_03-03_error_constant_with_same_name.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 3, column 15
-Stored procedure compile error: mismatched input ';' expecting {DEFAULT, NOT, ':='}
+Stored procedure compile error: mismatched input ';'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_03_common/answers/02_03_03-03_error_cursor_with_same_name.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_03_common/answers/02_03_03-03_error_cursor_with_same_name.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 3, column 15
-Stored procedure compile error: mismatched input ';' expecting {DEFAULT, NOT, ':='}
+Stored procedure compile error: mismatched input ';'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_03_common/answers/02_03_03-03_error_exception_with_same_name.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_03_common/answers/02_03_03-03_error_exception_with_same_name.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 3, column 15
-Stored procedure compile error: mismatched input ';' expecting {DEFAULT, NOT, ':='}
+Stored procedure compile error: mismatched input ';'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_03_common/answers/02_03_03-03_error_parameter_with_same_name.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_03_common/answers/02_03_03-03_error_parameter_with_same_name.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 2, column 15
-Stored procedure compile error: mismatched input ';' expecting {DEFAULT, NOT, ':='}
+Stored procedure compile error: mismatched input ';'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_03_common/answers/02_03_03-03_error_procedure_with_same_name.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_03_common/answers/02_03_03-03_error_procedure_with_same_name.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 6, column 15
-Stored procedure compile error: mismatched input ';' expecting {DEFAULT, NOT, ':='}
+Stored procedure compile error: mismatched input ';'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_03_common/answers/02_03_03-03_error_variable_with_same_name.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_03_common/answers/02_03_03-03_error_variable_with_same_name.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 3, column 15
-Stored procedure compile error: mismatched input ';' expecting {DEFAULT, NOT, ':='}
+Stored procedure compile error: mismatched input ';'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_04_exception/_01_basic/answers/02_04_01-03_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_04_exception/_01_basic/answers/02_04_01-03_error_typo.answer
@@ -6,10 +6,10 @@ Stored procedure compile error: no viable alternative at input 'exceptions;'
 ===================================================
 Error:-1360
 In line 6, column 1
-Stored procedure compile error: mismatched input 'when' expecting {LPAREN, SEMICOLON}
+Stored procedure compile error: mismatched input 'when'
 
 ===================================================
 Error:-1360
 In line 6, column 1
-Stored procedure compile error: mismatched input 'when' expecting {LPAREN, SEMICOLON}
+Stored procedure compile error: mismatched input 'when'
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_04_exception/_01_basic/answers/02_04_01-05_error_reserved_exception.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_04_exception/_01_basic/answers/02_04_01-05_error_reserved_exception.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 2, column 1
-Stored procedure compile error: mismatched input 'exception' expecting {BEGIN, CURSOR, FUNCTION, LANGUAGE, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'exception'
 
 ===================================================
 Error:-1360
@@ -11,5 +11,5 @@ Stored procedure compile error: extraneous input 'exception' expecting SEMICOLON
 ===================================================
 Error:-1360
 In line 6, column 6
-Stored procedure compile error: mismatched input 'exception' expecting {REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'exception'
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_04_exception/_01_basic/answers/02_04_01-05_error_reserved_exception.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_04_exception/_01_basic/answers/02_04_01-05_error_reserved_exception.answer
@@ -6,7 +6,7 @@ Stored procedure compile error: mismatched input 'exception'
 ===================================================
 Error:-1360
 In line 4, column 7
-Stored procedure compile error: extraneous input 'exception' expecting SEMICOLON
+Stored procedure compile error: extraneous input 'exception'
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_05_autonomous_transaction/_01_basic/answers/02_05_01-04_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_05_autonomous_transaction/_01_basic/answers/02_05_01-04_error_typo.answer
@@ -6,5 +6,5 @@ Stored procedure compile error: no viable alternative at input 'PRAGMAA AUTONOMO
 ===================================================
 Error:-1360
 In line 7, column 8
-Stored procedure compile error: mismatched input 'AUTONOMOUS_TRANSACTIONS' expecting AUTONOMOUS_TRANSACTION
+Stored procedure compile error: mismatched input 'AUTONOMOUS_TRANSACTIONS'
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_05_autonomous_transaction/_01_basic/answers/02_05_01-05_error_position.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_05_autonomous_transaction/_01_basic/answers/02_05_01-05_error_position.answer
@@ -1,10 +1,10 @@
 ===================================================
 Error:-1360
 In line 9, column 1
-Stored procedure compile error: mismatched input 'INSERT' expecting {<EOF>, COMMENT}
+Stored procedure compile error: mismatched input 'INSERT'
 
 ===================================================
 Error:-1360
 In line 13, column 1
-Stored procedure compile error: mismatched input 'WHEN' expecting {<EOF>, COMMENT}
+Stored procedure compile error: mismatched input 'WHEN'
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_06_cursor/_01_basic/answers/02_06_01-06_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_06_cursor/_01_basic/answers/02_06_01-06_error_typo.answer
@@ -30,7 +30,7 @@ Stored procedure compile error: mismatched input 'loop'
 ===================================================
 Error:-1360
 In line 13, column 7
-Stored procedure compile error: extraneous input 'c' expecting SEMICOLON
+Stored procedure compile error: extraneous input 'c'
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_06_cursor/_01_basic/answers/02_06_01-06_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_06_cursor/_01_basic/answers/02_06_01-06_error_typo.answer
@@ -10,12 +10,12 @@
 ===================================================
 Error:-1360
 In line 2, column 17
-Stored procedure compile error: mismatched input ')' expecting {DEFAULT, NOT, ':=', SEMICOLON}
+Stored procedure compile error: mismatched input ')'
 
 ===================================================
 Error:-1360
 In line 2, column 19
-Stored procedure compile error: mismatched input 'as' expecting {RPAREN, ','}
+Stored procedure compile error: mismatched input 'as'
 
 ===================================================
 Error:-1360
@@ -25,7 +25,7 @@ Stored procedure compile error: missing SEMICOLON at 'c'
 ===================================================
 Error:-1360
 In line 12, column 5
-Stored procedure compile error: mismatched input 'loop' expecting {<EOF>, COMMENT, REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input 'loop'
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_06_cursor/_01_basic/answers/02_06_01-07_error_reserved.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_06_cursor/_01_basic/answers/02_06_01-07_error_reserved.answer
@@ -10,7 +10,7 @@
 ===================================================
 Error:-1360
 In line 13, column 7
-Stored procedure compile error: mismatched input 'cursor' expecting {REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'cursor'
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_06_cursor/_02_into_type_conversion/answers/02_06_02-17_column_to_into_NUMERIC.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_06_cursor/_02_into_type_conversion/answers/02_06_02-17_column_to_into_NUMERIC.answer
@@ -222,7 +222,7 @@ t_NUMERIC_NUMERIC. This scenario is a success.
 ===================================================
 Error:-1360
 In line 11, column 38
-Stored procedure compile error: mismatched input 'DECIMAL' expecting {RPAREN, ','}
+Stored procedure compile error: mismatched input 'DECIMAL'
 
 ===================================================
 Error:-495

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_07_local_proc/_01_wo_param/answers/02_07_01-02_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_07_local_proc/_01_wo_param/answers/02_07_01-02_error_typo.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 3, column 22
-Stored procedure compile error: mismatched input ')' expecting {DEFAULT, NOT, ':=', SEMICOLON}
+Stored procedure compile error: mismatched input ')'
 
 ===================================================
 Error:-493
@@ -17,7 +17,7 @@ Syntax error: unexpected 'end', expecting SELECT or VALUE or VALUES or '('
 ===================================================
 Error:-1360
 In line 12, column 1
-Stored procedure compile error: mismatched input 'begin' expecting {<EOF>, COMMENT}
+Stored procedure compile error: mismatched input 'begin'
 
 ===================================================
 Error:-1360
@@ -38,5 +38,5 @@ Syntax error: unexpected 'end', expecting SELECT or VALUE or VALUES or '('
 ===================================================
 Error:-1360
 In line 16, column 1
-Stored procedure compile error: mismatched input 'end' expecting {BEGIN, CURSOR, FUNCTION, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'end'
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_07_local_proc/_06_writing_rule/answers/02_07_06-03_error_bracket_symbol.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_07_local_proc/_06_writing_rule/answers/02_07_06-03_error_bracket_symbol.answer
@@ -6,10 +6,10 @@ Stored procedure compile error: mismatched input ';'
 ===================================================
 Error:-1360
 In line 13, column 10
-Stored procedure compile error: extraneous input ')' expecting SEMICOLON
+Stored procedure compile error: extraneous input ')'
 
 ===================================================
 Error:-1360
 In line 13, column 6
-Stored procedure compile error: extraneous input 'cnt' expecting SEMICOLON
+Stored procedure compile error: extraneous input 'cnt'
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_07_local_proc/_06_writing_rule/answers/02_07_06-03_error_bracket_symbol.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_07_local_proc/_06_writing_rule/answers/02_07_06-03_error_bracket_symbol.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 13, column 10
-Stored procedure compile error: mismatched input ';' expecting {RPAREN, ','}
+Stored procedure compile error: mismatched input ';'
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_08_local_func/_01_wo_param/answers/02_08_01-02_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_08_local_func/_01_wo_param/answers/02_08_01-02_error_typo.answer
@@ -112,7 +112,7 @@ Syntax error: unexpected 'END', expecting SELECT or VALUE or VALUES or '('
 ===================================================
 Error:-1360
 In line 15, column 1
-Stored procedure compile error: mismatched input 'begin' expecting {<EOF>, COMMENT}
+Stored procedure compile error: mismatched input 'begin'
 
 ===================================================
 Error:-494
@@ -125,7 +125,7 @@ dba.INTS is not defined. create function [dba.choose](m  integer, n  integer) re
 ===================================================
 Error:-1360
 In line 15, column 1
-Stored procedure compile error: mismatched input 'begin' expecting {<EOF>, COMMENT}
+Stored procedure compile error: mismatched input 'begin'
 
 ===================================================
 Error:-1360
@@ -168,5 +168,5 @@ Stored procedure compile error: undeclared identifier 'AA'
 ===================================================
 Error:-1360
 In line 23, column 1
-Stored procedure compile error: mismatched input 'end' expecting {BEGIN, CURSOR, FUNCTION, PRAGMA, PROCEDURE, REVERSE, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'end'
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_08_local_func/_01_wo_param/answers/02_08_01-02_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_08_local_func/_01_wo_param/answers/02_08_01-02_error_typo.answer
@@ -158,7 +158,7 @@ Syntax error: unexpected 'END', expecting SELECT or VALUE or VALUES or '('
 ===================================================
 Error:-1360
 In line 10, column 9
-Stored procedure compile error: extraneous input '1' expecting SEMICOLON
+Stored procedure compile error: extraneous input '1'
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_08_local_func/_06_writing_rule/answers/02_08_06-03_error_bracket_symbol.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_08_local_func/_06_writing_rule/answers/02_08_06-03_error_bracket_symbol.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 19, column 20
-Stored procedure compile error: mismatched input ';' expecting {RPAREN, ','}
+Stored procedure compile error: mismatched input ';'
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_08_local_func/_06_writing_rule/answers/02_08_06-03_error_bracket_symbol.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_08_local_func/_06_writing_rule/answers/02_08_06-03_error_bracket_symbol.answer
@@ -6,10 +6,10 @@ Stored procedure compile error: mismatched input ';'
 ===================================================
 Error:-1360
 In line 19, column 19
-Stored procedure compile error: extraneous input ')' expecting SEMICOLON
+Stored procedure compile error: extraneous input ')'
 
 ===================================================
 Error:-1360
 In line 19, column 18
-Stored procedure compile error: extraneous input 'm' expecting SEMICOLON
+Stored procedure compile error: extraneous input 'm'
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/06_error_unsupport_percent_type_variable.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/06_error_unsupport_percent_type_variable.answer
@@ -9,7 +9,7 @@ TIMESTAMPLTZ #1
 ===================================================
 Error:-1360
 In line 4, column 21
-Stored procedure compile error: extraneous input 'timestampltz' expecting {INSERT, REPLACE, TRUNCATE, CASE, CURRENT_USER, DATE, DATETIME, DEFAULT, FALSE, IF, MOD, NOT, NULL_, REVERSE, SQL, SQLCODE, SQLERRM, TIMESTAMP, TIME, TRUE, FLOATING_POINT_NUM, UNSIGNED_INTEGER, DELIMITED_ID, CHAR_STRING, LPAREN, '+', '-', '~', REGULAR_ID}
+Stored procedure compile error: extraneous input 'timestampltz'
 
 ===================================================
     
@@ -29,7 +29,7 @@ TIMESTAMPTZ #1
 ===================================================
 Error:-1360
 In line 4, column 21
-Stored procedure compile error: extraneous input 'timestamptz' expecting {INSERT, REPLACE, TRUNCATE, CASE, CURRENT_USER, DATE, DATETIME, DEFAULT, FALSE, IF, MOD, NOT, NULL_, REVERSE, SQL, SQLCODE, SQLERRM, TIMESTAMP, TIME, TRUE, FLOATING_POINT_NUM, UNSIGNED_INTEGER, DELIMITED_ID, CHAR_STRING, LPAREN, '+', '-', '~', REGULAR_ID}
+Stored procedure compile error: extraneous input 'timestamptz'
 
 ===================================================
     
@@ -49,7 +49,7 @@ DATETIMELTZ #1
 ===================================================
 Error:-1360
 In line 4, column 21
-Stored procedure compile error: extraneous input 'datetimeltz' expecting {INSERT, REPLACE, TRUNCATE, CASE, CURRENT_USER, DATE, DATETIME, DEFAULT, FALSE, IF, MOD, NOT, NULL_, REVERSE, SQL, SQLCODE, SQLERRM, TIMESTAMP, TIME, TRUE, FLOATING_POINT_NUM, UNSIGNED_INTEGER, DELIMITED_ID, CHAR_STRING, LPAREN, '+', '-', '~', REGULAR_ID}
+Stored procedure compile error: extraneous input 'datetimeltz'
 
 ===================================================
     
@@ -69,7 +69,7 @@ DATETIMETZ #1
 ===================================================
 Error:-1360
 In line 4, column 21
-Stored procedure compile error: extraneous input 'datetimetz' expecting {INSERT, REPLACE, TRUNCATE, CASE, CURRENT_USER, DATE, DATETIME, DEFAULT, FALSE, IF, MOD, NOT, NULL_, REVERSE, SQL, SQLCODE, SQLERRM, TIMESTAMP, TIME, TRUE, FLOATING_POINT_NUM, UNSIGNED_INTEGER, DELIMITED_ID, CHAR_STRING, LPAREN, '+', '-', '~', REGULAR_ID}
+Stored procedure compile error: extraneous input 'datetimetz'
 
 ===================================================
     
@@ -149,7 +149,7 @@ BLOB #1
 ===================================================
 Error:-1360
 In line 4, column 34
-Stored procedure compile error: extraneous input ''000100'' expecting {RPAREN, ','}
+Stored procedure compile error: extraneous input ''000100''
 
 ===================================================
     

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/06_error_unsupport_percent_type_variable.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/06_error_unsupport_percent_type_variable.answer
@@ -89,7 +89,7 @@ BIT #1
 ===================================================
 Error:-1360
 In line 4, column 22
-Stored procedure compile error: extraneous input ''1'' expecting SEMICOLON
+Stored procedure compile error: extraneous input ''1''
 
 ===================================================
     
@@ -109,7 +109,7 @@ BIT VARYING #1
 ===================================================
 Error:-1360
 In line 4, column 22
-Stored procedure compile error: extraneous input 'xcf' expecting SEMICOLON
+Stored procedure compile error: extraneous input 'xcf'
 
 ===================================================
     

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/09_error_percent_type_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/09_error_percent_type_typo.answer
@@ -165,12 +165,12 @@ written a column type
 ===================================================
 Error:-1360
 In line 2, column 20
-Stored procedure compile error: mismatched input 'type_support' expecting {DEFAULT, NOT, ':=', SEMICOLON}
+Stored procedure compile error: mismatched input 'type_support'
 
 ===================================================
 Error:-1360
 In line 2, column 57
-Stored procedure compile error: extraneous input 'INTEGER' expecting {DEFAULT, NOT, ':='}
+Stored procedure compile error: extraneous input 'INTEGER'
 
 ===================================================
 Error:-493

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/26_error_unsupport_viewtable_percent_type_variable.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/26_error_unsupport_viewtable_percent_type_variable.answer
@@ -12,7 +12,7 @@ TIMESTAMPLTZ #1
 ===================================================
 Error:-1360
 In line 4, column 21
-Stored procedure compile error: extraneous input 'timestampltz' expecting {INSERT, REPLACE, TRUNCATE, CASE, CURRENT_USER, DATE, DATETIME, DEFAULT, FALSE, IF, MOD, NOT, NULL_, REVERSE, SQL, SQLCODE, SQLERRM, TIMESTAMP, TIME, TRUE, FLOATING_POINT_NUM, UNSIGNED_INTEGER, DELIMITED_ID, CHAR_STRING, LPAREN, '+', '-', '~', REGULAR_ID}
+Stored procedure compile error: extraneous input 'timestampltz'
 
 ===================================================
     
@@ -32,7 +32,7 @@ TIMESTAMPTZ #1
 ===================================================
 Error:-1360
 In line 4, column 21
-Stored procedure compile error: extraneous input 'timestamptz' expecting {INSERT, REPLACE, TRUNCATE, CASE, CURRENT_USER, DATE, DATETIME, DEFAULT, FALSE, IF, MOD, NOT, NULL_, REVERSE, SQL, SQLCODE, SQLERRM, TIMESTAMP, TIME, TRUE, FLOATING_POINT_NUM, UNSIGNED_INTEGER, DELIMITED_ID, CHAR_STRING, LPAREN, '+', '-', '~', REGULAR_ID}
+Stored procedure compile error: extraneous input 'timestamptz'
 
 ===================================================
     
@@ -52,7 +52,7 @@ DATETIMELTZ #1
 ===================================================
 Error:-1360
 In line 4, column 21
-Stored procedure compile error: extraneous input 'datetimeltz' expecting {INSERT, REPLACE, TRUNCATE, CASE, CURRENT_USER, DATE, DATETIME, DEFAULT, FALSE, IF, MOD, NOT, NULL_, REVERSE, SQL, SQLCODE, SQLERRM, TIMESTAMP, TIME, TRUE, FLOATING_POINT_NUM, UNSIGNED_INTEGER, DELIMITED_ID, CHAR_STRING, LPAREN, '+', '-', '~', REGULAR_ID}
+Stored procedure compile error: extraneous input 'datetimeltz'
 
 ===================================================
     
@@ -72,7 +72,7 @@ DATETIMETZ #1
 ===================================================
 Error:-1360
 In line 4, column 21
-Stored procedure compile error: extraneous input 'datetimetz' expecting {INSERT, REPLACE, TRUNCATE, CASE, CURRENT_USER, DATE, DATETIME, DEFAULT, FALSE, IF, MOD, NOT, NULL_, REVERSE, SQL, SQLCODE, SQLERRM, TIMESTAMP, TIME, TRUE, FLOATING_POINT_NUM, UNSIGNED_INTEGER, DELIMITED_ID, CHAR_STRING, LPAREN, '+', '-', '~', REGULAR_ID}
+Stored procedure compile error: extraneous input 'datetimetz'
 
 ===================================================
     
@@ -152,7 +152,7 @@ BLOB #1
 ===================================================
 Error:-1360
 In line 4, column 34
-Stored procedure compile error: extraneous input ''000100'' expecting {RPAREN, ','}
+Stored procedure compile error: extraneous input ''000100''
 
 ===================================================
     

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/26_error_unsupport_viewtable_percent_type_variable.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/26_error_unsupport_viewtable_percent_type_variable.answer
@@ -92,7 +92,7 @@ BIT #1
 ===================================================
 Error:-1360
 In line 4, column 22
-Stored procedure compile error: extraneous input ''1'' expecting SEMICOLON
+Stored procedure compile error: extraneous input ''1''
 
 ===================================================
     
@@ -112,7 +112,7 @@ BIT VARYING #1
 ===================================================
 Error:-1360
 In line 4, column 22
-Stored procedure compile error: extraneous input 'xcf' expecting SEMICOLON
+Stored procedure compile error: extraneous input 'xcf'
 
 ===================================================
     

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/29_error_viewtable_percent_type_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/29_error_viewtable_percent_type_typo.answer
@@ -159,12 +159,12 @@ written a column type
 ===================================================
 Error:-1360
 In line 2, column 20
-Stored procedure compile error: mismatched input 'type_support' expecting {DEFAULT, NOT, ':=', SEMICOLON}
+Stored procedure compile error: mismatched input 'type_support'
 
 ===================================================
 Error:-1360
 In line 2, column 57
-Stored procedure compile error: extraneous input 'INTEGER' expecting {DEFAULT, NOT, ':='}
+Stored procedure compile error: extraneous input 'INTEGER'
 
 ===================================================
 Error:-493

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_01_block/_01_with_decl_part/answers/03_01_01-08_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_01_block/_01_with_decl_part/answers/03_01_01-08_error_typo.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 6, column 1
-Stored procedure compile error: mismatched input 'BEGIN' expecting {LPAREN, SEMICOLON}
+Stored procedure compile error: mismatched input 'BEGIN'
 
 ===================================================
 Error:-1360
@@ -26,17 +26,17 @@ Stored procedure compile error: no viable alternative at input 'EXCEPTIONS;'
 ===================================================
 Error:-1360
 In line 15, column 1
-Stored procedure compile error: mismatched input 'RAISE' expecting {REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input 'RAISE'
 
 ===================================================
 Error:-1360
 In line 15, column 1
-Stored procedure compile error: mismatched input 'RAISE' expecting {REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input 'RAISE'
 
 ===================================================
 Error:-1360
 In line 15, column 1
-Stored procedure compile error: mismatched input 'RAISE' expecting {REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input 'RAISE'
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_01_open/answers/03_03_01-07_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_01_open/answers/03_03_01-07_error_typo.answer
@@ -21,12 +21,12 @@ Stored procedure compile error: missing SEMICOLON at 'my_cursor'
 ===================================================
 Error:-1360
 In line 13, column 5
-Stored procedure compile error: mismatched input 'LOOP' expecting {<EOF>, COMMENT, REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LOOP'
 
 ===================================================
 Error:-1360
 In line 13, column 5
-Stored procedure compile error: mismatched input 'LOOP' expecting {<EOF>, COMMENT, REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LOOP'
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_01_open/answers/03_03_01-07_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_01_open/answers/03_03_01-07_error_typo.answer
@@ -31,12 +31,12 @@ Stored procedure compile error: mismatched input 'LOOP'
 ===================================================
 Error:-1360
 In line 11, column 29
-Stored procedure compile error: extraneous input 's' expecting SEMICOLON
+Stored procedure compile error: extraneous input 's'
 
 ===================================================
 Error:-1360
 In line 14, column 8
-Stored procedure compile error: extraneous input 'my_cursor' expecting SEMICOLON
+Stored procedure compile error: extraneous input 'my_cursor'
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_01_into_clause/answers/03_04_01-05_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_01_into_clause/answers/03_04_01-05_error_typo.answer
@@ -1,12 +1,12 @@
 ===================================================
 Error:-1360
 In line 4, column 10
-Stored procedure compile error: mismatched input 'IMMEDIATE' expecting {LPAREN, SEMICOLON}
+Stored procedure compile error: mismatched input 'IMMEDIATE'
 
 ===================================================
 Error:-1360
 In line 4, column 20
-Stored procedure compile error: mismatched input ''create table '' expecting {AND, BETWEEN, DIV, IN, INTO, IS, LIKE, MOD, NOT, OR, USING, XOR, '<=>', '>=', '<=', '||', '<<', '>>', '*', '+', '-', '/', NOT_EQUAL_OP, '&', '^', '>', '<', SEMICOLON, '|', '='}
+Stored procedure compile error: mismatched input ''create table ''
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_01_into_clause/answers/03_04_01-05_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_01_into_clause/answers/03_04_01-05_error_typo.answer
@@ -11,5 +11,5 @@ Stored procedure compile error: mismatched input ''create table ''
 ===================================================
 Error:-1360
 In line 5, column 8
-Stored procedure compile error: extraneous input 'name' expecting SEMICOLON
+Stored procedure compile error: extraneous input 'name'
 

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_03_common/answers/03_04_03-07_error_into.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_03_common/answers/03_04_03-07_error_into.answer
@@ -1,5 +1,5 @@
 ===================================================
 Error:-1360
 In line 7, column 1
-Stored procedure compile error: mismatched input 'put_line' expecting {USING, ',', SEMICOLON}
+Stored procedure compile error: mismatched input 'put_line'
 

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_05_assign/_01_basic/answers/03_05_01-04_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_05_assign/_01_basic/answers/03_05_01-04_error_typo.answer
@@ -1,10 +1,10 @@
 ===================================================
 Error:-1360
 In line 6, column 1
-Stored procedure compile error: mismatched input 'EXECUTE' expecting {LPAREN, SEMICOLON}
+Stored procedure compile error: mismatched input 'EXECUTE'
 
 ===================================================
 Error:-1360
 In line 6, column 1
-Stored procedure compile error: mismatched input 'EXECUTE' expecting {LPAREN, SEMICOLON}
+Stored procedure compile error: mismatched input 'EXECUTE'
 

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_06_continue/_01_with_label/answers/03_06_01-03_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_06_continue/_01_with_label/answers/03_06_01-03_error_typo.answer
@@ -1,20 +1,20 @@
 ===================================================
 Error:-1360
 In line 5, column 7
-Stored procedure compile error: mismatched input 'WHEN' expecting {LPAREN, SEMICOLON}
+Stored procedure compile error: mismatched input 'WHEN'
 
 ===================================================
 Error:-1360
 In line 5, column 13
-Stored procedure compile error: mismatched input '>' expecting {WHEN, SEMICOLON}
+Stored procedure compile error: mismatched input '>'
 
 ===================================================
 Error:-1360
 In line 5, column 11
-Stored procedure compile error: mismatched input 'WHEN' expecting {LPAREN, SEMICOLON}
+Stored procedure compile error: mismatched input 'WHEN'
 
 ===================================================
 Error:-1360
 In line 5, column 17
-Stored procedure compile error: mismatched input '>' expecting {WHEN, SEMICOLON}
+Stored procedure compile error: mismatched input '>'
 

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_07_exit/_02_with_when_clause/answers/03_07_02-03_error_not_boolean.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_07_exit/_02_with_when_clause/answers/03_07_02-03_error_not_boolean.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 5, column 13
-Stored procedure compile error: mismatched input ':=' expecting {AND, BETWEEN, DIV, IN, IS, LIKE, MOD, NOT, OR, XOR, '<=>', '>=', '<=', '||', '<<', '>>', '*', '+', '-', '/', NOT_EQUAL_OP, '&', '^', '>', '<', SEMICOLON, '|', '='}
+Stored procedure compile error: mismatched input ':='
 
 ===================================================
 Error:-1360
@@ -16,5 +16,5 @@ Stored procedure compile error: type of the condition must be boolean
 ===================================================
 Error:-1360
 In line 5, column 11
-Stored procedure compile error: extraneous input '!' expecting {INSERT, REPLACE, TRUNCATE, CASE, CURRENT_USER, DATE, DATETIME, DEFAULT, FALSE, IF, MOD, NOT, NULL_, REVERSE, SQL, SQLCODE, SQLERRM, TIMESTAMP, TIME, TRUE, FLOATING_POINT_NUM, UNSIGNED_INTEGER, DELIMITED_ID, CHAR_STRING, LPAREN, '+', '-', '~', REGULAR_ID}
+Stored procedure compile error: extraneous input '!'
 

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-19_variable_to_return_SET.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-19_variable_to_return_SET.answer
@@ -10,7 +10,7 @@ t_DATETIME_SET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 116
-Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SET'
 
 ===================================================
 Error:-494
@@ -79,7 +79,7 @@ t_DATE_SET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 108
-Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SET'
 
 ===================================================
 Error:-494
@@ -100,7 +100,7 @@ t_TIME_SET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 108
-Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SET'
 
 ===================================================
 Error:-494
@@ -121,7 +121,7 @@ t_TIMESTAMP_SET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 118
-Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SET'
 
 ===================================================
 Error:-494
@@ -190,7 +190,7 @@ t_DOUBLE_SET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 112
-Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SET'
 
 ===================================================
 Error:-494
@@ -211,7 +211,7 @@ t_FLOAT_SET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 110
-Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SET'
 
 ===================================================
 Error:-494
@@ -232,7 +232,7 @@ t_NUMERIC(8,4)_SET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 114
-Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SET'
 
 ===================================================
 Error:-494
@@ -253,7 +253,7 @@ t_BIGINT_SET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 112
-Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SET'
 
 ===================================================
 Error:-494
@@ -274,7 +274,7 @@ t_INT_SET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 106
-Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SET'
 
 ===================================================
 Error:-494
@@ -295,7 +295,7 @@ t_SHORT_SET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 110
-Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SET'
 
 ===================================================
 Error:-494
@@ -365,7 +365,7 @@ t_CHAR_SET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 108
-Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SET'
 
 ===================================================
 Error:-494
@@ -386,7 +386,7 @@ t_VARCHAR_SET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 114
-Stored procedure compile error: mismatched input 'SET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'SET'
 
 ===================================================
 Error:-494

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-20_variable_to_return_MULTISET.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-20_variable_to_return_MULTISET.answer
@@ -10,7 +10,7 @@ t_DATETIME_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 121
-Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'MULTISET'
 
 ===================================================
 Error:-494
@@ -79,7 +79,7 @@ t_DATE_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 113
-Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'MULTISET'
 
 ===================================================
 Error:-494
@@ -100,7 +100,7 @@ t_TIME_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 113
-Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'MULTISET'
 
 ===================================================
 Error:-494
@@ -121,7 +121,7 @@ t_TIMESTAMP_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 123
-Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'MULTISET'
 
 ===================================================
 Error:-494
@@ -190,7 +190,7 @@ t_DOUBLE_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 117
-Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'MULTISET'
 
 ===================================================
 Error:-494
@@ -211,7 +211,7 @@ t_FLOAT_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 115
-Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'MULTISET'
 
 ===================================================
 Error:-494
@@ -232,7 +232,7 @@ t_NUMERIC(8,4)_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 119
-Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'MULTISET'
 
 ===================================================
 Error:-494
@@ -253,7 +253,7 @@ t_BIGINT_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 117
-Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'MULTISET'
 
 ===================================================
 Error:-494
@@ -274,7 +274,7 @@ t_INT_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 111
-Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'MULTISET'
 
 ===================================================
 Error:-494
@@ -295,7 +295,7 @@ t_SHORT_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 115
-Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'MULTISET'
 
 ===================================================
 Error:-494
@@ -364,7 +364,7 @@ t_CHAR_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 113
-Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'MULTISET'
 
 ===================================================
 Error:-494
@@ -385,7 +385,7 @@ t_VARCHAR_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 119
-Stored procedure compile error: mismatched input 'MULTISET' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'MULTISET'
 
 ===================================================
 Error:-494

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-21_variable_to_return_LIST.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-21_variable_to_return_LIST.answer
@@ -10,7 +10,7 @@ t_DATETIME_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 117
-Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIST'
 
 ===================================================
 Error:-494
@@ -79,7 +79,7 @@ t_DATE_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 109
-Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIST'
 
 ===================================================
 Error:-494
@@ -100,7 +100,7 @@ t_TIME_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 109
-Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIST'
 
 ===================================================
 Error:-494
@@ -121,7 +121,7 @@ t_TIMESTAMP_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 119
-Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIST'
 
 ===================================================
 Error:-494
@@ -190,7 +190,7 @@ t_DOUBLE_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 113
-Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIST'
 
 ===================================================
 Error:-494
@@ -211,7 +211,7 @@ t_FLOAT_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 111
-Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIST'
 
 ===================================================
 Error:-494
@@ -232,7 +232,7 @@ t_NUMERIC(8,4)_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 115
-Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIST'
 
 ===================================================
 Error:-494
@@ -253,7 +253,7 @@ t_BIGINT_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 113
-Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIST'
 
 ===================================================
 Error:-494
@@ -274,7 +274,7 @@ t_INT_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 107
-Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIST'
 
 ===================================================
 Error:-494
@@ -295,7 +295,7 @@ t_SHORT_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 111
-Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIST'
 
 ===================================================
 Error:-494
@@ -365,7 +365,7 @@ t_CHAR_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 109
-Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIST'
 
 ===================================================
 Error:-494
@@ -386,7 +386,7 @@ t_VARCHAR_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
 In line 1, column 115
-Stored procedure compile error: mismatched input 'LIST' expecting {BIGINT, BOOLEAN, CHARACTER, CHAR, DATE, DATETIME, DEC, DECIMAL, DOUBLE, FLOAT, INTEGER, INT, NUMERIC, REAL, REVERSE, SHORT, SMALLINT, STRING, SYS_REFCURSOR, TIMESTAMP, TIME, VARCHAR, DELIMITED_ID, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LIST'
 
 ===================================================
 Error:-494

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_03_for_iter/answers/03_13_03-07_normal_space_handling_between_dots.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_03_for_iter/answers/03_13_03-07_normal_space_handling_between_dots.answer
@@ -63,7 +63,7 @@ case4
 ===================================================
 Error:-1360
 In line 3, column 13
-Stored procedure compile error: extraneous input '..' expecting {INSERT, REPLACE, TRUNCATE, CASE, CURRENT_USER, DATE, DATETIME, DEFAULT, FALSE, IF, MOD, NULL_, REVERSE, SQL, SQLCODE, SQLERRM, TIMESTAMP, TIME, TRUE, FLOATING_POINT_NUM, UNSIGNED_INTEGER, DELIMITED_ID, CHAR_STRING, LPAREN, '+', '-', '~', REGULAR_ID}
+Stored procedure compile error: extraneous input '..'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-01_normal_basic.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-01_normal_basic.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 6, column 5
-Stored procedure compile error: mismatched input 'loop' expecting {<EOF>, COMMENT, REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input 'loop'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-01_normal_basic_2.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-01_normal_basic_2.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 6, column 5
-Stored procedure compile error: mismatched input 'loop' expecting {<EOF>, COMMENT, REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input 'loop'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-02_error_using_out_var.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-02_error_using_out_var.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 6, column 5
-Stored procedure compile error: mismatched input 'loop' expecting {<EOF>, COMMENT, REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input 'loop'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-02_error_using_out_var_2.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-02_error_using_out_var_2.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 6, column 5
-Stored procedure compile error: mismatched input 'loop' expecting {<EOF>, COMMENT, REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input 'loop'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-02_error_using_out_var_3.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-02_error_using_out_var_3.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 6, column 5
-Stored procedure compile error: mismatched input 'loop' expecting {<EOF>, COMMENT, REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input 'loop'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-03_normal_hostvar_len_mismatch.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-03_normal_hostvar_len_mismatch.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 5, column 5
-Stored procedure compile error: mismatched input 'loop' expecting {<EOF>, COMMENT, REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input 'loop'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-03_normal_hostvar_len_mismatch_2.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-03_normal_hostvar_len_mismatch_2.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 5, column 5
-Stored procedure compile error: mismatched input 'loop' expecting {<EOF>, COMMENT, REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input 'loop'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-04_error_incompatible_used_val.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-04_error_incompatible_used_val.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 5, column 5
-Stored procedure compile error: mismatched input 'loop' expecting {<EOF>, COMMENT, REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input 'loop'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-04_normal_incompatible_used_val_2.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-04_normal_incompatible_used_val_2.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 5, column 5
-Stored procedure compile error: mismatched input 'loop' expecting {<EOF>, COMMENT, REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input 'loop'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/normal_basic_3.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/normal_basic_3.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 5, column 5
-Stored procedure compile error: mismatched input 'loop' expecting {<EOF>, COMMENT, REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input 'loop'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_03_field/_01_basic/answers/04_03_01-03_normal_dyn_field_name_unknown.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_03_field/_01_basic/answers/04_03_01-03_normal_dyn_field_name_unknown.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 5, column 5
-Stored procedure compile error: mismatched input 'loop' expecting {<EOF>, COMMENT, REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input 'loop'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_bit_length.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_bit_length.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 7, column 34
-Stored procedure compile error: extraneous input ''01010101'' expecting {RPAREN, ','}
+Stored procedure compile error: extraneous input ''01010101''
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_character_length.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_character_length.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 7, column 40
-Stored procedure compile error: extraneous input ''01010101'' expecting {RPAREN, ','}
+Stored procedure compile error: extraneous input ''01010101''
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_chr.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_chr.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 8, column 31
-Stored procedure compile error: extraneous input ''E381BE'' expecting {RPAREN, ','}
+Stored procedure compile error: extraneous input ''E381BE''
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_concat.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_concat.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 9, column 34
-Stored procedure compile error: extraneous input ''E381BE'' expecting {RPAREN, ','}
+Stored procedure compile error: extraneous input ''E381BE''
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_octet_length.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_octet_length.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 7, column 36
-Stored procedure compile error: extraneous input ''01010101'' expecting {RPAREN, ','}
+Stored procedure compile error: extraneous input ''01010101''
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_position.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_position.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 7, column 45
-Stored procedure compile error: mismatched input ';' expecting {RPAREN, ','}
+Stored procedure compile error: mismatched input ';'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_replace.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_replace.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 11, column 37
-Stored procedure compile error: extraneous input ''abcdefg'' expecting {RPAREN, ','}
+Stored procedure compile error: extraneous input ''abcdefg''
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_reverse.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_reverse.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 7, column 31
-Stored procedure compile error: extraneous input ''01010101'' expecting {RPAREN, ','}
+Stored procedure compile error: extraneous input ''01010101''
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_strcmp.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_strcmp.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 9, column 75
-Stored procedure compile error: extraneous input ')' expecting SEMICOLON
+Stored procedure compile error: extraneous input ')'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_substring.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_substring.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 11, column 64
-Stored procedure compile error: extraneous input ')' expecting SEMICOLON
+Stored procedure compile error: extraneous input ')'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_trim.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_trim.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 8, column 57
-Stored procedure compile error: extraneous input ')' expecting SEMICOLON
+Stored procedure compile error: extraneous input ')'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_02_numeric_function/answers/04_04_03_02_bfn_numeric_conv.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_02_numeric_function/answers/04_04_03_02_bfn_numeric_conv.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 7, column 41
-Stored procedure compile error: mismatched input ';' expecting {RPAREN, ','}
+Stored procedure compile error: mismatched input ';'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_04_type_convert_function/answers/04_04_03_04_bfn_type_cast1.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_04_type_convert_function/answers/04_04_03_04_bfn_type_cast1.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 52, column 1
-Stored procedure compile error: mismatched input 'dbms_output' expecting {<EOF>, COMMENT}
+Stored procedure compile error: mismatched input 'dbms_output'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_04_type_convert_function/answers/04_04_03_04_bfn_type_cast2.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_04_type_convert_function/answers/04_04_03_04_bfn_type_cast2.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 6, column 1
-Stored procedure compile error: mismatched input 'dbms_output' expecting {AND, BETWEEN, DIV, IN, IS, LIKE, MOD, NOT, OR, XOR, '<=>', '>=', '<=', '||', '<<', '>>', RPAREN, '*', '+', '-', ',', '/', NOT_EQUAL_OP, '&', '^', '>', '<', '|', '='}
+Stored procedure compile error: mismatched input 'dbms_output'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_05_datetime_function/answers/04_04_03_05_bfn_datetime_adddate.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_05_datetime_function/answers/04_04_03_05_bfn_datetime_adddate.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 26, column 66
-Stored procedure compile error: extraneous input ''12-13'' expecting {RPAREN, ','}
+Stored procedure compile error: extraneous input ''12-13''
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_05_datetime_function/answers/04_04_03_05_bfn_datetime_date_sub.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_05_datetime_function/answers/04_04_03_05_bfn_datetime_date_sub.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 9, column 77
-Stored procedure compile error: extraneous input '24' expecting {RPAREN, ','}
+Stored procedure compile error: extraneous input '24'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_05_datetime_function/answers/04_04_03_05_bfn_datetime_extract.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_05_datetime_function/answers/04_04_03_05_bfn_datetime_extract.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 10, column 62
-Stored procedure compile error: extraneous input ')' expecting SEMICOLON
+Stored procedure compile error: extraneous input ')'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_05_datetime_function/answers/04_04_03_05_bfn_datetime_months_between.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_05_datetime_function/answers/04_04_03_05_bfn_datetime_months_between.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 4, column 83
-Stored procedure compile error: extraneous input ')' expecting SEMICOLON
+Stored procedure compile error: extraneous input ')'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_06_information_function/answers/04_04_03_06_bfn_info_charset.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_06_information_function/answers/04_04_03_06_bfn_info_charset.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 5, column 35
-Stored procedure compile error: extraneous input '''' expecting {RPAREN, ','}
+Stored procedure compile error: extraneous input ''''
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_06_information_function/answers/04_04_03_06_bfn_info_coerclibility.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_06_information_function/answers/04_04_03_06_bfn_info_coerclibility.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 4, column 47
-Stored procedure compile error: extraneous input ')' expecting SEMICOLON
+Stored procedure compile error: extraneous input ')'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_06_information_function/answers/04_04_03_06_bfn_info_collation.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_06_information_function/answers/04_04_03_06_bfn_info_collation.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 5, column 44
-Stored procedure compile error: extraneous input ')' expecting SEMICOLON
+Stored procedure compile error: extraneous input ')'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_07_encryption_function/answers/04_04_03_07_bfn_encrypt_sha2.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_07_encryption_function/answers/04_04_03_07_bfn_encrypt_sha2.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 5, column 36
-Stored procedure compile error: mismatched input ';' expecting {RPAREN, ','}
+Stored procedure compile error: mismatched input ';'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_05_identifier/_01_basic/answers/04_05_01-02_error_unknown_id_2.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_05_identifier/_01_basic/answers/04_05_01-02_error_unknown_id_2.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
 In line 3, column 1
-Stored procedure compile error: mismatched input 'begin' expecting {DEFAULT, NOT, ':=', SEMICOLON}
+Stored procedure compile error: mismatched input 'begin'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_15_arithmetic_binary_op/_09_normal_int_mod_div_type_conversion/answers/04_15_09-01_int_arithmetic_op_null.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_15_arithmetic_binary_op/_09_normal_int_mod_div_type_conversion/answers/04_15_09-01_int_arithmetic_op_null.answer
@@ -30,7 +30,7 @@ This test produces a compilation error. ( t_compile_error_boolean, null )
 ===================================================
 Error:-1360
 In line 56, column 51
-Stored procedure compile error: extraneous input ')' expecting SEMICOLON
+Stored procedure compile error: extraneous input ')'
 
 ===================================================
 'This test produces a compilation error. ( t_compile_error_boolean, null )'    
@@ -40,7 +40,7 @@ This test produces a compilation error. ( t_compile_error_boolean, null )
 ===================================================
 Error:-1360
 In line 56, column 51
-Stored procedure compile error: extraneous input ')' expecting SEMICOLON
+Stored procedure compile error: extraneous input ')'
 
 ===================================================
 'This test is a normal run case. ( t_compile_error_string, null )'    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_15_arithmetic_binary_op/_09_normal_int_mod_div_type_conversion/answers/04_15_09-02_int_arithmetic_op_boolean.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_15_arithmetic_binary_op/_09_normal_int_mod_div_type_conversion/answers/04_15_09-02_int_arithmetic_op_boolean.answer
@@ -156,7 +156,7 @@ This test produces a compilation error. ( t_compile_error_float, boolean )
 ===================================================
 Error:-1360
 In line 57, column 52
-Stored procedure compile error: extraneous input ')' expecting SEMICOLON
+Stored procedure compile error: extraneous input ')'
 
 ===================================================
 'This test produces a compilation error. ( t_compile_error_double, boolean )'    


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25866

PL/CSQL 컴파일러 쪽의 syntax error에서 'expecting' 이후의 구문을 삭제하도록 엔진을 수정하였고, 
이에 따른 답안지 변경 건 입니다. 
삭제된 부분은 ANTLR 내부 동작에 의해 문법이 조금만 바뀌어도 변하는 부분이라 
ANTLR 문법이 바뀐 수정건에 대해서 TC 관리에 큰 부담을 일으켜 왔던 부분입니다.
삭제되는 부분이 사용자에게 크게 유용한 정보를 주고 있지도 않은 것 같습니다. 

CBRD-25866 수정건 적용 전에 미리 적용되어야 의미 있는 변경 구별이 되어 먼저 PR 올립니다. 
