### PR TITLE
[CBRD-25138] updated 77 answers

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-02_error_use_char.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-02_error_use_char.answer
@@ -5,6 +5,6 @@ Stored procedure compile error: token recognition error at: '#'
 
 ===================================================
 Error:-1360
-In line 1, column 29
-Stored procedure compile error: token recognition error at: '"('
+In line 1, column 18
+Stored procedure compile error: token recognition error at: '"test_prc#'
 

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_constant.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_constant.answer
@@ -866,8 +866,8 @@ BEGIN
 
 ===================================================
 Error:-1360
-In line 3, column 1
-Stored procedure compile error: mismatched input 'begin'
+In line 2, column 7
+Stored procedure compile error: mismatched input 'CONSTANT'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_exception.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_exception.answer
@@ -125,8 +125,8 @@ CURSOR
 
 ===================================================
 Error:-1360
-In line 7, column 19
-Stored procedure compile error: mismatched input 'CURSOR'
+In line 2, column 8
+Stored procedure compile error: mismatched input 'EXCEPTION'
 
 ===================================================
 'DATE'    
@@ -528,8 +528,8 @@ PRAGMA
 
 ===================================================
 Error:-1360
-In line 7, column 19
-Stored procedure compile error: mismatched input 'PRAGMA'
+In line 2, column 8
+Stored procedure compile error: mismatched input 'EXCEPTION'
 
 ===================================================
 'RAISE'    
@@ -878,8 +878,8 @@ BEGIN
 
 ===================================================
 Error:-1360
-In line 3, column 1
-Stored procedure compile error: mismatched input 'begin'
+In line 2, column 7
+Stored procedure compile error: mismatched input 'EXCEPTION'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_local_function.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_local_function.answer
@@ -15,8 +15,8 @@ AS
 
 ===================================================
 Error:-1360
-In line 6, column 1
-Stored procedure compile error: mismatched input 'begin'
+In line 2, column 10
+Stored procedure compile error: mismatched input 'AS'
 
 ===================================================
 'BETWEEN'    
@@ -125,8 +125,8 @@ CURSOR
 
 ===================================================
 Error:-1360
-In line 6, column 1
-Stored procedure compile error: mismatched input 'begin'
+In line 2, column 10
+Stored procedure compile error: mismatched input 'CURSOR'
 
 ===================================================
 'DATE'    
@@ -255,8 +255,8 @@ END
 
 ===================================================
 Error:-1360
-In line 5, column 4
-Stored procedure compile error: mismatched input '<EOF>'
+In line 2, column 10
+Stored procedure compile error: mismatched input 'END'
 
 ===================================================
 Error:-493
@@ -406,8 +406,8 @@ IS
 
 ===================================================
 Error:-1360
-In line 6, column 1
-Stored procedure compile error: mismatched input 'begin'
+In line 2, column 10
+Stored procedure compile error: mismatched input 'IS'
 
 ===================================================
 'LIKE'    
@@ -456,8 +456,8 @@ NOT
 
 ===================================================
 Error:-1360
-In line 6, column 1
-Stored procedure compile error: mismatched input 'begin'
+In line 2, column 10
+Stored procedure compile error: mismatched input 'NOT'
 
 ===================================================
 'NULL'    
@@ -516,8 +516,8 @@ PRAGMA
 
 ===================================================
 Error:-1360
-In line 6, column 1
-Stored procedure compile error: mismatched input 'begin'
+In line 2, column 10
+Stored procedure compile error: mismatched input 'PRAGMA'
 
 ===================================================
 'RAISE'    
@@ -556,8 +556,8 @@ RETURN
 
 ===================================================
 Error:-1360
-In line 2, column 17
-Stored procedure compile error: extraneous input 'return'
+In line 2, column 10
+Stored procedure compile error: mismatched input 'RETURN'
 
 ===================================================
 'REVERSE'    
@@ -866,8 +866,8 @@ BEGIN
 
 ===================================================
 Error:-1360
-In line 6, column 1
-Stored procedure compile error: mismatched input 'begin'
+In line 2, column 10
+Stored procedure compile error: mismatched input 'BEGIN'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_local_procedure.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_local_procedure.answer
@@ -5,7 +5,7 @@ AND
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'AND'
 
 ===================================================
@@ -15,7 +15,7 @@ AS
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'AS'
 
 ===================================================
@@ -25,7 +25,7 @@ BETWEEN
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'BETWEEN'
 
 ===================================================
@@ -35,7 +35,7 @@ BIGINT
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'BIGINT'
 
 ===================================================
@@ -45,7 +45,7 @@ BOOLEAN
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'BOOLEAN'
 
 ===================================================
@@ -55,7 +55,7 @@ BY
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'BY'
 
 ===================================================
@@ -65,7 +65,7 @@ CHAR
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'CHAR'
 
 ===================================================
@@ -75,8 +75,8 @@ CLOSE
 
 ===================================================
 Error:-1360
-In line 7, column 6
-Stored procedure compile error: mismatched input '('
+In line 2, column 11
+Stored procedure compile error: mismatched input 'CLOSE'
 
 ===================================================
 'COMMIT'    
@@ -85,8 +85,8 @@ COMMIT
 
 ===================================================
 Error:-1360
-In line 7, column 7
-Stored procedure compile error: mismatched input '('
+In line 2, column 11
+Stored procedure compile error: mismatched input 'COMMIT'
 
 ===================================================
 'CONSTANT'    
@@ -95,7 +95,7 @@ CONSTANT
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'CONSTANT'
 
 ===================================================
@@ -105,8 +105,8 @@ CONTINUE
 
 ===================================================
 Error:-1360
-In line 7, column 9
-Stored procedure compile error: mismatched input '('
+In line 2, column 11
+Stored procedure compile error: mismatched input 'CONTINUE'
 
 ===================================================
 'CREATE'    
@@ -115,7 +115,7 @@ CREATE
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'CREATE'
 
 ===================================================
@@ -125,8 +125,8 @@ CURSOR
 
 ===================================================
 Error:-1360
-In line 6, column 1
-Stored procedure compile error: mismatched input 'begin'
+In line 2, column 11
+Stored procedure compile error: mismatched input 'CURSOR'
 
 ===================================================
 'DATE'    
@@ -135,7 +135,7 @@ DATE
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'DATE'
 
 ===================================================
@@ -145,7 +145,7 @@ DATETIME
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'DATETIME'
 
 ===================================================
@@ -155,7 +155,7 @@ DATETIMELTZ
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'DATETIMELTZ'
 
 ===================================================
@@ -165,7 +165,7 @@ DATETIMETZ
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'DATETIMETZ'
 
 ===================================================
@@ -175,7 +175,7 @@ DEC
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'DEC'
 
 ===================================================
@@ -185,7 +185,7 @@ DECIMAL
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'DECIMAL'
 
 ===================================================
@@ -195,8 +195,8 @@ DECLARE
 
 ===================================================
 Error:-1360
-In line 7, column 8
-Stored procedure compile error: mismatched input '('
+In line 2, column 11
+Stored procedure compile error: mismatched input 'DECLARE'
 
 ===================================================
 'DEFAULT'    
@@ -205,7 +205,7 @@ DEFAULT
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'DEFAULT'
 
 ===================================================
@@ -215,7 +215,7 @@ DIV
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'DIV'
 
 ===================================================
@@ -225,7 +225,7 @@ DOUBLE
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'DOUBLE'
 
 ===================================================
@@ -235,7 +235,7 @@ ELSE
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'ELSE'
 
 ===================================================
@@ -245,7 +245,7 @@ ELSIF
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'ELSIF'
 
 ===================================================
@@ -255,8 +255,8 @@ END
 
 ===================================================
 Error:-1360
-In line 5, column 4
-Stored procedure compile error: mismatched input '<EOF>'
+In line 2, column 11
+Stored procedure compile error: mismatched input 'END'
 
 ===================================================
 Error:-493
@@ -276,7 +276,7 @@ ESCAPE
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'ESCAPE'
 
 ===================================================
@@ -286,8 +286,8 @@ EXCEPTION
 
 ===================================================
 Error:-1360
-In line 8, column 1
-Stored procedure compile error: extraneous input 'end' expecting <EOF>
+In line 2, column 11
+Stored procedure compile error: mismatched input 'EXCEPTION'
 
 ===================================================
 'EXECUTE'    
@@ -296,8 +296,8 @@ EXECUTE
 
 ===================================================
 Error:-1360
-In line 7, column 9
-Stored procedure compile error: mismatched input ')'
+In line 2, column 11
+Stored procedure compile error: mismatched input 'EXECUTE'
 
 ===================================================
 'EXIT'    
@@ -306,8 +306,8 @@ EXIT
 
 ===================================================
 Error:-1360
-In line 7, column 5
-Stored procedure compile error: mismatched input '('
+In line 2, column 11
+Stored procedure compile error: mismatched input 'EXIT'
 
 ===================================================
 'FALSE'    
@@ -316,7 +316,7 @@ FALSE
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'FALSE'
 
 ===================================================
@@ -326,8 +326,8 @@ FETCH
 
 ===================================================
 Error:-1360
-In line 7, column 6
-Stored procedure compile error: mismatched input '('
+In line 2, column 11
+Stored procedure compile error: mismatched input 'FETCH'
 
 ===================================================
 'FLOAT'    
@@ -336,7 +336,7 @@ FLOAT
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'FLOAT'
 
 ===================================================
@@ -346,8 +346,8 @@ FOR
 
 ===================================================
 Error:-1360
