### PR TITLE
[CUBRIDQA-1136] removed charset-related test from PL/CSQL sql test

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_replace.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/answers/04_04_03_01_bfn_string_replace.answer
@@ -38,7 +38,6 @@ UBRID DATABASE
 CUBRId dATABASE
 CUBRID DATABASE
 CUBRID DATABASE
-ä½ å¼å¿æå¼å¿å¤§å®¶å¼å¿
 ===================================================
 0
 

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/cases/04_04_03_01_bfn_string_replace.sql
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_01_string_function/cases/04_04_03_01_bfn_string_replace.sql
@@ -21,7 +21,6 @@ begin
     dbms_output.put_line(REPLACE('CUBRID DATABASE', 'D', 'd'));
     dbms_output.put_line(REPLACE('CUBRID DATABASE', 3.0));
     dbms_output.put_line(REPLACE('CUBRID DATABASE', 32000000));
-    dbms_output.put_line(REPLACE('你好我好大家好','好','开心'));
 end;
 
 select count(*) from db_stored_procedure where sp_name = 't';


### PR DESCRIPTION
https://github.com/CUBRID/cubrid-testcases/pull/2189 로 인해 fail하던 TC가 성공하도록 변경되었을때, cci를 답지에서 고려하지않아서 현재 regression sql_by_cci에서 fail하고있습니다. SQL에서는 깨진 문자열이 answer로 새로 지정이 되었는데, SQL_BY_CCI에서는 깨지지않고 한자 출력이되고있습니다.

한문이 SQL(jdbc)에서 깨지는 현상은 예전에 https://github.com/CUBRID/cubrid-testcases/pull/1997 에서 현익님의 comment랑 관련이 있다고 판단이 되었습니다.

> 예전과 달리 에러가 났던 이유는 최근 pl server 의 character encoding 을 서버와 맞추는 개선이 있었고,
(https://github.com/CUBRID/cubrid/pull/5668)
테스트하는 basic db가 iso88591 로 되어 있기 때문에
utf-8 로 날아온 byte string 이 pl server 에서 서버의 인코딩에 맞추어 iso88591 로 맞추어 인식하기 때문에
길이가 3인 깨진 문자열로 인식되고 있었습니다.
예전에 에러가 나지 않았던 이유는 서버 인코딩에 상관없이 pl server 는 utf8로 인식했기 때문에
utf8 로 클라이언트로부터 날아온 '한' 이 pl server 에서 utf8 로 인식되어서 에러가 나지 않았던 것 입니다.

이 TC는 위 거론된 변경 전에 생성되었으며, 원래 fail하도록 동작하였기에 따로 수정을 고려 하지 않았던 것으로 추정됩니다. 
(https://github.com/CUBRID/cubrid-testcases/pull/2189 이전 04_04_03_01_bfn_string_replace.answer answer):
```
===================================================
Error:-1360
Stored procedure compile error: extraneous input ''abcdefg''

===================================================
count(*)    
0     


===================================================
count(*)    
0     


===================================================
Error:-894
Stored procedure/function 'dba.t' does not exist.

===================================================
Error:-894
Stored procedure/function 'dba.t' does not exist.
```


서버 인코딩과 다른 인코딩을 가진 데이터는 shell 테스트로 따로 하기로 했으므로 이 TC에서 제거하도록 하겠습니다.