### PR TITLE
[CUBRIDQA-1136] Added missing DROP SERIAL statement (dev)

### DIFF
--- a/isolation/_05_ReadCommitted_RepeatableRead/serial/multi_serials_01.ctl
+++ b/isolation/_05_ReadCommitted_RepeatableRead/serial/multi_serials_01.ctl
@@ -43,6 +43,7 @@ MC: wait until C1 ready;
 C2: SELECT * FROM tt1 ORDER BY id;
 C2: CREATE SERIAL s2 START WITH 10 INCREMENT BY -1;
 C2: select name, current_val, increment_val, max_val, min_val, cyclic, started, class_name, attr_name, cached_num, comment from db_serial;
+C2: DROP SERIAL s2;
 C2: commit;
 C2: quit;
 C1: quit;


### PR DESCRIPTION
isolation의 unstable test case를 수정합니다.