-In line 7, column 4
-Stored procedure compile error: no viable alternative at input 'FOR('
+In line 2, column 11
+Stored procedure compile error: mismatched input 'FOR'
 
 ===================================================
 'IMMEDIATE'    
@@ -356,7 +356,7 @@ IMMEDIATE
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'IMMEDIATE'
 
 ===================================================
@@ -366,7 +366,7 @@ IN
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'IN'
 
 ===================================================
@@ -376,7 +376,7 @@ INT
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'INT'
 
 ===================================================
@@ -386,7 +386,7 @@ INTEGER
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'INTEGER'
 
 ===================================================
@@ -396,7 +396,7 @@ INTO
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'INTO'
 
 ===================================================
@@ -406,7 +406,7 @@ IS
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'IS'
 
 ===================================================
@@ -416,7 +416,7 @@ LIKE
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'LIKE'
 
 ===================================================
@@ -426,7 +426,7 @@ LIST
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'LIST'
 
 ===================================================
@@ -436,7 +436,7 @@ MOD
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'MOD'
 
 ===================================================
@@ -446,7 +446,7 @@ MULTISET
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'MULTISET'
 
 ===================================================
@@ -456,8 +456,8 @@ NOT
 
 ===================================================
 Error:-1360
-In line 6, column 1
-Stored procedure compile error: mismatched input 'begin'
+In line 2, column 11
+Stored procedure compile error: mismatched input 'NOT'
 
 ===================================================
 'NULL'    
@@ -466,8 +466,8 @@ NULL
 
 ===================================================
 Error:-1360
-In line 7, column 5
-Stored procedure compile error: mismatched input '('
+In line 2, column 11
+Stored procedure compile error: mismatched input 'NULL'
 
 ===================================================
 'NUMERIC'    
@@ -476,7 +476,7 @@ NUMERIC
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'NUMERIC'
 
 ===================================================
@@ -486,8 +486,8 @@ OPEN
 
 ===================================================
 Error:-1360
-In line 7, column 5
-Stored procedure compile error: no viable alternative at input 'OPEN('
+In line 2, column 11
+Stored procedure compile error: mismatched input 'OPEN'
 
 ===================================================
 'OR'    
@@ -496,7 +496,7 @@ OR
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'OR'
 
 ===================================================
@@ -506,7 +506,7 @@ OUT
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'OUT'
 
 ===================================================
@@ -516,8 +516,8 @@ PRAGMA
 
 ===================================================
 Error:-1360
-In line 6, column 1
-Stored procedure compile error: mismatched input 'begin'
+In line 2, column 11
+Stored procedure compile error: mismatched input 'PRAGMA'
 
 ===================================================
 'RAISE'    
@@ -526,8 +526,8 @@ RAISE
 
 ===================================================
 Error:-1360
-In line 7, column 6
-Stored procedure compile error: mismatched input '('
+In line 2, column 11
+Stored procedure compile error: mismatched input 'RAISE'
 
 ===================================================
 'REAL'    
@@ -536,7 +536,7 @@ REAL
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'REAL'
 
 ===================================================
@@ -546,8 +546,8 @@ REPLACE
 
 ===================================================
 Error:-1360
-In line 7, column 8
-Stored procedure compile error: mismatched input '('
+In line 2, column 11
+Stored procedure compile error: mismatched input 'REPLACE'
 
 ===================================================
 'RETURN'    
@@ -556,8 +556,8 @@ RETURN
 
 ===================================================
 Error:-1360
-In line 7, column 8
-Stored procedure compile error: mismatched input ')'
+In line 2, column 11
+Stored procedure compile error: mismatched input 'RETURN'
 
 ===================================================
 'REVERSE'    
@@ -566,7 +566,7 @@ REVERSE
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'REVERSE'
 
 ===================================================
@@ -576,8 +576,8 @@ ROLLBACK
 
 ===================================================
 Error:-1360
-In line 7, column 9
-Stored procedure compile error: mismatched input '('
+In line 2, column 11
+Stored procedure compile error: mismatched input 'ROLLBACK'
 
 ===================================================
 'SEQUENCE'    
@@ -586,7 +586,7 @@ SEQUENCE
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'SEQUENCE'
 
 ===================================================
@@ -596,7 +596,7 @@ SET
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'SET'
 
 ===================================================
@@ -606,7 +606,7 @@ SETEQ
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'SETEQ'
 
 ===================================================
@@ -616,7 +616,7 @@ SETNEQ
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'SETNEQ'
 
 ===================================================
@@ -626,7 +626,7 @@ SHORT
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'SHORT'
 
 ===================================================
@@ -636,7 +636,7 @@ SMALLINT
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'SMALLINT'
 
 ===================================================
@@ -646,7 +646,7 @@ SQL
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'SQL'
 
 ===================================================
@@ -656,7 +656,7 @@ STRING
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'STRING'
 
 ===================================================
@@ -666,7 +666,7 @@ SUBSET
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'SUBSET'
 
 ===================================================
@@ -676,7 +676,7 @@ SUBSETEQ
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'SUBSETEQ'
 
 ===================================================
@@ -686,7 +686,7 @@ SUPERSET
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'SUPERSET'
 
 ===================================================
@@ -696,7 +696,7 @@ SUPERSETEQ
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'SUPERSETEQ'
 
 ===================================================
@@ -706,7 +706,7 @@ SYS_REFCURSOR
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'SYS_REFCURSOR'
 
 ===================================================
@@ -716,7 +716,7 @@ THEN
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'THEN'
 
 ===================================================
@@ -726,7 +726,7 @@ TIME
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'TIME'
 
 ===================================================
@@ -736,7 +736,7 @@ TIMESTAMP
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'TIMESTAMP'
 
 ===================================================
@@ -746,7 +746,7 @@ TIMESTAMPLTZ
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'TIMESTAMPLTZ'
 
 ===================================================
@@ -756,7 +756,7 @@ TIMESTAMPTZ
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'TIMESTAMPTZ'
 
 ===================================================
@@ -766,7 +766,7 @@ TRUE
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'TRUE'
 
 ===================================================
@@ -776,7 +776,7 @@ USING
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'USING'
 
 ===================================================
@@ -786,7 +786,7 @@ VARCHAR
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'VARCHAR'
 
 ===================================================
@@ -796,7 +796,7 @@ WHEN
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'WHEN'
 
 ===================================================
@@ -806,8 +806,8 @@ WHILE
 
 ===================================================
 Error:-1360
-In line 7, column 8
-Stored procedure compile error: mismatched input ';'
+In line 2, column 11
+Stored procedure compile error: mismatched input 'WHILE'
 
 ===================================================
 'WORK'    
@@ -816,7 +816,7 @@ WORK
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'WORK'
 
 ===================================================
@@ -826,7 +826,7 @@ XOR
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'XOR'
 
 ===================================================
@@ -836,8 +836,8 @@ INSERT
 
 ===================================================
 Error:-1360
-In line 7, column 7
-Stored procedure compile error: mismatched input '('
+In line 2, column 11
+Stored procedure compile error: mismatched input 'INSERT'
 
 ===================================================
 'TRUNCATE'    
@@ -846,8 +846,8 @@ TRUNCATE
 
 ===================================================
 Error:-1360
-In line 7, column 9
-Stored procedure compile error: mismatched input '('
+In line 2, column 11
+Stored procedure compile error: mismatched input 'TRUNCATE'
 
 ===================================================
 'AUTONOMOUS_TRANSACTION'    
@@ -856,7 +856,7 @@ AUTONOMOUS_TRANSACTION
 
 ===================================================
 Error:-1360
-In line 7, column 1
+In line 2, column 11
 Stored procedure compile error: mismatched input 'AUTONOMOUS_TRANSACTION'
 
 ===================================================
@@ -866,8 +866,8 @@ BEGIN
 
 ===================================================
 Error:-1360
-In line 11, column 1
-Stored procedure compile error: extraneous input 'end' expecting <EOF>
+In line 2, column 11
+Stored procedure compile error: mismatched input 'BEGIN'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_variable.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_variable.answer
@@ -866,8 +866,8 @@ BEGIN
 
 ===================================================
 Error:-1360
-In line 3, column 1
-Stored procedure compile error: mismatched input 'begin'
+In line 2, column 7
+Stored procedure compile error: mismatched input 'varchar'
 
 ===================================================
 Error:-894

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_02_uninitialized/answers/02_02_02-04_normal_comparison_function.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_02_uninitialized/answers/02_02_02-04_normal_comparison_function.answer
@@ -32,8 +32,8 @@ IF function is not supported.
 
 ===================================================
 Error:-1360
-In line 6, column 1
-Stored procedure compile error: extraneous input 'end' expecting <EOF>
+In line 2, column 14
+Stored procedure compile error: extraneous input 'IF'
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-02_param_to_variable_DATETIMELTZ.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-02_param_to_variable_DATETIMELTZ.answer
@@ -393,8 +393,8 @@ null
 t_SET_DATETIMELTZ. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR DATETIMELTZ'
+In line 1, column 95
+Stored procedure compile error: no viable alternative at input 'param SET'
 
 ===================================================
 Error:-495
@@ -413,8 +413,8 @@ null
 t_MULTISET_DATETIMELTZ. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR DATETIMELTZ'
+In line 1, column 100
+Stored procedure compile error: no viable alternative at input 'param MULTISET'
 
 ===================================================
 Error:-495
@@ -433,8 +433,8 @@ null
 t_LIST_DATETIMELTZ. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR DATETIMELTZ'
+In line 1, column 96
+Stored procedure compile error: no viable alternative at input 'param LIST'
 
 ===================================================
 Error:-495

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-03_param_to_variable_DATETIMETZ.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-03_param_to_variable_DATETIMETZ.answer
@@ -393,8 +393,8 @@ null
 t_SET_DATETIMETZ. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR DATETIMETZ'
