### PR TITLE
[CUBRIDQA-1136] Revised on top of a previous revise that ensured correct ordering (corrected order by column)

### DIFF
--- a/sql/_35_fig_cake/grant_revoke_redefine/cases/cbrd_25627_04.sql
+++ b/sql/_35_fig_cake/grant_revoke_redefine/cases/cbrd_25627_04.sql
@@ -46,7 +46,7 @@ call login('dba','') on class db_user;
 ALTER TABLE u1.tbl OWNER TO u3;
 ALTER TABLE u1.tbl2 OWNER TO u3;
 
-select grantor_name, grantee_name, owner_name, object_type, object_name, auth_type, is_grantable from db_auth where grantee_name != 'PUBLIC' order by grantor_name, object_type;
+select grantor_name, grantee_name, owner_name, object_type, object_name, auth_type, is_grantable from db_auth where grantee_name != 'PUBLIC' order by grantor_name, object_name;
 
 select class_name, owner_name from db_class where class_name in ('tbl', 'tbl2') order by class_name;
 


### PR DESCRIPTION
Extended from: https://github.com/CUBRID/cubrid-testcases/pull/2044

위 TC랑 같은 수정건입니다. 29 번 째 라인의  order by grantor_name, object_name; 를 수정 했는데,  49번 째 라인의 order by는 수정되지 않아서 알맞게 수정하였습니다.