### PR TITLE
[CBRD-26021] Add fix NULL default when using non-pseudo column expres…

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_05_bug_fix/answers/31_func_non_pseudo_column_expr_error.answer
+++ b/sql/_05_plcsql/_01_testspec/_05_bug_fix/answers/31_func_non_pseudo_column_expr_error.answer
@@ -1,0 +1,30 @@
+===================================================
+Error:-493
+Syntax: invalid create function
+  CREATE [OR REPLACE] FUNCTION identifier '(' {sp_param_list} ')' RETURN {data_type|CURSOR} {IS|AS} {[LANGUAGE PLCSQL|LANGUAGE JAVA]} {function_source|function_spec} 
+
+===================================================
+0
+
+===================================================
+Error:-493
+Syntax: invalid create function
+  CREATE [OR REPLACE] FUNCTION identifier '(' {sp_param_list} ')' RETURN {data_type|CURSOR} {IS|AS} {[LANGUAGE PLCSQL|LANGUAGE JAVA]} {function_source|function_spec} 
+
+===================================================
+0
+
+===================================================
+Error:-493
+Syntax: invalid create statement 
+
+===================================================
+Error:-493
+Syntax: invalid create statement 
+
+===================================================
+0
+
+===================================================
+0
+

--- a/sql/_05_plcsql/_01_testspec/_05_bug_fix/answers/31_func_non_pseudo_column_expr_error.answer
+++ b/sql/_05_plcsql/_01_testspec/_05_bug_fix/answers/31_func_non_pseudo_column_expr_error.answer
@@ -7,6 +7,11 @@ Syntax: invalid create function
 0
 
 ===================================================
+default_value    
+OK     
+
+
+===================================================
 Error:-493
 Syntax: invalid create function
   CREATE [OR REPLACE] FUNCTION identifier '(' {sp_param_list} ')' RETURN {data_type|CURSOR} {IS|AS} {[LANGUAGE PLCSQL|LANGUAGE JAVA]} {function_source|function_spec} 

--- a/sql/_05_plcsql/_01_testspec/_05_bug_fix/answers/31_func_non_pseudo_column_expr_error.answer
+++ b/sql/_05_plcsql/_01_testspec/_05_bug_fix/answers/31_func_non_pseudo_column_expr_error.answer
@@ -15,6 +15,11 @@ Syntax: invalid create function
 0
 
 ===================================================
+default_value    
+0.5     
+
+
+===================================================
 Error:-493
 Syntax: invalid create statement 
 

--- a/sql/_05_plcsql/_01_testspec/_05_bug_fix/cases/31_func_non_pseudo_column_expr_error.sql
+++ b/sql/_05_plcsql/_01_testspec/_05_bug_fix/cases/31_func_non_pseudo_column_expr_error.sql
@@ -8,6 +8,9 @@ CREATE OR REPLACE FUNCTION t (a int RAND()) RETURN int as begin return a; end;
 -- compile success : rand function
 CREATE OR REPLACE FUNCTION t (a int default RAND()) RETURN int as begin return a; end;
 
+-- CASE WHEN default_value is not null THEN OK ELSE NOK END  
+SELECT CASE WHEN default_value is not null THEN 'OK' ELSE 'NOK' END as default_value FROM db_stored_procedure_args WHERE sp_name = 't';
+
 -- Error : -493 non-default
 CREATE OR REPLACE function t1 (a int log(4,2)) return int as begin return a; end;
 

--- a/sql/_05_plcsql/_01_testspec/_05_bug_fix/cases/31_func_non_pseudo_column_expr_error.sql
+++ b/sql/_05_plcsql/_01_testspec/_05_bug_fix/cases/31_func_non_pseudo_column_expr_error.sql
@@ -1,0 +1,26 @@
+--+ server-message on
+-- verified the CBRD-26021
+-- Fix NULL default when using non-pseudo column expressions in a stored function' parameter
+
+-- Error : -493 non-default
+CREATE OR REPLACE FUNCTION t (a int RAND()) RETURN int as begin return a; end;
+
+-- compile success : rand function
+CREATE OR REPLACE FUNCTION t (a int default RAND()) RETURN int as begin return a; end;
+
+-- Error : -493 non-default
+CREATE OR REPLACE function t1 (a int log(4,2)) return int as begin return a; end;
+
+-- compile success : add log function  
+CREATE OR REPLACE function t1 (a int default log(4,2)) return int as begin return a; end;
+
+-- Error : -493 invalid create statement
+CREATE OK REPLACE FUNCTION t2 (a int logk(4,2)) return int as begin return a; end;
+
+-- Error : -493 invalid create statement
+CREATE OK REPLACE FUNCTION t2 (a int default logk(4,2)) return int as begin return a; end;
+
+DROP FUNCTION t;
+DROP FUNCTION t1;
+
+--+ server-message off

--- a/sql/_05_plcsql/_01_testspec/_05_bug_fix/cases/31_func_non_pseudo_column_expr_error.sql
+++ b/sql/_05_plcsql/_01_testspec/_05_bug_fix/cases/31_func_non_pseudo_column_expr_error.sql
@@ -14,6 +14,9 @@ CREATE OR REPLACE function t1 (a int log(4,2)) return int as begin return a; end
 -- compile success : add log function  
 CREATE OR REPLACE function t1 (a int default log(4,2)) return int as begin return a; end;
 
+-- default_value
+SELECT default_value FROM db_stored_procedure_args WHERE sp_name = 't1';
+
 -- Error : -493 invalid create statement
 CREATE OK REPLACE FUNCTION t2 (a int logk(4,2)) return int as begin return a; end;
 


### PR DESCRIPTION
to refer : http://jira.cubrid.org/browse/CBRD-26021

- user function 내에 저장 함수의 매개변수 기본값에 pseudo column이 아닌 일반 expression을 사용할 경우 NULL로 처리 및 
   저장 함수의 기본값이 없을 시 에러 발생하도록
1) non-pseudo column expression에 대해서 evaluate 한 후, 결과 DB_VALUE를 PT_VALUE 타입 출력
2) SymbolStack에 추가되지 않은 LOG 함수