### PR TITLE
[CUBRIDQA-1226] Modified view merging TC 11.3 answers to match develop

### DIFF
--- a/sql/_33_elderberry/cbrd_24042/add/answers/using_index.answer
+++ b/sql/_33_elderberry/cbrd_24042/add/answers/using_index.answer
@@ -60,7 +60,7 @@ idx-join (inner join)
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select t.id, t.mgrid, t.[name], t.birthyear, x.empid, x.salary, x.jobtitle from tbl t, tbl_emp x where (t.BirthYear< ?:? ) and ( right(x.JobTitle, ?)< cast('zz' as varchar)) and t.ID=x.empid using index t.idx_tbl_birthyear(+), x.idx_empinfo_empid(+)
+select t.id, t.mgrid, t.[name], t.birthyear, x.empid, x.salary, x.jobtitle from tbl t, tbl_emp x where (t.BirthYear< ?:? ) and ( right(x.JobTitle, ?)< ?:? ) and t.ID=x.empid using index t.idx_tbl_birthyear(+), x.idx_empinfo_empid(+)
 ===================================================
 id    mgrid    name    birthyear    empid    salary    jobtitle    
 2     null     Moy     1958     2     2000     Developer1     
@@ -81,7 +81,7 @@ idx-join (inner join)
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select t.id, t.mgrid, t.[name], t.birthyear, x.empid, x.salary, x.jobtitle from tbl t, tbl_emp x where (t.BirthYear< ?:? ) and ( right(x.JobTitle, ?)< cast('zz' as varchar)) and t.ID=x.empid using index t.idx_tbl_birthyear(+), x.idx_empinfo_empid(+)
+select t.id, t.mgrid, t.[name], t.birthyear, x.empid, x.salary, x.jobtitle from tbl t, tbl_emp x where (t.BirthYear< ?:? ) and ( right(x.JobTitle, ?)< ?:? ) and t.ID=x.empid using index t.idx_tbl_birthyear(+), x.idx_empinfo_empid(+)
 ===================================================
 0
 ===================================================


### PR DESCRIPTION
백포트 당시 11.3에서는 결과가 다르게 나와서 develop과는 다르게 작성이 되었었는데, 이와 관련된 이슈가 11.3 앤진에도 백포트가 되어 이제 11.3도 develop과 동일한 결과가 나옵니다. 

이전 11.3 백포트 PR:
https://github.com/CUBRID/cubrid-testcases/pull/1892

**sql/_33_elderberry/cbrd_24042/add/answers/using_index.answer:**

- develop 파일 링크: https://github.com/CUBRID/cubrid-testcases/blob/develop/sql/_33_elderberry/cbrd_24042/add/answers/using_index.answer
  - 본 PR이 머지되면 11.3 브랜치의 using_index.answer과 develop 브랜치의 using_index.answer 파일이랑 내용이 같아집니다.