### PR TITLE
[CBRD-25868] Revised answers for PL/CSQL procedure commit/rollback support

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_04_expression/_07_sql_rowcount/_01_basic/answers/04_07_01-01_normal_basic_rollback.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_07_sql_rowcount/_01_basic/answers/04_07_01-01_normal_basic_rollback.answer
@@ -24,10 +24,6 @@ null
 
 after insert:4
 after rollback:0
-id=1 name=aaa phone=000-0000
-id=2 name=bbb phone=000-0000
-id=3 name=ccc phone=333-3333
-id=6 name=eee phone=000-0000
 ===================================================
 0
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25868

위 이슈 머지 후 PL/CSQL 프로시저 롤백이 성공적이고 테이블 'tbl'이 롤백으로 인해서 비어 있기 때문에 COMMIT/ROLLBACK에 따른 루프에서 dbms_output.put_line 결과가 더 이상 표시되지 않습니다. 표시되지 않는게 정상이며, 기존 답지는 rollback이 무시될때를 기준으로 작성된 것이라고 판단이됩니다. 

오라클에서 같은 프로시저를 call했을때 동일하게 표시되지 않습니다.

```
create table tbl (id INT UNIQUE, name VARCHAR, phone VARCHAR DEFAULT '000-0000');
create or replace procedure t(i int) as

    function helper(bi bigint) return varchar as
    begin
        return case when bi is null then 'null' else '' || bi end;
    end;

    cursor c is select * from tbl;
begin

    insert into tbl values
        (1, 'aaa', '000-0000'),
        (2, 'bbb', '000-0000'),
        (3, 'ccc', '333-3333'),
        (6, 'eee', '000-0000');
    dbms_output.put_line('after insert:' || helper(sql%rowcount));

    rollback;
    dbms_output.put_line('after rollback:' || helper(sql%rowcount));

    -- CBRD-25868 이후에 ROLLBACK이 성공적이므로 tbl은 비어있기에 출력이 되지않는다
    for r in c loop
        dbms_output.put_line('id=' || r.id || ' name=' || r.name || ' phone=' || r.phone);
    end loop;

end;

call t(7);
```


