### PR TITLE
[CBRD-25138] Revised an answer for Getting a proper error message for a TC

### DIFF
--- a/sql/_35_fig_cake/plcsql/basic/answers/dynamic_sql_loop.answer
+++ b/sql/_35_fig_cake/plcsql/basic/answers/dynamic_sql_loop.answer
@@ -27,8 +27,8 @@
 
 ===================================================
 Error:-1360
-In line 6, column 5
-Stored procedure compile error: mismatched input 'LOOP'
+In line 4, column 11
+Stored procedure compile error: no viable alternative at input 'FOR r IN (EXECUTE'
 
 ===================================================
 Error:-495


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-25138

sql/_35_fig_cake/plcsql/basic 디렉터리는 circleci에서는 제외되어 https://github.com/CUBRID/cubrid-testcases/pull/2149 에서 누락된 듯 합니다. 개발팀과 확인 후 수정하였습니다.