### PR TITLE
[CBRD-25866] Revised answers for cut 'expecting' clauses in PL/CSQL syntax error messages

### DIFF
--- a/sql/_35_fig_cake/plcsql/basic/answers/dynamic_sql_loop.answer
+++ b/sql/_35_fig_cake/plcsql/basic/answers/dynamic_sql_loop.answer
@@ -28,7 +28,7 @@
 ===================================================
 Error:-1360
 In line 6, column 5
-Stored procedure compile error: mismatched input 'LOOP' expecting {<EOF>, COMMENT, REVERSE, DELIMITED_ID, SEMICOLON, REGULAR_ID}
+Stored procedure compile error: mismatched input 'LOOP'
 
 ===================================================
 Error:-495


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-25866
https://github.com/CUBRID/cubrid/pull/5870 에서 빠진 듯 합니다.