+In line 1, column 94
+Stored procedure compile error: no viable alternative at input 'param SET'
 
 ===================================================
 Error:-495
@@ -413,8 +413,8 @@ null
 t_MULTISET_DATETIMETZ. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR DATETIMETZ'
+In line 1, column 99
+Stored procedure compile error: no viable alternative at input 'param MULTISET'
 
 ===================================================
 Error:-495
@@ -433,8 +433,8 @@ null
 t_LIST_DATETIMETZ. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR DATETIMETZ'
+In line 1, column 95
+Stored procedure compile error: no viable alternative at input 'param LIST'
 
 ===================================================
 Error:-495

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-07_param_to_variable_TIMESTAMPLTZ.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-07_param_to_variable_TIMESTAMPLTZ.answer
@@ -393,8 +393,8 @@ null
 t_SET_TIMESTAMPLTZ. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR TIMESTAMPLTZ'
+In line 1, column 96
+Stored procedure compile error: no viable alternative at input 'param SET'
 
 ===================================================
 Error:-495
@@ -413,8 +413,8 @@ null
 t_MULTISET_TIMESTAMPLTZ. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR TIMESTAMPLTZ'
+In line 1, column 101
+Stored procedure compile error: no viable alternative at input 'param MULTISET'
 
 ===================================================
 Error:-495
@@ -433,8 +433,8 @@ null
 t_LIST_TIMESTAMPLTZ. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR TIMESTAMPLTZ'
+In line 1, column 97
+Stored procedure compile error: no viable alternative at input 'param LIST'
 
 ===================================================
 Error:-495

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-08_param_to_variable_TIMESTAMPTZ.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-08_param_to_variable_TIMESTAMPTZ.answer
@@ -393,8 +393,8 @@ null
 t_SET_TIMESTAMPTZ. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR TIMESTAMPTZ'
+In line 1, column 95
+Stored procedure compile error: no viable alternative at input 'param SET'
 
 ===================================================
 Error:-495
@@ -413,8 +413,8 @@ null
 t_MULTISET_TIMESTAMPTZ. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR TIMESTAMPTZ'
+In line 1, column 100
+Stored procedure compile error: no viable alternative at input 'param MULTISET'
 
 ===================================================
 Error:-495
@@ -433,8 +433,8 @@ null
 t_LIST_TIMESTAMPTZ. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR TIMESTAMPTZ'
+In line 1, column 96
+Stored procedure compile error: no viable alternative at input 'param LIST'
 
 ===================================================
 Error:-495

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-11_param_to_variable_BIT.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-11_param_to_variable_BIT.answer
@@ -9,8 +9,8 @@ null
 t_DATETIME_BIT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 11
-Stored procedure compile error: no viable alternative at input 'BIT  ;'
+In line 2, column 9
+Stored procedure compile error: no viable alternative at input 'BIT :='
 
 ===================================================
 Error:-495
@@ -79,8 +79,8 @@ null
 t_DATE_BIT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 11
-Stored procedure compile error: no viable alternative at input 'BIT  ;'
+In line 2, column 9
+Stored procedure compile error: no viable alternative at input 'BIT :='
 
 ===================================================
 Error:-495
@@ -99,8 +99,8 @@ null
 t_TIME_BIT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 11
-Stored procedure compile error: no viable alternative at input 'BIT  ;'
+In line 2, column 9
+Stored procedure compile error: no viable alternative at input 'BIT :='
 
 ===================================================
 Error:-495
@@ -119,8 +119,8 @@ null
 t_TIMESTAMP_BIT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 11
-Stored procedure compile error: no viable alternative at input 'BIT  ;'
+In line 2, column 9
+Stored procedure compile error: no viable alternative at input 'BIT :='
 
 ===================================================
 Error:-495
@@ -189,8 +189,8 @@ null
 t_DOUBLE_BIT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 11
-Stored procedure compile error: no viable alternative at input 'BIT  ;'
+In line 2, column 9
+Stored procedure compile error: no viable alternative at input 'BIT :='
 
 ===================================================
 Error:-495
@@ -209,8 +209,8 @@ null
 t_FLOAT_BIT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 11
-Stored procedure compile error: no viable alternative at input 'BIT  ;'
+In line 2, column 9
+Stored procedure compile error: no viable alternative at input 'BIT :='
 
 ===================================================
 Error:-495
@@ -229,8 +229,8 @@ null
 t_NUMERIC_BIT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 11
-Stored procedure compile error: no viable alternative at input 'BIT  ;'
+In line 2, column 9
+Stored procedure compile error: no viable alternative at input 'BIT :='
 
 ===================================================
 Error:-495
@@ -249,8 +249,8 @@ null
 t_BIGINT_BIT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 11
-Stored procedure compile error: no viable alternative at input 'BIT  ;'
+In line 2, column 9
+Stored procedure compile error: no viable alternative at input 'BIT :='
 
 ===================================================
 Error:-495
@@ -269,8 +269,8 @@ null
 t_INT_BIT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 11
-Stored procedure compile error: no viable alternative at input 'BIT  ;'
+In line 2, column 9
+Stored procedure compile error: no viable alternative at input 'BIT :='
 
 ===================================================
 Error:-495
@@ -289,8 +289,8 @@ null
 t_SHORT_BIT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 11
-Stored procedure compile error: no viable alternative at input 'BIT  ;'
+In line 2, column 9
+Stored procedure compile error: no viable alternative at input 'BIT :='
 
 ===================================================
 Error:-495
@@ -359,8 +359,8 @@ null
 t_CHAR_BIT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 11
-Stored procedure compile error: no viable alternative at input 'BIT  ;'
+In line 2, column 9
+Stored procedure compile error: no viable alternative at input 'BIT :='
 
 ===================================================
 Error:-495
@@ -379,8 +379,8 @@ null
 t_VARCHAR_BIT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 11
-Stored procedure compile error: no viable alternative at input 'BIT  ;'
+In line 2, column 9
+Stored procedure compile error: no viable alternative at input 'BIT :='
 
 ===================================================
 Error:-495
@@ -399,8 +399,8 @@ null
 t_SET_BIT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 11
-Stored procedure compile error: no viable alternative at input 'BIT  ;'
+In line 1, column 87
+Stored procedure compile error: no viable alternative at input 'param SET'
 
 ===================================================
 Error:-495
@@ -419,8 +419,8 @@ null
 t_MULTISET_BIT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 11
-Stored procedure compile error: no viable alternative at input 'BIT  ;'
+In line 1, column 92
+Stored procedure compile error: no viable alternative at input 'param MULTISET'
 
 ===================================================
 Error:-495
@@ -439,8 +439,8 @@ null
 t_LIST_BIT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 11
-Stored procedure compile error: no viable alternative at input 'BIT  ;'
+In line 1, column 88
+Stored procedure compile error: no viable alternative at input 'param LIST'
 
 ===================================================
 Error:-495

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-12_param_to_variable_BIT_VARYING.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-12_param_to_variable_BIT_VARYING.answer
@@ -9,7 +9,7 @@ null
 t_DATETIME_BIT VARYING. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 10
+In line 2, column 9
 Stored procedure compile error: no viable alternative at input 'BIT VARYING'
 
 ===================================================
@@ -77,7 +77,7 @@ null
 t_DATE_BIT VARYING. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 10
+In line 2, column 9
 Stored procedure compile error: no viable alternative at input 'BIT VARYING'
 
 ===================================================
@@ -97,7 +97,7 @@ null
 t_TIME_BIT VARYING. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 10
+In line 2, column 9
 Stored procedure compile error: no viable alternative at input 'BIT VARYING'
 
 ===================================================
@@ -117,7 +117,7 @@ null
 t_TIMESTAMP_BIT VARYING. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 10
+In line 2, column 9
 Stored procedure compile error: no viable alternative at input 'BIT VARYING'
 
 ===================================================
@@ -185,7 +185,7 @@ null
 t_DOUBLE_BIT VARYING. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 10
+In line 2, column 9
 Stored procedure compile error: no viable alternative at input 'BIT VARYING'
 
 ===================================================
@@ -205,7 +205,7 @@ null
 t_FLOAT_BIT VARYING. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 10
+In line 2, column 9
 Stored procedure compile error: no viable alternative at input 'BIT VARYING'
 
 ===================================================
@@ -225,7 +225,7 @@ null
 t_NUMERIC_BIT VARYING. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 10
+In line 2, column 9
 Stored procedure compile error: no viable alternative at input 'BIT VARYING'
 
 ===================================================
@@ -245,7 +245,7 @@ null
 t_BIGINT_BIT VARYING. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 10
+In line 2, column 9
 Stored procedure compile error: no viable alternative at input 'BIT VARYING'
 
 ===================================================
@@ -265,7 +265,7 @@ null
 t_INT_BIT VARYING. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 10
+In line 2, column 9
 Stored procedure compile error: no viable alternative at input 'BIT VARYING'
 
 ===================================================
@@ -285,7 +285,7 @@ null
 t_SHORT_BIT VARYING. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 10
+In line 2, column 9
 Stored procedure compile error: no viable alternative at input 'BIT VARYING'
 
 ===================================================
@@ -353,7 +353,7 @@ null
 t_CHAR_BIT VARYING. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 10
+In line 2, column 9
 Stored procedure compile error: no viable alternative at input 'BIT VARYING'
 
 ===================================================
@@ -373,7 +373,7 @@ null
 t_VARCHAR_BIT VARYING. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 10
