### PR TITLE
[CBRD-25990] Revised cci answers for The problem where for orderby_num() in inline views gets removed due to view merging

### DIFF
--- a/sql/_13_issues/_14_2h/answers/bug_bts_13764.answer_cci
+++ b/sql/_13_issues/_14_2h/answers/bug_bts_13764.answer_cci
@@ -1304,23 +1304,26 @@ Query stmt:
 select newt.i, newt.k from t? newt where newt.i= ?:?  group by newt.i, newt.k
 ===================================================
 i    k    
-1     1     
-2     2     
-3     3     
-4     4     
-5     5     
-6     6     
 7     7     
+6     6     
+5     5     
+4     4     
+3     3     
+2     2     
+1     1     
 
 Query plan:
-temp(group by)
-    subplan: sscan
-                 class: newt node[?]
+temp(order by)
+    subplan: temp(group by)
+                 subplan: sscan
+                              class: newt node[?]
+                              cost:  ? card ?
+                 sort:  ? asc, ? asc
                  cost:  ? card ?
-    sort:  ? asc, ? asc
+    sort:  ? desc, ? asc
     cost:  ? card ?
 Query stmt:
-select newt.i, newt.k from t? newt group by newt.i, newt.k
+select newt.i, newt.k from t? newt group by newt.i, newt.k order by ? desc , ?
 ===================================================
 i    k    
 
@@ -1338,15 +1341,18 @@ i    k
 1     1     
 
 Query plan:
-temp(group by)
-    subplan: sscan
-                 class: newt node[?]
-                 sargs: term[?]
+temp(order by)
+    subplan: temp(group by)
+                 subplan: sscan
+                              class: newt node[?]
+                              sargs: term[?]
+                              cost:  ? card ?
+                 sort:  ? asc, ? asc
                  cost:  ? card ?
-    sort:  ? asc, ? asc
+    sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select newt.i, newt.k from t? newt where newt.i= ?:?  group by newt.i, newt.k
+select newt.i, newt.k from t? newt where newt.i= ?:?  group by newt.i, newt.k order by ?
 ===================================================
 0
 ===================================================


### PR DESCRIPTION
cci revision of: https://github.com/CUBRID/cubrid-testcases/pull/2172

Refer to: http://jira.cubrid.org/browse/CBRD-25990