### PR TITLE
[CBRD-25906] update two answers

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/10_error_percent_type_modify_column_type.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/10_error_percent_type_modify_column_type.answer
@@ -102,7 +102,7 @@ BUG, TODO
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 4, column 1) internal server error
+  (line 4, column 1) type of a value does not match the one known at compile time (hint: try recompiling this stored procedure)
 
 ===================================================
     

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/30_error_viewtable_percent_type_modify_column_type.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_09_percent_type/answers/30_error_viewtable_percent_type_modify_column_type.answer
@@ -111,7 +111,7 @@ BUG, TODO
 ===================================================
 Error:-889
 Stored procedure execute error: 
-  (line 4, column 1) internal server error
+  (line 4, column 1) type of a value does not match the one known at compile time (hint: try recompiling this stored procedure)
 
 ===================================================
     


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25906

'internal server error' 메시지가 좀 더 유용한 에러 메시지로 바뀌었습니다. 