### PR TITLE
[CBRD-25084] Removed fetch_time from trace info in 11.3 test cases

### DIFF
--- a/sql/_13_issues/_24_2h/answers/cbrd_24795.answer
+++ b/sql/_13_issues/_24_2h/answers/cbrd_24795.answer
@@ -51,7 +51,7 @@ Query Plan:
   rewritten query: select ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta where ( abs(ta.b)= ?:? ) and (inst_num()<= ?:? ) using index ta.idx_tbla_abs_b_a
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (index: dba.tbla.idx_tbla_abs_b_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
 
@@ -71,7 +71,7 @@ Query Plan:
   rewritten query: select ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta where ( abs(ta.b)=-?) and (inst_num()<= ?:? ) using index ta.idx_tbla_abs_b_a
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (index: dba.tbla.idx_tbla_abs_b_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
 
@@ -92,7 +92,7 @@ Query Plan:
   rewritten query: select ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta where ( abs(ta.b)= ?:? ) and (inst_num()<= ?:? ) using index ta.idx_tbla_abs_b_a
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (index: dba.tbla.idx_tbla_abs_b_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
 
@@ -113,7 +113,7 @@ Query Plan:
   rewritten query: select ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta where ( abs(ta.b)=--?) and (inst_num()<= ?:? ) using index ta.idx_tbla_abs_b_a
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (index: dba.tbla.idx_tbla_abs_b_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
 
@@ -133,7 +133,7 @@ Query Plan:
   rewritten query: select ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta where ( abs(ta.b)= ?:? ) and (inst_num()<= ?:? ) using index ta.idx_tbla_abs_b_a
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (index: dba.tbla.idx_tbla_abs_b_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
 
@@ -153,7 +153,7 @@ Query Plan:
   rewritten query: select ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta where ( abs(ta.b)< ?:? ) and (inst_num()<= ?:? ) using index ta.idx_tbla_abs_b_a
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (index: dba.tbla.idx_tbla_abs_b_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
 
@@ -174,7 +174,7 @@ Query Plan:
   rewritten query: select ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta where ( abs(ta.b)>-?) and (inst_num()<= ?:? ) using index ta.idx_tbla_abs_b_a
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (index: dba.tbla.idx_tbla_abs_b_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
 
@@ -197,7 +197,7 @@ Query Plan:
   rewritten query: select /*+ ORDERED */ ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta, [dba.tbla] tb where ta.b= abs(tb.b) and ta.c= abs(tb.b) and ta.a=tb.a and (inst_num()<= ?:? ) using index tb.idx_tbla_a_abs_b
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbla), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (index: dba.tbla.idx_tbla_a_abs_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
@@ -220,7 +220,7 @@ Query Plan:
   rewritten query: select /*+ ORDERED */ ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta, [dba.tbla] tb where (ta.b<= abs(tb.b)) and (ta.c> abs(tb.b)) and ta.a=tb.a and (inst_num()<= ?:? ) using index tb.idx_tbla_a_abs_b
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbla), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (index: dba.tbla.idx_tbla_a_abs_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
@@ -243,7 +243,7 @@ Query Plan:
   rewritten query: select /*+ ORDERED */ ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta, [dba.tbla] tb where ( abs(tb.b)>=ta.b) and (ta.c> abs(tb.b)) and ta.a=tb.a and (inst_num()<= ?:? ) using index tb.idx_tbla_a_abs_b
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbla), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (index: dba.tbla.idx_tbla_a_abs_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
@@ -266,7 +266,7 @@ Query Plan:
   rewritten query: select /*+ ORDERED */ ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta, [dba.tbla] tb where ( abs(tb.b)>=ta.b and  abs(tb.b)<ta.c) and ta.a=tb.a and (inst_num()<= ?:? ) using index tb.idx_tbla_a_abs_b
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbla), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (index: dba.tbla.idx_tbla_a_abs_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
@@ -289,7 +289,7 @@ Query Plan:
   rewritten query: select /*+ ORDERED */ ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta, [dba.tbla] tb where (ta.b<=tb.b) and (ta.c>tb.b) and ta.a=tb.a and (inst_num()<= ?:? ) using index tb.idx_tbla_a_b
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbla), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (index: dba.tbla.idx_tbla_a_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
      
@@ -312,7 +312,7 @@ Query Plan:
   rewritten query: select /*+ ORDERED */ ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta, [dba.tbla] tb where (tb.b>=ta.b and tb.b<ta.c) and ta.a=tb.a and (inst_num()<= ?:? ) using index tb.idx_tbla_a_b
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbla), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (index: dba.tbla.idx_tbla_a_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
      
@@ -336,7 +336,7 @@ Query Plan:
   rewritten query: select /*+ ORDERED */ ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta, [dba.tbla] tb where (( abs(tb.b)=ta.b) or ( abs(tb.b)=ta.c)) and ta.a=tb.a and (inst_num()<= ?:? ) using index tb.idx_tbla_a_abs_b
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbla), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (index: dba.tbla.idx_tbla_a_abs_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
@@ -360,7 +360,7 @@ Query Plan:
   rewritten query: select /*+ ORDERED */ ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta, [dba.tbla] tb where (( abs(tb.b)>=ta.b) or ( abs(tb.b)<ta.c)) and ta.a=tb.a and (inst_num()<= ?:? ) using index tb.idx_tbla_a_abs_b
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbla), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (index: dba.tbla.idx_tbla_a_abs_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
@@ -384,7 +384,7 @@ Query Plan:
   rewritten query: select /*+ ORDERED */ ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta, [dba.tbla] tb where ((ta.b<=- abs(tb.b)) or (ta.c>- abs(tb.b))) and ta.a=tb.a and (inst_num()<= ?:? ) using index tb.idx_tbla_a_abs_b
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbla), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (index: dba.tbla.idx_tbla_a_abs_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
@@ -409,7 +409,7 @@ Query Plan:
   rewritten query: select /*+ ORDERED */ ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta, [dba.tbla] tb where ((ta.b<=- abs(tb.b)) or ( abs(tb.b)<ta.c)) and ta.a=tb.a using index tb.idx_tbla_a_abs_b order by ? for orderby_num()<= ?:? 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbla), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (index: dba.tbla.idx_tbla_a_abs_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
     ORDERBY (time: ?, topnsort: true)
@@ -434,7 +434,7 @@ Query Plan:
   rewritten query: select /*+ ORDERED */ ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta, [dba.tbla] tb where (( abs(tb.b)<=ta.b) or ( abs(tb.b)<ta.c)) and ta.a=tb.a and (inst_num()<= ?:? ) using index tb.idx_tbla_a_abs_b
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbla), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (index: dba.tbla.idx_tbla_a_abs_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
@@ -458,7 +458,7 @@ Query Plan:
   rewritten query: select /*+ ORDERED */ ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta, [dba.tbla] tb where ((ta.b<=-tb.b) or (ta.c>-tb.b)) and ta.a=tb.a and (inst_num()<= ?:? ) using index tb.idx_tbla_a_b
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbla), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (index: dba.tbla.idx_tbla_a_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
      
@@ -483,7 +483,7 @@ Query Plan:
   rewritten query: select /*+ ORDERED */ ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta, [dba.tbla] tb where ((ta.b<=-tb.b) or (tb.b<ta.c)) and ta.a=tb.a using index tb.idx_tbla_a_b order by ? for orderby_num()<= ?:? 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbla), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (index: dba.tbla.idx_tbla_a_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ORDERBY (time: ?, topnsort: true)
@@ -508,7 +508,7 @@ Query Plan:
   rewritten query: select /*+ ORDERED */ ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta, [dba.tbla] tb where (( abs(tb.b)=ta.b) or ( abs(tb.b)=ta.c) or ( abs(tb.b)=ta.d)) and ta.a=tb.a and (inst_num()<= ?:? ) using index tb.idx_tbla_a_abs_b
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbla), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (index: dba.tbla.idx_tbla_a_abs_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
@@ -533,7 +533,7 @@ Query Plan:
   rewritten query: select /*+ ORDERED */ ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta, [dba.tbla] tb where ( abs(ta.b)>= ?:?  and  abs(ta.b)< ?:? ) and ( abs(tb.b)>= ?:?  and  abs(tb.b)< ?:? ) and ta.a=tb.a using index ta.idx_tbla_abs_b_a, tb.idx_tbla_a_abs_b
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (index: dba.tbla.idx_tbla_abs_b_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
       SCAN (index: dba.tbla.idx_tbla_a_abs_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
@@ -558,7 +558,7 @@ Query Plan:
   rewritten query: select ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta where ( abs(ta.b)>= ?:?  and  abs(ta.b)<= ?:? ) using index ta.idx_tbla_abs_b_a
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (index: dba.tbla.idx_tbla_abs_b_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
 
@@ -577,12 +577,12 @@ a    b    c    d    e
 trace    
 
 Query Plan:
-  INDEX SCAN (ta.idx_tbla_abs_b_a) (key range: ( abs(ta.b)>=--? and  abs(ta.b)<=--?))
+  INDEX SCAN (ta.idx_tbla_abs_b_a) (key range: ( abs(ta.b)>= ?:? ))
 
   rewritten query: select ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta where ( abs(ta.b)>=--? and  abs(ta.b)<=--?) and ( abs(ta.b)>= ?:? ) using index ta.idx_tbla_abs_b_a
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (index: dba.tbla.idx_tbla_abs_b_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
 
@@ -604,7 +604,7 @@ Query Plan:
   rewritten query: select ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta where (ta.b>=--? and ta.b<=--?) and (ta.b>= ?:? ) using index ta.idx_tbla_b_a
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (index: dba.tbla.idx_tbla_b_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
 
@@ -625,7 +625,7 @@ Query Plan:
   rewritten query: select ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta where  char_length( cast(ta.b as varchar))>? and  char_length( cast(ta.b as varchar))<=? using index ta.idx_tbla_length_b(+)
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (index: dba.tbla.idx_tbla_length_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
 
@@ -646,7 +646,7 @@ Query Plan:
   rewritten query: select ta.a, ta.b, ta.c, ta.d, ta.e from [dba.tbla] ta where ( char_length( cast(ta.b as varchar))> ?:?  and  char_length( cast(ta.b as varchar))<= ?:? ) using index ta.idx_tbla_length_b(+)
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (index: dba.tbla.idx_tbla_length_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
 
@@ -667,7 +667,7 @@ Query Plan:
   rewritten query: select count([dba.tblb].ca) from [dba.tblb] [dba.tblb] where ( to_char([dba.tblb].cb, 'YYYY-MM-DD HH?:MI:SS')>= ?:?  and  to_char([dba.tblb].cb, 'YYYY-MM-DD HH?:MI:SS')<= ?:? ) and [dba.tblb].ca= ?:? 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (index: dba.tblb.i_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
 
@@ -688,7 +688,7 @@ Query Plan:
   rewritten query: select count([dba.tblb].ca) from [dba.tblb] [dba.tblb] where ( to_char([dba.tblb].cb, 'YYYY-MM-DD HH?:MI:SS')>= ?:?  and  to_char([dba.tblb].cb, 'YYYY-MM-DD HH?:MI:SS')<= ?:? )
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (index: dba.tblb.i_c), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
 
@@ -729,7 +729,7 @@ Query Plan:
   rewritten query: select j.i_id from [dba.item] i, [dba.item] j where ((j.i_id=i.i_related_a) or (j.i_id=i.i_related_b) or (j.i_id=i.i_related_c) or (j.i_id=i.i_related_d) or (j.i_id=i.i_related_e)) and i.i_id= ?:? 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (index: dba.item.pk_item_i_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
       SCAN (index: dba.item.pk_item_i_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
      

--- a/sql/_13_issues/_24_2h/answers/cbrd_25317.answer
+++ b/sql/_13_issues/_24_2h/answers/cbrd_25317.answer
@@ -29,7 +29,7 @@ Query Plan:
   rewritten query: select  cast('q?: ' as varchar)|| cast(a.col_b as varchar) from [dba.tbl] a, [dba.tbl] b where a.col_a=b.col_a and b.col_b= ?:? 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
@@ -49,7 +49,7 @@ Query Plan:
   rewritten query: select  cast('q?: ' as varchar)|| cast(a.col_b as varchar) from [dba.tbl] a, [dba.tbl] b where a.col_a=b.col_a and b.col_b= ?:? 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
@@ -75,7 +75,7 @@ Query Plan:
   rewritten query: select  cast('q?: ' as varchar)|| cast(a.col_b as varchar) from [dba.tbl] a, [dba.tbl] b where a.col_a=b.col_a and b.col_b= ?:? 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
@@ -95,7 +95,7 @@ Query Plan:
   rewritten query: select  cast('q?: ' as varchar)|| cast(a.col_b as varchar) from [dba.tbl] a, [dba.tbl] b where a.col_a=b.col_a and b.col_b= ?:? 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
@@ -121,7 +121,7 @@ Query Plan:
   rewritten query: select  cast('q?: ' as varchar)|| cast(a.col_b as varchar) from [dba.tbl] a, [dba.tbl] b where a.col_a=b.col_a and b.col_b= ?:? 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
@@ -147,7 +147,7 @@ Query Plan:
   rewritten query: select  cast('q?: ' as varchar)|| cast(a.col_b as varchar) from [dba.tbl] a, [dba.tbl] b where a.col_a=b.col_a and b.col_b= ?:? 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
@@ -186,16 +186,16 @@ Query Plan:
 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
           SCAN (method time: ?, fetch: ?, ioread: ?)
           SUBQUERY (uncorrelated)
-            SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SELECT (time: ?, fetch: ?, ioread: ?)
               SCAN (set time: ?, fetch: ?, ioread: ?)
      
 
@@ -227,16 +227,16 @@ Query Plan:
 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
           SCAN (method time: ?, fetch: ?, ioread: ?)
           SUBQUERY (uncorrelated)
-            SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SELECT (time: ?, fetch: ?, ioread: ?)
               SCAN (set time: ?, fetch: ?, ioread: ?)
      
 
@@ -274,16 +274,16 @@ Query Plan:
 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
           SCAN (method time: ?, fetch: ?, ioread: ?)
           SUBQUERY (uncorrelated)
-            SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SELECT (time: ?, fetch: ?, ioread: ?)
               SCAN (set time: ?, fetch: ?, ioread: ?)
      
 
@@ -315,16 +315,16 @@ Query Plan:
 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
           SCAN (method time: ?, fetch: ?, ioread: ?)
           SUBQUERY (uncorrelated)
-            SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SELECT (time: ?, fetch: ?, ioread: ?)
               SCAN (set time: ?, fetch: ?, ioread: ?)
      
 
@@ -362,16 +362,16 @@ Query Plan:
 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
           SCAN (method time: ?, fetch: ?, ioread: ?)
           SUBQUERY (uncorrelated)
-            SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SELECT (time: ?, fetch: ?, ioread: ?)
               SCAN (set time: ?, fetch: ?, ioread: ?)
      
 
@@ -409,16 +409,16 @@ Query Plan:
 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
           SCAN (method time: ?, fetch: ?, ioread: ?)
           SUBQUERY (uncorrelated)
-            SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SELECT (time: ?, fetch: ?, ioread: ?)
               SCAN (set time: ?, fetch: ?, ioread: ?)
      
 
@@ -443,7 +443,7 @@ Query Plan:
   rewritten query: select  cast('q?: ' as varchar)|| cast(test_fc( ?:? ) as varchar) from [dba.tbl] a, [dba.tbl] b where a.col_a=b.col_a and b.col_b=?
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
@@ -469,7 +469,7 @@ Query Plan:
   rewritten query: select  cast('q?: ' as varchar)|| cast(test_fc( ?:? ) as varchar) from [dba.tbl] a, [dba.tbl] b where a.col_a=b.col_a and b.col_b=?
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
@@ -510,17 +510,17 @@ Query Plan:
 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         SUBQUERY (correlated)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
             SCAN (method time: ?, fetch: ?, ioread: ?)
             SUBQUERY (uncorrelated)
-              SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+              SELECT (time: ?, fetch: ?, ioread: ?)
                 SCAN (set time: ?, fetch: ?, ioread: ?)
      
 
@@ -560,17 +560,17 @@ Query Plan:
 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         SUBQUERY (correlated)
-          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SELECT (time: ?, fetch: ?, ioread: ?)
             SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
             SCAN (method time: ?, fetch: ?, ioread: ?)
             SUBQUERY (uncorrelated)
-              SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+              SELECT (time: ?, fetch: ?, ioread: ?)
                 SCAN (set time: ?, fetch: ?, ioread: ?)
      
 
@@ -612,17 +612,17 @@ Query Plan:
 
 
 Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+  SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
           SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SUBQUERY (correlated)
-        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
           SCAN (method time: ?, fetch: ?, ioread: ?)
           SUBQUERY (uncorrelated)
-            SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SELECT (time: ?, fetch: ?, ioread: ?)
               SCAN (set time: ?, fetch: ?, ioread: ?)
      
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25084

Fetch time이 11.4부터만 trace info에 출력이됩니다. develop에서 만들어진 답지가 그대로 백포트가 되었을때 11.3 이하는 fetch_time이 출력이 되지않기에 알맞게 수정합니다.