+In line 2, column 9
 Stored procedure compile error: no viable alternative at input 'BIT VARYING'
 
 ===================================================
@@ -393,8 +393,8 @@ null
 t_SET_BIT VARYING. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 10
-Stored procedure compile error: no viable alternative at input 'BIT VARYING'
+In line 1, column 94
+Stored procedure compile error: no viable alternative at input 'param SET'
 
 ===================================================
 Error:-495
@@ -413,8 +413,8 @@ null
 t_MULTISET_BIT VARYING. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 10
-Stored procedure compile error: no viable alternative at input 'BIT VARYING'
+In line 1, column 99
+Stored procedure compile error: no viable alternative at input 'param MULTISET'
 
 ===================================================
 Error:-495
@@ -433,8 +433,8 @@ null
 t_LIST_BIT VARYING. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 10
-Stored procedure compile error: no viable alternative at input 'BIT VARYING'
+In line 1, column 95
+Stored procedure compile error: no viable alternative at input 'param LIST'
 
 ===================================================
 Error:-495

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-19_param_to_variable_SET.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-19_param_to_variable_SET.answer
@@ -399,8 +399,8 @@ null
 t_SET_SET. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR SET'
+In line 1, column 87
+Stored procedure compile error: no viable alternative at input 'param SET'
 
 ===================================================
 Error:-495
@@ -419,8 +419,8 @@ null
 t_MULTISET_SET. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR SET'
+In line 1, column 92
+Stored procedure compile error: no viable alternative at input 'param MULTISET'
 
 ===================================================
 Error:-495
@@ -439,8 +439,8 @@ null
 t_LIST_SET. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR SET'
+In line 1, column 88
+Stored procedure compile error: no viable alternative at input 'param LIST'
 
 ===================================================
 Error:-495

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-20_param_to_variable_MULTISET.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-20_param_to_variable_MULTISET.answer
@@ -393,8 +393,8 @@ null
 t_SET_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
+In line 1, column 92
+Stored procedure compile error: no viable alternative at input 'param SET'
 
 ===================================================
 Error:-495
@@ -413,8 +413,8 @@ null
 t_MULTISET_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
+In line 1, column 97
+Stored procedure compile error: no viable alternative at input 'param MULTISET'
 
 ===================================================
 Error:-495
@@ -433,8 +433,8 @@ null
 t_LIST_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
+In line 1, column 93
+Stored procedure compile error: no viable alternative at input 'param LIST'
 
 ===================================================
 Error:-495

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-21_param_to_variable_LIST.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-21_param_to_variable_LIST.answer
@@ -399,8 +399,8 @@ null
 t_SET_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR LIST'
+In line 1, column 88
+Stored procedure compile error: no viable alternative at input 'param SET'
 
 ===================================================
 Error:-495
@@ -419,8 +419,8 @@ null
 t_MULTISET_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR LIST'
+In line 1, column 93
+Stored procedure compile error: no viable alternative at input 'param MULTISET'
 
 ===================================================
 Error:-495
@@ -439,8 +439,8 @@ null
 t_LIST_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR LIST'
+In line 1, column 89
+Stored procedure compile error: no viable alternative at input 'param LIST'
 
 ===================================================
 Error:-495

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-22_param_to_variable_ENUM.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-22_param_to_variable_ENUM.answer
@@ -9,8 +9,8 @@ null
 t_DATETIME_ENUM. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'ENUM  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'ENUM :='
 
 ===================================================
 Error:-495
@@ -79,8 +79,8 @@ null
 t_DATE_ENUM. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'ENUM  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'ENUM :='
 
 ===================================================
 Error:-495
@@ -99,8 +99,8 @@ null
 t_TIME_ENUM. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'ENUM  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'ENUM :='
 
 ===================================================
 Error:-495
@@ -119,8 +119,8 @@ null
 t_TIMESTAMP_ENUM. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'ENUM  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'ENUM :='
 
 ===================================================
 Error:-495
@@ -189,8 +189,8 @@ null
 t_DOUBLE_ENUM. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'ENUM  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'ENUM :='
 
 ===================================================
 Error:-495
@@ -209,8 +209,8 @@ null
 t_FLOAT_ENUM. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'ENUM  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'ENUM :='
 
 ===================================================
 Error:-495
@@ -229,8 +229,8 @@ null
 t_NUMERIC_ENUM. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'ENUM  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'ENUM :='
 
 ===================================================
 Error:-495
@@ -249,8 +249,8 @@ null
 t_BIGINT_ENUM. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'ENUM  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'ENUM :='
 
 ===================================================
 Error:-495
@@ -269,8 +269,8 @@ null
 t_INT_ENUM. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'ENUM  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'ENUM :='
 
 ===================================================
 Error:-495
@@ -289,8 +289,8 @@ null
 t_SHORT_ENUM. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'ENUM  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'ENUM :='
 
 ===================================================
 Error:-495
@@ -359,8 +359,8 @@ null
 t_CHAR_ENUM. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'ENUM  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'ENUM :='
 
 ===================================================
 Error:-495
@@ -379,8 +379,8 @@ null
 t_VARCHAR_ENUM. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'ENUM  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'ENUM :='
 
 ===================================================
 Error:-495
@@ -399,8 +399,8 @@ null
 t_SET_ENUM. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'ENUM  ;'
+In line 1, column 88
+Stored procedure compile error: no viable alternative at input 'param SET'
 
 ===================================================
 Error:-495
@@ -419,8 +419,8 @@ null
 t_MULTISET_ENUM. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'ENUM  ;'
+In line 1, column 93
+Stored procedure compile error: no viable alternative at input 'param MULTISET'
 
 ===================================================
 Error:-495
@@ -439,8 +439,8 @@ null
 t_LIST_ENUM. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'ENUM  ;'
+In line 1, column 89
+Stored procedure compile error: no viable alternative at input 'param LIST'
 
 ===================================================
 Error:-495

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-23_param_to_variable_BLOB.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-23_param_to_variable_BLOB.answer
@@ -9,8 +9,8 @@ null
 t_DATETIME_BLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'BLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'BLOB :='
 
 ===================================================
 Error:-495
@@ -79,8 +79,8 @@ null
 t_DATE_BLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'BLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'BLOB :='
 
 ===================================================
 Error:-495
@@ -99,8 +99,8 @@ null
 t_TIME_BLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'BLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'BLOB :='
 
 ===================================================
 Error:-495
@@ -119,8 +119,8 @@ null
 t_TIMESTAMP_BLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'BLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'BLOB :='
 
 ===================================================
 Error:-495
@@ -189,8 +189,8 @@ null
 t_DOUBLE_BLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'BLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'BLOB :='
 
 ===================================================
 Error:-495
@@ -209,8 +209,8 @@ null
 t_FLOAT_BLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'BLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'BLOB :='
 
 ===================================================
 Error:-495
@@ -229,8 +229,8 @@ null
 t_NUMERIC_BLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'BLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'BLOB :='
 
 ===================================================
 Error:-495
@@ -249,8 +249,8 @@ null
 t_BIGINT_BLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'BLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'BLOB :='
 
 ===================================================
 Error:-495
@@ -269,8 +269,8 @@ null
 t_INT_BLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'BLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'BLOB :='
 
 ===================================================
 Error:-495
@@ -289,8 +289,8 @@ null
 t_SHORT_BLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'BLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'BLOB :='
 
 ===================================================
 Error:-495
@@ -359,8 +359,8 @@ null
 t_CHAR_BLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'BLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'BLOB :='
 
 ===================================================
 Error:-495
@@ -379,8 +379,8 @@ null
 t_VARCHAR_BLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'BLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'BLOB :='
 
 ===================================================
 Error:-495
@@ -399,8 +399,8 @@ null
 t_SET_BLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'BLOB  ;'
+In line 1, column 88
+Stored procedure compile error: no viable alternative at input 'param SET'
 
 ===================================================
 Error:-495
@@ -419,8 +419,8 @@ null
 t_MULTISET_BLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'BLOB  ;'
+In line 1, column 93
+Stored procedure compile error: no viable alternative at input 'param MULTISET'
 
 ===================================================
 Error:-495
@@ -439,8 +439,8 @@ null
 t_LIST_BLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'BLOB  ;'
+In line 1, column 89
+Stored procedure compile error: no viable alternative at input 'param LIST'
 
 ===================================================
 Error:-495

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-24_param_to_variable_CLOB.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-24_param_to_variable_CLOB.answer
@@ -9,8 +9,8 @@ null
 t_DATETIME_CLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'CLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'CLOB :='
 
 ===================================================
 Error:-495
@@ -79,8 +79,8 @@ null
 t_DATE_CLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'CLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'CLOB :='
 
 ===================================================
 Error:-495
@@ -99,8 +99,8 @@ null
 t_TIME_CLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'CLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'CLOB :='
 
 ===================================================
 Error:-495
@@ -119,8 +119,8 @@ null
 t_TIMESTAMP_CLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'CLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'CLOB :='
 
 ===================================================
 Error:-495
@@ -189,8 +189,8 @@ null
 t_DOUBLE_CLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'CLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'CLOB :='
 
 ===================================================
 Error:-495
@@ -209,8 +209,8 @@ null
 t_FLOAT_CLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'CLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'CLOB :='
 
 ===================================================
 Error:-495
@@ -229,8 +229,8 @@ null
 t_NUMERIC_CLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'CLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'CLOB :='
 
 ===================================================
 Error:-495
@@ -249,8 +249,8 @@ null
 t_BIGINT_CLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'CLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'CLOB :='
 
 ===================================================
 Error:-495
@@ -269,8 +269,8 @@ null
 t_INT_CLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'CLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'CLOB :='
 
 ===================================================
 Error:-495
