### PR TITLE
[CBRD-25175] Revised a missed answer for Line numbers removed from Stored procedure compile error messages

### DIFF
--- a/sql/_35_fig_cake/plcsql/basic/answers/dynamic_sql_loop.answer
+++ b/sql/_35_fig_cake/plcsql/basic/answers/dynamic_sql_loop.answer
@@ -27,7 +27,6 @@
 
 ===================================================
 Error:-1360
-In line 4, column 11
 Stored procedure compile error: no viable alternative at input 'FOR r IN (EXECUTE'
 
 ===================================================


### PR DESCRIPTION
Extended from https://github.com/CUBRID/cubrid-testcases/pull/2159

sql/_35_fig_cake/plcsql 디렉터리에 포함되어있는 테스트는 ci에서 확인되지 않아서 위 수정건에서 누락된듯합니다.

Refer to http://jira.cubrid.org/browse/CBRD-25175