### PR TITLE
[CBRD-25658] Added an exception case to prohibit the use of stored functions that …

### DIFF
--- a/sql/config/daily_regression_test_exclude_list_ha_repl.conf
+++ b/sql/config/daily_regression_test_exclude_list_ha_repl.conf
@@ -306,5 +306,5 @@ sql/_27_banana_qa/issue_8909_unquoted_keywords/cases/_004_update.test
 #[PERMANENT] don't support 'call' on HA.
 sql/_33_elderberry/cbrd_23845/cases/_02_permission_check.test
 
-# When a function such as rand() is used as the default value in a stored function, the result generated at the time of creation is used. In an HA environment, different values are inevitable.
+#[PERMANENT] When a function such as rand() is used as the default value in a stored function, the result generated at the time of creation is used. In an HA environment, different values are inevitable.
 sql/_05_plcsql/_01_testspec/_05_bug_fix/cases/31_func_non_pseudo_column_expr_error.test

--- a/sql/config/daily_regression_test_exclude_list_ha_repl.conf
+++ b/sql/config/daily_regression_test_exclude_list_ha_repl.conf
@@ -305,3 +305,6 @@ sql/_27_banana_qa/issue_8909_unquoted_keywords/cases/_004_update.test
 
 #[PERMANENT] don't support 'call' on HA.
 sql/_33_elderberry/cbrd_23845/cases/_02_permission_check.test
+
+# When a function such as rand() is used as the default value in a stored function, the result generated at the time of creation is used. In an HA environment, different values are inevitable.
+sql/_05_plcsql/_01_testspec/_05_bug_fix/cases/31_func_non_pseudo_column_expr_error.test


### PR DESCRIPTION
…use rand() as a default value in an HA environment.

http://jira.cubrid.org/browse/CBRD-25658

stored function 의 default 인자로 rand() 를 사용하는 경우 
ha 복제 확인시 master 와 slave 간에 default_value 가 달라질 수 밖에 없어 
예외 경우로 추가합니다. 