@@ -289,8 +289,8 @@ null
 t_SHORT_CLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'CLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'CLOB :='
 
 ===================================================
 Error:-495
@@ -359,8 +359,8 @@ null
 t_CHAR_CLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'CLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'CLOB :='
 
 ===================================================
 Error:-495
@@ -379,8 +379,8 @@ null
 t_VARCHAR_CLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'CLOB  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'CLOB :='
 
 ===================================================
 Error:-495
@@ -399,8 +399,8 @@ null
 t_SET_CLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'CLOB  ;'
+In line 1, column 88
+Stored procedure compile error: no viable alternative at input 'param SET'
 
 ===================================================
 Error:-495
@@ -419,8 +419,8 @@ null
 t_MULTISET_CLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'CLOB  ;'
+In line 1, column 93
+Stored procedure compile error: no viable alternative at input 'param MULTISET'
 
 ===================================================
 Error:-495
@@ -439,8 +439,8 @@ null
 t_LIST_CLOB. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'CLOB  ;'
+In line 1, column 89
+Stored procedure compile error: no viable alternative at input 'param LIST'
 
 ===================================================
 Error:-495

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-25_param_to_variable_JSON.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_02_variable/_04_type_conversion/answers/02_02_04-25_param_to_variable_JSON.answer
@@ -9,8 +9,8 @@ null
 t_DATETIME_JSON. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'JSON  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'JSON :='
 
 ===================================================
 Error:-495
@@ -79,8 +79,8 @@ null
 t_DATE_JSON. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'JSON  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'JSON :='
 
 ===================================================
 Error:-495
@@ -99,8 +99,8 @@ null
 t_TIME_JSON. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'JSON  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'JSON :='
 
 ===================================================
 Error:-495
@@ -119,8 +119,8 @@ null
 t_TIMESTAMP_JSON. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'JSON  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'JSON :='
 
 ===================================================
 Error:-495
@@ -189,8 +189,8 @@ null
 t_DOUBLE_JSON. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'JSON  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'JSON :='
 
 ===================================================
 Error:-495
@@ -209,8 +209,8 @@ null
 t_FLOAT_JSON. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'JSON  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'JSON :='
 
 ===================================================
 Error:-495
@@ -229,8 +229,8 @@ null
 t_NUMERIC_JSON. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'JSON  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'JSON :='
 
 ===================================================
 Error:-495
@@ -249,8 +249,8 @@ null
 t_BIGINT_JSON. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'JSON  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'JSON :='
 
 ===================================================
 Error:-495
@@ -269,8 +269,8 @@ null
 t_INT_JSON. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'JSON  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'JSON :='
 
 ===================================================
 Error:-495
@@ -289,8 +289,8 @@ null
 t_SHORT_JSON. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'JSON  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'JSON :='
 
 ===================================================
 Error:-495
@@ -359,8 +359,8 @@ null
 t_CHAR_JSON. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'JSON  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'JSON :='
 
 ===================================================
 Error:-495
@@ -379,8 +379,8 @@ null
 t_VARCHAR_JSON. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'JSON  ;'
+In line 2, column 10
+Stored procedure compile error: no viable alternative at input 'JSON :='
 
 ===================================================
 Error:-495
@@ -399,8 +399,8 @@ null
 t_SET_JSON. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'JSON  ;'
+In line 1, column 88
+Stored procedure compile error: no viable alternative at input 'param SET'
 
 ===================================================
 Error:-495
@@ -419,8 +419,8 @@ null
 t_MULTISET_JSON. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'JSON  ;'
+In line 1, column 93
+Stored procedure compile error: no viable alternative at input 'param MULTISET'
 
 ===================================================
 Error:-495
@@ -439,8 +439,8 @@ null
 t_LIST_JSON. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 3, column 12
-Stored procedure compile error: no viable alternative at input 'JSON  ;'
+In line 1, column 89
+Stored procedure compile error: no viable alternative at input 'param LIST'
 
 ===================================================
 Error:-495

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_01_initialized/answers/02_03_01-03_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_01_initialized/answers/02_03_01-03_error_typo.answer
@@ -5,21 +5,21 @@ Stored procedure compile error: no viable alternative at input 'a INT'
 
 ===================================================
 Error:-1360
-In line 2, column 20
-Stored procedure compile error: mismatched input 'NOLL'
+In line 2, column 1
+Stored procedure compile error: extraneous input 'CONSTANT'
 
 ===================================================
 Error:-1360
-In line 2, column 16
-Stored procedure compile error: mismatched input 'NUT'
+In line 2, column 1
+Stored procedure compile error: extraneous input 'CONSTANT'
 
 ===================================================
 Error:-1360
-In line 2, column 17
-Stored procedure compile error: mismatched input 'DEFAULTS'
+In line 2, column 1
+Stored procedure compile error: extraneous input 'CONSTANT'
 
 ===================================================
 Error:-1360
-In line 2, column 16
-Stored procedure compile error: mismatched input '3'
+In line 2, column 1
+Stored procedure compile error: extraneous input 'CONSTANT'
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_01_initialized/answers/02_03_01-07_normal_comparison_function.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_01_initialized/answers/02_03_01-07_normal_comparison_function.answer
@@ -32,8 +32,8 @@ IF function is not supported.
 
 ===================================================
 Error:-1360
-In line 6, column 1
-Stored procedure compile error: extraneous input 'end' expecting <EOF>
+In line 2, column 23
+Stored procedure compile error: extraneous input 'IF'
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_03_common/answers/02_03_03-03_error_constant_with_same_name.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_03_constant/_03_common/answers/02_03_03-03_error_constant_with_same_name.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 3, column 15
-Stored procedure compile error: mismatched input ';'
+In line 2, column 9
+Stored procedure compile error: no viable alternative at input 'const int'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_04_exception/_01_basic/answers/02_04_01-03_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_04_exception/_01_basic/answers/02_04_01-03_error_typo.answer
@@ -10,6 +10,6 @@ Stored procedure compile error: mismatched input 'when'
 
 ===================================================
 Error:-1360
-In line 6, column 1
-Stored procedure compile error: mismatched input 'when'
+In line 2, column 24
+Stored procedure compile error: no viable alternative at input 'exceptions;'
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_05_autonomous_transaction/_01_basic/answers/02_05_01-05_error_position.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_05_autonomous_transaction/_01_basic/answers/02_05_01-05_error_position.answer
@@ -1,10 +1,10 @@
 ===================================================
 Error:-1360
-In line 9, column 1
-Stored procedure compile error: mismatched input 'INSERT'
+In line 8, column 1
+Stored procedure compile error: mismatched input 'PRAGMA'
 
 ===================================================
 Error:-1360
-In line 13, column 1
-Stored procedure compile error: mismatched input 'WHEN'
+In line 12, column 1
+Stored procedure compile error: mismatched input 'PRAGMA'
 

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_06_cursor/_01_basic/answers/02_06_01-06_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_06_cursor/_01_basic/answers/02_06_01-06_error_typo.answer
@@ -9,8 +9,8 @@
 
 ===================================================
 Error:-1360
-In line 2, column 17
-Stored procedure compile error: mismatched input ')'
+In line 2, column 9
+Stored procedure compile error: no viable alternative at input 'c('
 
 ===================================================
 Error:-1360
@@ -24,8 +24,8 @@ Stored procedure compile error: missing SEMICOLON at 'c'
 
 ===================================================
 Error:-1360
-In line 12, column 5
-Stored procedure compile error: mismatched input 'loop'
+In line 8, column 8
+Stored procedure compile error: missing SEMICOLON at 'c'
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_06_cursor/_01_basic/answers/02_06_01-07_error_reserved.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_06_cursor/_01_basic/answers/02_06_01-07_error_reserved.answer
@@ -9,7 +9,7 @@
 
 ===================================================
 Error:-1360
-In line 13, column 7
+In line 2, column 8
 Stored procedure compile error: mismatched input 'cursor'
 
 ===================================================

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_06_cursor/_02_into_type_conversion/answers/02_06_02-17_column_to_into_NUMERIC.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_06_cursor/_02_into_type_conversion/answers/02_06_02-17_column_to_into_NUMERIC.answer
@@ -221,8 +221,8 @@ null
 t_NUMERIC_NUMERIC. This scenario is a success.
 ===================================================
 Error:-1360
-In line 11, column 38
-Stored procedure compile error: mismatched input 'DECIMAL'
+In line 5, column 38
+Stored procedure compile error: mismatched input 'NUMERIC'
 
 ===================================================
 Error:-495

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_07_local_proc/_01_wo_param/answers/02_07_01-02_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_07_local_proc/_01_wo_param/answers/02_07_01-02_error_typo.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 3, column 22
-Stored procedure compile error: mismatched input ')'
+In line 3, column 16
+Stored procedure compile error: no viable alternative at input 'ping('
 
 ===================================================
 Error:-493
@@ -16,8 +16,8 @@ Syntax error: unexpected 'end', expecting SELECT or VALUE or VALUES or '('
 
 ===================================================
 Error:-1360
-In line 12, column 1
-Stored procedure compile error: mismatched input 'begin'
+In line 4, column 1
+Stored procedure compile error: mismatched input 'TO'
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_07_local_proc/_06_writing_rule/answers/02_07_06-03_error_bracket_symbol.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_07_local_proc/_06_writing_rule/answers/02_07_06-03_error_bracket_symbol.answer
@@ -5,8 +5,8 @@ Stored procedure compile error: mismatched input ';'
 
 ===================================================
 Error:-1360
