### PR TITLE
[CUBVEC-59] support CREATE VECTOR INDEX

### DIFF
--- a/sql/_36_cubvec/_03_create_vector_index/cases/_create_vector_index_empty_table.sql
+++ b/sql/_36_cubvec/_03_create_vector_index/cases/_create_vector_index_empty_table.sql
@@ -1,0 +1,13 @@
+--------------------------------------------------------------------------------
+-- Spec
+--------------------------------------------------------------------------------
+
+DROP IF EXISTS test_empty_table;
+CREATE TABLE test_empty_table (
+    id INT,
+    vector_data VECTOR
+);
+
+-- Spec: Cannot create a vector index on an empty table
+CREATE VECTOR INDEX idx_empty ON test_empty_table(vector_data);
+

--- a/sql/_36_cubvec/_03_create_vector_index/cases/_create_vector_index_on_various_dim.sql
+++ b/sql/_36_cubvec/_03_create_vector_index/cases/_create_vector_index_on_various_dim.sql
@@ -1,0 +1,15 @@
+--------------------------------------------------------------------------------
+-- Spec
+--------------------------------------------------------------------------------
+DROP IF EXISTS test_vector_table;
+CREATE TABLE test_vector_table (
+    id INT,
+    vector_col VECTOR
+);
+INSERT INTO test_vector_table VALUES (1, '[1,2]');
+INSERT INTO test_vector_table VALUES (2, '[1,2,3]');
+
+-- Spec: Cannot create vector index on various dimension column: Error
+SELECT VECTOR_DISTANCE(t1.vector_col, t2.vector_col, COSINE) AS cosine_distance
+FROM test_vector_table t1, test_vector_table t2;
+

--- a/sql/_36_cubvec/_03_create_vector_index/cases/_create_vector_index_syntax.sql
+++ b/sql/_36_cubvec/_03_create_vector_index/cases/_create_vector_index_syntax.sql
@@ -1,0 +1,34 @@
+-- Prepare a table with a vector column.
+DROP IF EXISTS test_vector_index;
+CREATE TABLE test_vector_index (
+    id INT,
+    vector_data VECTOR
+    varchar_data VARCHAR
+);
+INSERT INTO test_vector_index VALUES (1, '[1,2,3]', '[1,2,3]');
+INSERT INTO test_vector_index VALUES (2, '[3,2,1]', '[3,2,1]');
+
+--------------------------------------------------------------------------------
+-- Syntax
+--------------------------------------------------------------------------------
+-- Syntax: Valid
+CREATE VECTOR INDEX idx_vector1 ON test_vector_index(vector_data COSINE);
+
+-- Syntax: Missing parens: Error
+CREATE VECTOR INDEX idx_vector1 ON test_vector_index;
+
+-- Syntax: Missing column name: Error
+CREATE VECTOR INDEX idx_vector1 ON test_vector_index();
+
+-- Syntax: Missing column name: Error
+CREATE VECTOR INDEX idx_vector1 ON test_vector_index(COSINE);
+--
+-- Syntax: Missing metric name: Error
+CREATE VECTOR INDEX idx_vector1 ON test_vector_index(vector_data);
+
+--------------------------------------------------------------------------------
+-- Semantics
+--------------------------------------------------------------------------------
+-- Semantics: Create vector index on non-vector type: Error
+CREATE VECTOR INDEX idx_vector1 ON test_vector_index(id COSINE);
+CREATE VECTOR INDEX idx_vector1 ON test_vector_index(varchar_data COSINE);

--- a/sql/_36_cubvec/_03_create_vector_index/cases/_create_vector_index_twice.sql
+++ b/sql/_36_cubvec/_03_create_vector_index/cases/_create_vector_index_twice.sql
@@ -1,0 +1,19 @@
+--------------------------------------------------------------------------------
+-- Spec
+--------------------------------------------------------------------------------
+
+-- Spec: Multiple Vector Indexes on the Same Vector Column (Invalid)
+DROP IF EXISTS test_vector_index;
+CREATE TABLE test_vector_index (
+    id INT,
+    vector_data VECTOR
+);
+INSERT INTO test_vector_index VALUES (1, '[1,2,3]');
+INSERT INTO test_vector_index VALUES (2, '[3,2,1]');
+
+-- Spec: Valid
+CREATE VECTOR INDEX idx_vector1 ON test_vector_index(vector_data COSINE);
+
+-- Spec: Error
+CREATE VECTOR INDEX idx_vector2 ON test_vector_index(vector_data COSINE);
+

