### PR TITLE
[CBRD-25722] Added test case for subquery cache including TYPE_SP

### DIFF
--- a/sql/_13_issues/_25_1h/answers/cbrd_25722.answer
+++ b/sql/_13_issues/_25_1h/answers/cbrd_25722.answer
@@ -1,0 +1,95 @@
+===================================================
+0
+===================================================
+0
+===================================================
+3
+===================================================
+0
+===================================================
+0
+===================================================
+jsp(c, c)    
+2     
+4     
+6     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.t)
+
+  rewritten query: select [dba.jsp]([dba.t].c, [dba.t].c) from [dba.t] [dba.t]
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+    SCAN (table: dba.t), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+(select jsp(c, c) from dual)    
+2     
+4     
+6     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dual)
+
+  rewritten query: (select [dba.jsp]([dba.t].c, [dba.t].c) from dual dual)
+
+  TABLE SCAN (dba.t)
+
+  rewritten query: select (select [dba.jsp]([dba.t].c, [dba.t].c) from dual dual) from [dba.t] [dba.t]
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+    SCAN (table: dba.t), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+        SCAN (table: dual), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SUBQUERY_CACHE (hit: ?, miss: ?, size: ?, status: enabled)
+     
+
+===================================================
+(select /*+ NO_SUBQUERY_CACHE */ jsp(c, c) from dual)    
+2     
+4     
+6     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dual)
+
+  rewritten query: (select /*+ NO_SUBQUERY_CACHE */ [dba.jsp]([dba.t].c, [dba.t].c) from dual dual)
+
+  TABLE SCAN (dba.t)
+
+  rewritten query: select (select /*+ NO_SUBQUERY_CACHE */ [dba.jsp]([dba.t].c, [dba.t].c) from dual dual) from [dba.t] [dba.t]
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+    SCAN (table: dba.t), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+        SCAN (table: dual), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+0
+===================================================
+0
+===================================================
+0

--- a/sql/_13_issues/_25_1h/cases/cbrd_25722.sql
+++ b/sql/_13_issues/_25_1h/cases/cbrd_25722.sql
@@ -1,0 +1,31 @@
+-- Issue: improving the caching of correlated subqueries, including TYPE_SP.
+-- Test Scenarios:
+--  1. Queries should execute without caching
+--  2. Subquery should execute with caching enabled.
+--  3. Subquery should not be cached due to NO_SUBQUERY_CACHE hint. 
+
+
+drop table if exists t;
+
+create table t (c int);
+insert into t values(1),(2),(3);
+
+create or replace function jsp(c1 int, c2 int) return string deterministic as language java name 'SpTest.testInt_2(int, int) return string';
+
+--  1. Queries should execute without caching
+set trace on;
+SELECT jsp(c,c) FROM t;
+show trace;
+
+--  2. Subquery should execute with caching enabled.
+SELECT (SELECT jsp(c,c) FROM dual) FROM t;
+show trace;
+
+--  3. Subquery should not be cached due to NO_SUBQUERY_CACHE hint. 
+SELECT (SELECT /*+ NO_SUBQUERY_CACHE */ jsp(c,c) FROM dual) FROM t;
+show trace;
+
+set trace off;
+
+drop function jsp;
+drop table if exists t;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25722

jsp 포함한 서브쿼리 캐싱을 통계 정보로 확인 

시나리오
 1. non-cache
 2. cache (SUBQUERY_CACHE 확인)
 3.  no cache with 'NO_SUBQUERY_CACHE' hint. 