-In line 13, column 10
-Stored procedure compile error: extraneous input ')'
+In line 13, column 6
+Stored procedure compile error: missing SEMICOLON at 'cnt'
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_08_local_func/_01_wo_param/answers/02_08_01-02_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_08_local_func/_01_wo_param/answers/02_08_01-02_error_typo.answer
@@ -111,8 +111,8 @@ Syntax error: unexpected 'END', expecting SELECT or VALUE or VALUES or '('
 
 ===================================================
 Error:-1360
-In line 15, column 1
-Stored procedure compile error: mismatched input 'begin'
+In line 4, column 27
+Stored procedure compile error: mismatched input 'retorn'
 
 ===================================================
 Error:-494
@@ -124,8 +124,8 @@ dba.INTS is not defined. create function [dba.choose](m  integer, n  integer) re
 
 ===================================================
 Error:-1360
-In line 15, column 1
-Stored procedure compile error: mismatched input 'begin'
+In line 5, column 1
+Stored procedure compile error: mismatched input 'TO'
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_08_local_func/_06_writing_rule/answers/02_08_06-03_error_bracket_symbol.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_08_local_func/_06_writing_rule/answers/02_08_06-03_error_bracket_symbol.answer
@@ -5,8 +5,8 @@ Stored procedure compile error: mismatched input ';'
 
 ===================================================
 Error:-1360
-In line 19, column 19
-Stored procedure compile error: extraneous input ')'
+In line 19, column 18
+Stored procedure compile error: missing SEMICOLON at 'm'
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_10_row_type/answers/03_percent_rowtype_compare.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_10_row_type/answers/03_percent_rowtype_compare.answer
@@ -100,8 +100,8 @@ Stored procedure compile error: only = and != are allowed for a record
 
 ===================================================
 Error:-1360
-In line 7, column 5
-Stored procedure compile error: mismatched input 'if'
+In line 5, column 8
+Stored procedure compile error: missing RPAREN at 'in'
 
 ===================================================
 0

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_01_block/_01_with_decl_part/answers/03_01_01-08_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_01_block/_01_with_decl_part/answers/03_01_01-08_error_typo.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 6, column 1
-Stored procedure compile error: mismatched input 'BEGIN'
+In line 5, column 1
+Stored procedure compile error: missing SEMICOLON at 'out_msg'
 
 ===================================================
 Error:-1360
@@ -25,18 +25,18 @@ Stored procedure compile error: no viable alternative at input 'EXCEPTIONS;'
 
 ===================================================
 Error:-1360
-In line 15, column 1
-Stored procedure compile error: mismatched input 'RAISE'
+In line 10, column 1
+Stored procedure compile error: mismatched input 'WHEN'
 
 ===================================================
 Error:-1360
-In line 15, column 1
-Stored procedure compile error: mismatched input 'RAISE'
+In line 10, column 1
+Stored procedure compile error: mismatched input 'WHENS'
 
 ===================================================
 Error:-1360
-In line 15, column 1
-Stored procedure compile error: mismatched input 'RAISE'
+In line 10, column 20
+Stored procedure compile error: mismatched input 'THENS'
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_01_open/answers/03_03_01-07_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_03_cursor_manipulation/_01_open/answers/03_03_01-07_error_typo.answer
@@ -20,13 +20,13 @@ Stored procedure compile error: missing SEMICOLON at 'my_cursor'
 
 ===================================================
 Error:-1360
-In line 13, column 5
-Stored procedure compile error: mismatched input 'LOOP'
+In line 10, column 8
+Stored procedure compile error: missing SEMICOLON at 'my_cursor'
 
 ===================================================
 Error:-1360
-In line 13, column 5
-Stored procedure compile error: mismatched input 'LOOP'
+In line 10, column 17
+Stored procedure compile error: missing INTO at 'INTOs'
 
 ===================================================
 Error:-1360

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_01_into_clause/answers/03_04_01-05_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_01_into_clause/answers/03_04_01-05_error_typo.answer
@@ -5,11 +5,11 @@ Stored procedure compile error: mismatched input 'IMMEDIATE'
 
 ===================================================
 Error:-1360
-In line 4, column 20
-Stored procedure compile error: mismatched input ''create table ''
+In line 4, column 9
+Stored procedure compile error: missing IMMEDIATE at 'IMMEDIATEs'
 
 ===================================================
 Error:-1360
-In line 5, column 8
-Stored procedure compile error: extraneous input 'name'
+In line 5, column 1
+Stored procedure compile error: missing SEMICOLON at 'USINGs'
 

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_03_common/answers/03_04_03-06_error_character.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_03_common/answers/03_04_03-06_error_character.answer
@@ -1,10 +1,10 @@
 ===================================================
 Error:-1360
-In line 4, column 50
-Stored procedure compile error: token recognition error at: '";'
+In line 4, column 19
+Stored procedure compile error: token recognition error at: '"create '
 
 ===================================================
 Error:-1360
-In line 4, column 50
-Stored procedure compile error: token recognition error at: '`;'
+In line 4, column 19
+Stored procedure compile error: token recognition error at: '`create '
 

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_03_common/answers/03_04_03-07_error_into.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_04_execute_immediate/_03_common/answers/03_04_03-07_error_into.answer
@@ -1,5 +1,5 @@
 ===================================================
 Error:-1360
-In line 7, column 1
-Stored procedure compile error: mismatched input 'put_line'
+In line 6, column 81
+Stored procedure compile error: mismatched input '+'
 

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_05_assign/_01_basic/answers/03_05_01-04_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_05_assign/_01_basic/answers/03_05_01-04_error_typo.answer
@@ -1,10 +1,10 @@
 ===================================================
 Error:-1360
-In line 6, column 1
-Stored procedure compile error: mismatched input 'EXECUTE'
+In line 5, column 14
+Stored procedure compile error: mismatched input '='
 
 ===================================================
 Error:-1360
-In line 6, column 1
-Stored procedure compile error: mismatched input 'EXECUTE'
+In line 5, column 14
+Stored procedure compile error: mismatched input '='
 

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_06_continue/_01_with_label/answers/03_06_01-03_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_06_continue/_01_with_label/answers/03_06_01-03_error_typo.answer
@@ -5,8 +5,8 @@ Stored procedure compile error: mismatched input 'WHEN'
 
 ===================================================
 Error:-1360
-In line 5, column 13
-Stored procedure compile error: mismatched input '>'
+In line 5, column 12
+Stored procedure compile error: missing SEMICOLON at 'i'
 
 ===================================================
 Error:-1360
@@ -15,6 +15,6 @@ Stored procedure compile error: mismatched input 'WHEN'
 
 ===================================================
 Error:-1360
-In line 5, column 17
-Stored procedure compile error: mismatched input '>'
+In line 5, column 16
+Stored procedure compile error: missing SEMICOLON at 'i'
 

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-01_variable_to_return_DATETIME.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-01_variable_to_return_DATETIME.answer
@@ -395,8 +395,8 @@ null
 t_SET_DATETIME. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR SET'
+In line 1, column 98
+Stored procedure compile error: no viable alternative at input 'param_value SET'
 
 ===================================================
 Error:-494
@@ -416,8 +416,8 @@ null
 t_MULTISET_DATETIME. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
+In line 1, column 103
+Stored procedure compile error: no viable alternative at input 'param_value MULTISET'
 
 ===================================================
 Error:-494
@@ -437,8 +437,8 @@ null
 t_LIST_DATETIME. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR LIST'
+In line 1, column 99
+Stored procedure compile error: no viable alternative at input 'param_value LIST'
 
 ===================================================
 Error:-494

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-04_variable_to_return_DATE.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-04_variable_to_return_DATE.answer
@@ -394,8 +394,8 @@ null
 t_SET_DATE. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR SET'
+In line 1, column 94
+Stored procedure compile error: no viable alternative at input 'param_value SET'
 
 ===================================================
 Error:-494
@@ -415,8 +415,8 @@ null
 t_MULTISET_DATE. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
+In line 1, column 99
+Stored procedure compile error: no viable alternative at input 'param_value MULTISET'
 
 ===================================================
 Error:-494
@@ -436,8 +436,8 @@ null
 t_LIST_DATE. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR LIST'
+In line 1, column 95
+Stored procedure compile error: no viable alternative at input 'param_value LIST'
 
 ===================================================
 Error:-494

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-05_variable_to_return_TIME.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-05_variable_to_return_TIME.answer
@@ -384,8 +384,8 @@ null
 t_SET_TIME. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR SET'
+In line 1, column 94
+Stored procedure compile error: no viable alternative at input 'param_value SET'
 
 ===================================================
 Error:-494
@@ -405,8 +405,8 @@ null
 t_MULTISET_TIME. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
+In line 1, column 99
+Stored procedure compile error: no viable alternative at input 'param_value MULTISET'
 
 ===================================================
 Error:-494
@@ -426,8 +426,8 @@ null
 t_LIST_TIME. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR LIST'
+In line 1, column 95
+Stored procedure compile error: no viable alternative at input 'param_value LIST'
 
 ===================================================
 Error:-494

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-06_variable_to_return_TIMESTAMP.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-06_variable_to_return_TIMESTAMP.answer
@@ -382,8 +382,8 @@ null
 t_SET_TIMESTAMP. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR SET'
+In line 1, column 99
+Stored procedure compile error: no viable alternative at input 'param_value SET'
 
 ===================================================
 Error:-494
@@ -403,8 +403,8 @@ null
 t_MULTISET_TIMESTAMP. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
+In line 1, column 104
+Stored procedure compile error: no viable alternative at input 'param_value MULTISET'
 
 ===================================================
 Error:-494