--- a/sql/_36_cubvec/_03_create_vector_index/cases/_hnsw_parameters.sql
+++ b/sql/_36_cubvec/_03_create_vector_index/cases/_hnsw_parameters.sql
@@ -1,0 +1,46 @@
+-- Prepare
+DROP IF EXISTS test_vector_index_hnsw;
+CREATE TABLE test_vector_index_hnsw (
+    id INT,
+    vec1 VECTOR
+    vec2 VECTOR
+);
+INSERT INTO test_vector_index_hnsw VALUES (1, '[0.1,0.2,0.3]', '[0.1,0.2,0.3]');
+INSERT INTO test_vector_index_hnsw VALUES (2, '[0.3,0.2,0.1]');
+INSERT INTO test_vector_index_hnsw VALUES (3, '[0.3,0.2,0.1]');
+INSERT INTO test_vector_index_hnsw VALUES (4, '[0.3,0.2,0.1]');
+
+--------------------------------------------------------------------------------
+-- Syntax
+--------------------------------------------------------------------------------
+-- Syntax: creation with wrong parameters: Invalid
+CREATE VECTOR INDEX idx_hnsw ON test_vector_index_hnsw(embedding COSINE)
+  WITH (a = 5, b = 6);
+
+--------------------------------------------------------------------------------
+-- Semantics
+--------------------------------------------------------------------------------
+-- Syntax: creation with parameters: Valid
+CREATE VECTOR INDEX idx_hnsw ON test_vector_index_hnsw(embedding COSINE)
+  WITH (m = 40, ef_construction = 500);
+-- Syntax: creation with parameters in reverse order: Valid
+CREATE VECTOR INDEX idx_hnsw ON test_vector_index_hnsw(embedding COSINE)
+  WITH (ef_construction = 500, m = 40);
+
+--------------------------------------------------------------------------------
+-- Spec
+--------------------------------------------------------------------------------
+-- Prepare
+CREATE TABLE test_invalid_params (
+    id INT,
+    embedding VECTOR
+);
+INSERT INTO test_invalid_params VALUES (1, '[1,2,3]');
+
+-- Spec: ef_construction is zero: Error
+CREATE VECTOR INDEX idx_invalid_params2 ON test_invalid_params(embedding COSINE)
+  WITH (m = 40, ef_construction = 0);
+
+-- Spec: m is zero: Error
+CREATE VECTOR INDEX idx_valid_boundary ON test_invalid_params(embedding COSINE)
+  WITH (m = 0, ef_construction = 1);

--- a/sql/_36_cubvec/_03_create_vector_index/cases/_recreate_vector_index.sql
+++ b/sql/_36_cubvec/_03_create_vector_index/cases/_recreate_vector_index.sql
@@ -1,0 +1,16 @@
+--------------------------------------------------------------------------------
+-- Spec
+--------------------------------------------------------------------------------
+DROP IF EXISTS test_index_lifecycle;
+CREATE TABLE test_index_lifecycle (
+    id INT,
+    vector_data VECTOR
+);
+INSERT INTO test_index_lifecycle VALUES (1, '[7,8,9]');
+INSERT INTO test_index_lifecycle VALUES (2, '[9,8,7]');
+CREATE VECTOR INDEX idx_lifecycle ON test_index_lifecycle(vector_data);
+DROP INDEX idx_lifecycle ON test_index_lifecycle; -- Drop index.
+
+-- Spec: Re-create index after DROP: Valid
+CREATE VECTOR INDEX idx_lifecycle ON test_index_lifecycle(vector_data);
+


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-59>

1. **빈 테이블에 벡터 인덱스 생성 테스트 (_create_vector_index_empty_table.sql)**  
   - `test_empty_table` 테이블을 생성한 후, 빈 테이블에 대해 벡터 인덱스를 생성하려 시도합니다.  
   - 스펙: 빈 테이블에는 벡터 인덱스를 생성할 수 없어야 함.

2. **차원이 다른 벡터에 대한 인덱스/연산 테스트 (_create_vector_index_on_various_dim.sql)**  
   - `test_vector_table`에 서로 다른 차원의 벡터 데이터를 삽입합니다 (`'[1,2]'`와 `'[1,2,3]'`).  
   - 스펙: 서로 다른 차원의 벡터에 대해 벡터 인덱스 생성 혹은 벡터 거리 계산 시 에러가 발생해야 함.

3. **인덱스 생성 구문 및 의미론적 오류 테스트 (_create_vector_index_syntax.sql)**  
   - `test_vector_index` 테이블에 벡터 컬럼과 일반 문자열 컬럼을 포함시킵니다.  
   - 올바른 구문: `CREATE VECTOR INDEX idx_vector1 ON test_vector_index(vector_data COSINE);`  
   - 구문 오류 테스트: 괄호 누락, 컬럼명 누락, 메트릭 지정 누락 등 여러 케이스로 에러 발생을 확인합니다.  
   - 의미론적 오류 테스트: 벡터 타입이 아닌 컬럼(예: `id`, `varchar_data`)에 대해 벡터 인덱스 생성 시 에러가 발생해야 함.

4. **동일 벡터 컬럼에 대해 여러 인덱스 생성 테스트 (_create_vector_index_twice.sql)**  
   - `test_vector_index` 테이블에서 벡터 컬럼에 대해 첫 번째 인덱스 생성은 유효하지만, 동일 컬럼에 두 번째 인덱스 생성 시 에러가 발생해야 함.

5. **HNSW 파라미터 관련 테스트 (_hnsw_parameters.sql)**  
   - `test_vector_index_hnsw` 테이블을 생성하고, HNSW 기반 벡터 인덱스 생성 시 잘못된 파라미터 조합(예: 존재하지 않는 파라미터 `a`, `b`)과 올바른 파라미터 조합(`m = 40`, `ef_construction = 500`)을 각각 테스트합니다.  
   - 파라미터 순서 변경에 대한 유효성도 확인합니다.  
   - 추가로, `test_invalid_params` 테이블을 생성하여 파라미터 값이 0인 경우(예: `ef_construction = 0`, `m = 0`) 에러가 발생하는지 검증합니다.

6. **인덱스 생성 및 재생성(라이프사이클) 테스트 (_recreate_vector_index.sql)**  
   - `test_index_lifecycle` 테이블에서 인덱스를 생성한 후 삭제하고, 다시 동일한 인덱스를 재생성하는 과정을 테스트합니다.