@@ -424,8 +424,8 @@ null
 t_LIST_TIMESTAMP. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR LIST'
+In line 1, column 100
+Stored procedure compile error: no viable alternative at input 'param_value LIST'
 
 ===================================================
 Error:-494

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-09_variable_to_return_INT.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-09_variable_to_return_INT.answer
@@ -388,8 +388,8 @@ null
 t_SET_INT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR SET'
+In line 1, column 93
+Stored procedure compile error: no viable alternative at input 'param_value SET'
 
 ===================================================
 Error:-494
@@ -409,8 +409,8 @@ null
 t_MULTISET_INT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
+In line 1, column 98
+Stored procedure compile error: no viable alternative at input 'param_value MULTISET'
 
 ===================================================
 Error:-494
@@ -430,8 +430,8 @@ null
 t_LIST_INT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR LIST'
+In line 1, column 94
+Stored procedure compile error: no viable alternative at input 'param_value LIST'
 
 ===================================================
 Error:-494

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-10_variable_to_return_SHORT.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-10_variable_to_return_SHORT.answer
@@ -388,8 +388,8 @@ null
 t_SET_SHORT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR SET'
+In line 1, column 95
+Stored procedure compile error: no viable alternative at input 'param_value SET'
 
 ===================================================
 Error:-494
@@ -409,8 +409,8 @@ null
 t_MULTISET_SHORT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
+In line 1, column 100
+Stored procedure compile error: no viable alternative at input 'param_value MULTISET'
 
 ===================================================
 Error:-494
@@ -430,8 +430,8 @@ null
 t_LIST_SHORT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR LIST'
+In line 1, column 96
+Stored procedure compile error: no viable alternative at input 'param_value LIST'
 
 ===================================================
 Error:-494

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-13_variable_to_return_CHAR.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-13_variable_to_return_CHAR.answer
@@ -380,8 +380,8 @@ null
 t_SET_CHAR. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR SET'
+In line 1, column 94
+Stored procedure compile error: no viable alternative at input 'param_value SET'
 
 ===================================================
 Error:-494
@@ -401,8 +401,8 @@ null
 t_MULTISET_CHAR. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
+In line 1, column 99
+Stored procedure compile error: no viable alternative at input 'param_value MULTISET'
 
 ===================================================
 Error:-494
@@ -422,8 +422,8 @@ null
 t_LIST_CHAR. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR LIST'
+In line 1, column 95
+Stored procedure compile error: no viable alternative at input 'param_value LIST'
 
 ===================================================
 Error:-494

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-14_variable_to_return_VARCHAR.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-14_variable_to_return_VARCHAR.answer
@@ -379,8 +379,8 @@ null
 t_SET_VARCHAR. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR SET'
+In line 1, column 97
+Stored procedure compile error: no viable alternative at input 'param_value SET'
 
 ===================================================
 Error:-494
@@ -400,8 +400,8 @@ null
 t_MULTISET_VARCHAR. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
+In line 1, column 102
+Stored procedure compile error: no viable alternative at input 'param_value MULTISET'
 
 ===================================================
 Error:-494
@@ -421,8 +421,8 @@ null
 t_LIST_VARCHAR. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR LIST'
+In line 1, column 98
+Stored procedure compile error: no viable alternative at input 'param_value LIST'
 
 ===================================================
 Error:-494

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-15_variable_to_return_DOUBLE.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-15_variable_to_return_DOUBLE.answer
@@ -390,8 +390,8 @@ null
 t_SET_DOUBLE. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR SET'
+In line 1, column 96
+Stored procedure compile error: no viable alternative at input 'param_value SET'
 
 ===================================================
 Error:-494
@@ -411,8 +411,8 @@ null
 t_MULTISET_DOUBLE. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
+In line 1, column 101
+Stored procedure compile error: no viable alternative at input 'param_value MULTISET'
 
 ===================================================
 Error:-494
@@ -432,8 +432,8 @@ null
 t_LIST_DOUBLE. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR LIST'
+In line 1, column 97
+Stored procedure compile error: no viable alternative at input 'param_value LIST'
 
 ===================================================
 Error:-494

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-16_variable_to_return_FLOAT.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-16_variable_to_return_FLOAT.answer
@@ -390,8 +390,8 @@ null
 t_SET_FLOAT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR SET'
+In line 1, column 95
+Stored procedure compile error: no viable alternative at input 'param_value SET'
 
 ===================================================
 Error:-494
@@ -411,8 +411,8 @@ null
 t_MULTISET_FLOAT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
+In line 1, column 100
+Stored procedure compile error: no viable alternative at input 'param_value MULTISET'
 
 ===================================================
 Error:-494
@@ -432,8 +432,8 @@ null
 t_LIST_FLOAT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR LIST'
+In line 1, column 96
+Stored procedure compile error: no viable alternative at input 'param_value LIST'
 
 ===================================================
 Error:-494

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-17_variable_to_return_NUMERIC.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-17_variable_to_return_NUMERIC.answer
@@ -387,8 +387,8 @@ null
 t_SET_NUMERIC(38,15). This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR SET'
+In line 1, column 97
+Stored procedure compile error: no viable alternative at input 'param_value SET'
 
 ===================================================
 Error:-494
@@ -408,8 +408,8 @@ null
 t_MULTISET_NUMERIC(38,15). This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
+In line 1, column 102
+Stored procedure compile error: no viable alternative at input 'param_value MULTISET'
 
 ===================================================
 Error:-494
@@ -429,8 +429,8 @@ null
 t_LIST_NUMERIC(38,15). This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR LIST'
+In line 1, column 98
+Stored procedure compile error: no viable alternative at input 'param_value LIST'
 
 ===================================================
 Error:-494

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-18_variable_to_return_BIGINT.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-18_variable_to_return_BIGINT.answer
@@ -388,8 +388,8 @@ null
 t_SET_BIGINT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR SET'
+In line 1, column 96
+Stored procedure compile error: no viable alternative at input 'param_value SET'
 
 ===================================================
 Error:-494
@@ -409,8 +409,8 @@ null
 t_MULTISET_BIGINT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
+In line 1, column 101
+Stored procedure compile error: no viable alternative at input 'param_value MULTISET'
 
 ===================================================
 Error:-494
@@ -430,8 +430,8 @@ null
 t_LIST_BIGINT. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR LIST'
+In line 1, column 97
+Stored procedure compile error: no viable alternative at input 'param_value LIST'
 
 ===================================================
 Error:-494

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-19_variable_to_return_SET.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-19_variable_to_return_SET.answer
@@ -406,8 +406,8 @@ null
 t_SET_SET. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR SET'
+In line 1, column 93
+Stored procedure compile error: no viable alternative at input 'param_value SET'
 
 ===================================================
 Error:-494
@@ -427,8 +427,8 @@ null
 t_MULTISET_SET. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
+In line 1, column 98
+Stored procedure compile error: no viable alternative at input 'param_value MULTISET'
 
 ===================================================
 Error:-494
@@ -448,8 +448,8 @@ null
 t_LIST_SET. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR LIST'
+In line 1, column 94
+Stored procedure compile error: no viable alternative at input 'param_value LIST'
 
 ===================================================
 Error:-494

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-20_variable_to_return_MULTISET.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-20_variable_to_return_MULTISET.answer
@@ -405,8 +405,8 @@ null
 t_SET_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR SET'
+In line 1, column 98
+Stored procedure compile error: no viable alternative at input 'param_value SET'
 
 ===================================================
 Error:-494
@@ -426,8 +426,8 @@ null
 t_MULTISET_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
+In line 1, column 103
+Stored procedure compile error: no viable alternative at input 'param_value MULTISET'
 
 ===================================================
 Error:-494
@@ -447,8 +447,8 @@ null
 t_LIST_MULTISET. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR LIST'
+In line 1, column 99
+Stored procedure compile error: no viable alternative at input 'param_value LIST'
 
 ===================================================
 Error:-494

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-21_variable_to_return_LIST.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_10_return/_03_type_conversion/answers/03_10_03-21_variable_to_return_LIST.answer
@@ -406,8 +406,8 @@ null
 t_SET_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR SET'
+In line 1, column 94
+Stored procedure compile error: no viable alternative at input 'param_value SET'
 
 ===================================================
 Error:-494
@@ -427,8 +427,8 @@ null
 t_MULTISET_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR MULTISET'
+In line 1, column 99
+Stored procedure compile error: no viable alternative at input 'param_value MULTISET'
 
 ===================================================
 Error:-494
@@ -448,8 +448,8 @@ null
 t_LIST_LIST. This scenario is a failure.
 ===================================================
 Error:-1360
-In line 2, column 5
-Stored procedure compile error: no viable alternative at input 'VAR LIST'
+In line 1, column 95
+Stored procedure compile error: no viable alternative at input 'param_value LIST'
 
 ===================================================
 Error:-494

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-01_normal_basic.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-01_normal_basic.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 6, column 5
-Stored procedure compile error: mismatched input 'loop'
+In line 3, column 11
+Stored procedure compile error: no viable alternative at input 'for r in (execute'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-01_normal_basic_2.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-01_normal_basic_2.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 6, column 5
-Stored procedure compile error: mismatched input 'loop'
+In line 3, column 11
+Stored procedure compile error: no viable alternative at input 'for r in (execute'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-02_error_using_out_var.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-02_error_using_out_var.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 6, column 5
-Stored procedure compile error: mismatched input 'loop'
+In line 4, column 11
+Stored procedure compile error: no viable alternative at input 'for r in (execute'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-02_error_using_out_var_2.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-02_error_using_out_var_2.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 6, column 5
-Stored procedure compile error: mismatched input 'loop'
+In line 4, column 11
+Stored procedure compile error: no viable alternative at input 'for r in (execute'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-02_error_using_out_var_3.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-02_error_using_out_var_3.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 6, column 5
-Stored procedure compile error: mismatched input 'loop'
+In line 4, column 11
+Stored procedure compile error: no viable alternative at input 'for r in (execute'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-03_normal_hostvar_len_mismatch.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-03_normal_hostvar_len_mismatch.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 5, column 5
-Stored procedure compile error: mismatched input 'loop'
+In line 3, column 11
+Stored procedure compile error: no viable alternative at input 'for r in (execute'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-03_normal_hostvar_len_mismatch_2.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-03_normal_hostvar_len_mismatch_2.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 5, column 5
-Stored procedure compile error: mismatched input 'loop'
+In line 3, column 11
+Stored procedure compile error: no viable alternative at input 'for r in (execute'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-04_error_incompatible_used_val.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-04_error_incompatible_used_val.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 5, column 5
-Stored procedure compile error: mismatched input 'loop'
+In line 3, column 11
+Stored procedure compile error: no viable alternative at input 'for r in (execute'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-04_normal_incompatible_used_val_2.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/03_13_06-04_normal_incompatible_used_val_2.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 5, column 5
-Stored procedure compile error: mismatched input 'loop'
+In line 3, column 11
+Stored procedure compile error: no viable alternative at input 'for r in (execute'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/normal_basic_3.answer
+++ b/sql/_05_plcsql/_01_testspec/_03_statement/_13_loop/_06_for_dynamic_sql/answers/normal_basic_3.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 5, column 5
-Stored procedure compile error: mismatched input 'loop'
+In line 3, column 11
+Stored procedure compile error: no viable alternative at input 'for r in (execute'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_03_field/_01_basic/answers/04_03_01-03_normal_dyn_field_name_unknown.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_03_field/_01_basic/answers/04_03_01-03_normal_dyn_field_name_unknown.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 5, column 5
-Stored procedure compile error: mismatched input 'loop'
+In line 3, column 11
+Stored procedure compile error: no viable alternative at input 'for r in (execute'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_chr.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_chr.answer
@@ -24,8 +24,8 @@ B
 
 ===================================================
 Error:-1360
-In line 4, column 40
-Stored procedure compile error: extraneous input ')'
+In line 3, column 31
+Stored procedure compile error: no viable alternative at input 'CHR(_utf8'ま''
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_concat.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_concat.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 9, column 34
-Stored procedure compile error: extraneous input ''E381BE''
+In line 7, column 38
+Stored procedure compile error: mismatched input 'USING'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_strcmp.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_strcmp.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 9, column 75
-Stored procedure compile error: extraneous input ')'
+In line 9, column 35
+Stored procedure compile error: mismatched input 'COLLATE'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_substring.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_substring.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 11, column 64
-Stored procedure compile error: extraneous input ')'
+In line 8, column 50
+Stored procedure compile error: mismatched input 'FROM'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_02_numeric_function/answers/04_04_03_02_bfn_numeric_conv.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_02_numeric_function/answers/04_04_03_02_bfn_numeric_conv.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 7, column 41
-Stored procedure compile error: mismatched input ';'
+In line 7, column 28
+Stored procedure compile error: extraneous input ''10''
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_04_type_convert_function/answers/04_04_03_04_bfn_type_cast3.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_04_type_convert_function/answers/04_04_03_04_bfn_type_cast3.answer
@@ -14,8 +14,8 @@ Stored procedure/function 'dba.t' does not exist.
 
 ===================================================
 Error:-1360
-In line 3, column 79
-Stored procedure compile error: extraneous input ')'
+In line 3, column 74
+Stored procedure compile error: no viable alternative at input 'BIT('
 
 ===================================================
 Error:-894
@@ -23,8 +23,8 @@ Stored procedure/function 'dba.t' does not exist.
 
 ===================================================
 Error:-1360
-In line 3, column 79
-Stored procedure compile error: extraneous input ')'
+In line 3, column 74
+Stored procedure compile error: no viable alternative at input 'BIT('
 
 ===================================================
 Error:-894
@@ -32,8 +32,8 @@ Stored procedure/function 'dba.t' does not exist.
 
 ===================================================
 Error:-1360
-In line 3, column 79
-Stored procedure compile error: extraneous input ')'
+In line 3, column 74
+Stored procedure compile error: no viable alternative at input 'BIT('
 
 ===================================================
 Error:-894
@@ -41,8 +41,8 @@ Stored procedure/function 'dba.t' does not exist.
 
 ===================================================
 Error:-1360
-In line 3, column 80
-Stored procedure compile error: extraneous input ')'
+In line 3, column 74
+Stored procedure compile error: no viable alternative at input 'BIT('
 
 ===================================================
 Error:-894
@@ -50,8 +50,8 @@ Stored procedure/function 'dba.t' does not exist.
 
 ===================================================
 Error:-1360
-In line 3, column 81
-Stored procedure compile error: extraneous input ')'
+In line 3, column 74
+Stored procedure compile error: no viable alternative at input 'BIT('
 
 ===================================================
 Error:-894
@@ -59,8 +59,8 @@ Stored procedure/function 'dba.t' does not exist.
 
 ===================================================
 Error:-1360
-In line 3, column 81
-Stored procedure compile error: extraneous input ')'
+In line 3, column 74
+Stored procedure compile error: no viable alternative at input 'BIT('
 
 ===================================================
 Error:-894
@@ -82,8 +82,8 @@ Stored procedure/function 'dba.t' does not exist.
 
 ===================================================
 Error:-1360
-In line 3, column 87
-Stored procedure compile error: extraneous input ')'
+In line 3, column 75
+Stored procedure compile error: no viable alternative at input 'BIT VARYING'
 
 ===================================================
 Error:-894
@@ -91,8 +91,8 @@ Stored procedure/function 'dba.t' does not exist.
 
 ===================================================
 Error:-1360
-In line 3, column 87
-Stored procedure compile error: extraneous input ')'
+In line 3, column 75
+Stored procedure compile error: no viable alternative at input 'BIT VARYING'
 
 ===================================================
 Error:-894
@@ -100,8 +100,8 @@ Stored procedure/function 'dba.t' does not exist.
 
 ===================================================
 Error:-1360
-In line 3, column 87
-Stored procedure compile error: extraneous input ')'
+In line 3, column 75
+Stored procedure compile error: no viable alternative at input 'BIT VARYING'
 
 ===================================================
 Error:-894
@@ -109,8 +109,8 @@ Stored procedure/function 'dba.t' does not exist.
 
 ===================================================
 Error:-1360
-In line 3, column 88
-Stored procedure compile error: extraneous input ')'
+In line 3, column 75
+Stored procedure compile error: no viable alternative at input 'BIT VARYING'
 
 ===================================================
 Error:-894
@@ -118,8 +118,8 @@ Stored procedure/function 'dba.t' does not exist.
 
 ===================================================
 Error:-1360
-In line 3, column 89
-Stored procedure compile error: extraneous input ')'
+In line 3, column 75
+Stored procedure compile error: no viable alternative at input 'BIT VARYING'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_06_information_function/answers/04_04_03_06_bfn_info_coerclibility.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_06_information_function/answers/04_04_03_06_bfn_info_coerclibility.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 4, column 47
-Stored procedure compile error: extraneous input ')'
+In line 4, column 40
+Stored procedure compile error: extraneous input ''abc''
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_06_information_function/answers/04_04_03_06_bfn_info_collation.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_06_information_function/answers/04_04_03_06_bfn_info_collation.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 5, column 44
-Stored procedure compile error: extraneous input ')'
+In line 5, column 37
+Stored procedure compile error: extraneous input ''abc''
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_07_encryption_function/answers/04_04_03_07_bfn_encrypt_sha2.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_07_encryption_function/answers/04_04_03_07_bfn_encrypt_sha2.answer
@@ -1,6 +1,6 @@
 ===================================================
 Error:-1360
-In line 5, column 36
+In line 4, column 41
 Stored procedure compile error: mismatched input ';'
 
 ===================================================

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_05_identifier/_01_basic/answers/04_05_01-03_error_lexical_err.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_05_identifier/_01_basic/answers/04_05_01-03_error_lexical_err.answer
@@ -1,7 +1,7 @@
 ===================================================
 Error:-1360
-In line 2, column 4
-Stored procedure compile error: token recognition error at: '$'
+In line 2, column 3
+Stored procedure compile error: token recognition error at: '#'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_16_arithmetic_unary_op/_02_minus/answers/04_16_02-01_normal_basic_bool.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_16_arithmetic_unary_op/_02_minus/answers/04_16_02-01_normal_basic_bool.answer
@@ -1,6 +1,6 @@
 ===================================================
 Error:-1360
-In line 3, column 8
+In line 2, column 8
 Stored procedure compile error: no viable alternative at input 'bool :='
 
 ===================================================


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25138

기존 TC 중 문법 에러가 있는 경우에 
에러 메시지에서 에러 위치가 잘못 보고되는 문제가 있었습니다. 

ANTLR 의 파싱 방식 상 문법에러가 있어도 파싱을 중단하지 않고 이어 나가며
그 와중에, 에러라고 인지되는 위치 중 가장 나중 것이 기록되었기 때문입니다. 

가장 첫번째 만나는 문법 에러에 파싱을 멈추고 에러를 리포트 하도록 PL/CSQL 파싱 과정을 수정하였기 때문에
기존 위치보다 앞쪽으로 에러 위치가 리포트되는 경우가 다수 발생하여 
답지를 수정하였습니다. 