### PR TITLE
[CBRD-25531] When an analytic function is included in a non-mergeable inline view, unreferenced select list items are not removed

### DIFF
--- a/sql/_33_elderberry/cbrd_24011/answers/analytic_functions.answer
+++ b/sql/_33_elderberry/cbrd_24011/answers/analytic_functions.answer
@@ -21,19 +21,16 @@ count(*)
 100     
 
 Query plan:
-sscan
+iscan
     class: tab_b node[?]
+    index: idx term[?] (covers)
     cost:  ? card ?
-Analytic functions:
-    run[?]: sort with key (? asc nulls first, ? asc nulls first)
-           func[?]: rank partition by (? asc nulls first) order by (? asc nulls first)
 Query stmt:
-(select tab_b.col_a, rank() over (partition by ? order by ?) from tab_b tab_b)
+(select tab_b.col_a from tab_b tab_b where tab_b.col_a= ?:? )
 Query plan:
 nl-join (cross join)
     outer: sscan
                class: b node[?]
-               sargs: term[?]
                cost:  ? card ?
     inner: iscan
                class: a node[?]
@@ -41,6 +38,6 @@ nl-join (cross join)
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select count(*) from tab_a a, (select tab_b.col_a, rank() over (partition by ? order by ?) from tab_b tab_b) b (col_a, col_b) where a.col_a= ?:?  and b.col_a= ?:?  and a.col_a=b.col_a
+select count(*) from tab_a a, (select tab_b.col_a from tab_b tab_b where tab_b.col_a= ?:? ) b (col_a) where a.col_a= ?:?  and a.col_a=b.col_a
 ===================================================
 0

--- a/sql/_33_elderberry/cbrd_24011/answers/analytic_functions.answer
+++ b/sql/_33_elderberry/cbrd_24011/answers/analytic_functions.answer
@@ -17,20 +17,23 @@
 ===================================================
 0
 ===================================================
-count(*)    
+count(b.col_b)    
 100     
 
 Query plan:
-iscan
+sscan
     class: tab_b node[?]
-    index: idx term[?] (covers)
     cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first, ? asc nulls first)
+           func[?]: rank partition by (? asc nulls first) order by (? asc nulls first)
 Query stmt:
-(select tab_b.col_a from tab_b tab_b where tab_b.col_a= ?:? )
+(select rank() over (partition by ? order by ?), tab_b.col_a from tab_b tab_b)
 Query plan:
 nl-join (cross join)
     outer: sscan
                class: b node[?]
+               sargs: term[?]
                cost:  ? card ?
     inner: iscan
                class: a node[?]
@@ -38,6 +41,6 @@ nl-join (cross join)
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select count(*) from tab_a a, (select tab_b.col_a from tab_b tab_b where tab_b.col_a= ?:? ) b (col_a) where a.col_a= ?:?  and a.col_a=b.col_a
+select count(b.col_b) from tab_a a, (select rank() over (partition by ? order by ?), tab_b.col_a from tab_b tab_b) b (col_b, col_a) where a.col_a= ?:?  and b.col_a= ?:?  and a.col_a=b.col_a
 ===================================================
 0

--- a/sql/_33_elderberry/cbrd_24011/answers/analytic_functions.answer
+++ b/sql/_33_elderberry/cbrd_24011/answers/analytic_functions.answer
@@ -17,6 +17,29 @@
 ===================================================
 0
 ===================================================
+count(*)    
+100     
+
+Query plan:
+iscan
+    class: tab_b node[?]
+    index: idx term[?] (covers)
+    cost:  ? card ?
+Query stmt:
+(select tab_b.col_a from tab_b tab_b where tab_b.col_a= ?:? )
+Query plan:
+nl-join (cross join)
+    outer: sscan
+               class: b node[?]
+               cost:  ? card ?
+    inner: iscan
+               class: a node[?]
+               index: idx term[?] (covers)
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select count(*) from tab_a a, (select tab_b.col_a from tab_b tab_b where tab_b.col_a= ?:? ) b (col_a) where a.col_a= ?:?  and a.col_a=b.col_a
+===================================================
 count(b.col_b)    
 100     
 

--- a/sql/_33_elderberry/cbrd_24011/cases/analytic_functions.sql
+++ b/sql/_33_elderberry/cbrd_24011/cases/analytic_functions.sql
@@ -9,6 +9,12 @@ create index idx on tab_b(col_a,col_b);
 update statistics on tab_a;
 update statistics on tab_b;
 
+select /*+ recompile */ count(*)
+from tab_a a
+      ,(select col_a, rank() over(partition by col_a order by col_b) col_b from tab_b ) b
+where a.col_a = b.col_a
+  and b.col_a = 2;
+
 select /*+ recompile */ count(b.col_b)
 from tab_a a
       ,(select col_a, rank() over(partition by col_a order by col_b) col_b from tab_b ) b

--- a/sql/_33_elderberry/cbrd_24011/cases/analytic_functions.sql
+++ b/sql/_33_elderberry/cbrd_24011/cases/analytic_functions.sql
@@ -9,7 +9,7 @@ create index idx on tab_b(col_a,col_b);
 update statistics on tab_a;
 update statistics on tab_b;
 
-select /*+ recompile */ count(*)
+select /*+ recompile */ count(b.col_b)
 from tab_a a
       ,(select col_a, rank() over(partition by col_a order by col_b) col_b from tab_b ) b
 where a.col_a = b.col_a

--- a/sql/_33_elderberry/cbrd_24042/cbrd_24082/answers/analytic.answer
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_24082/answers/analytic.answer
@@ -7,7 +7,7 @@
 ===================================================
 0
 ===================================================
-col_a    
+col_a    col_b    
 
 Query plan:
 nl-join (inner join)
@@ -20,8 +20,11 @@ nl-join (inner join)
                sargs: term[?]
                cost:  ? card ?
     cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first, ? asc nulls first)
+           func[?]: rank partition by (? asc nulls first) order by (? asc nulls first)
 Query stmt:
-(select a.col_a from t_a a, t_b b where (a.col_a=b.col_a))
+(select a.col_a, rank() over (partition by ? order by ?) from t_a a, t_b b where (a.col_a=b.col_a))
 Query plan:
 nl-join (inner join)
     edge:  term[?]
@@ -34,11 +37,11 @@ nl-join (inner join)
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select a.col_a from (select a.col_a from t_a a, t_b b where (a.col_a=b.col_a)) a (col_a), t_b b where a.col_a=b.col_a and b.col_b= ?:? 
+select a.col_a, a.col_b from (select a.col_a, rank() over (partition by ? order by ?) from t_a a, t_b b where (a.col_a=b.col_a)) a (col_a, col_b), t_b b where a.col_a=b.col_a and b.col_b= ?:? 
 ===================================================
 0
 ===================================================
-col_a    
+col_a    col_b    
 
 Query plan:
 nl-join (inner join)
@@ -51,8 +54,11 @@ nl-join (inner join)
                sargs: term[?]
                cost:  ? card ?
     cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first, ? asc nulls first)
+           func[?]: rank partition by (? asc nulls first) order by (? asc nulls first)
 Query stmt:
-(select a.col_a from t_a a, t_b b where a.col_a=b.col_a)
+(select a.col_a, rank() over (partition by ? order by ?) from t_a a, t_b b where a.col_a=b.col_a)
 Query plan:
 nl-join (inner join)
     edge:  term[?]
@@ -65,6 +71,6 @@ nl-join (inner join)
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select a.col_a from (select a.col_a from t_a a, t_b b where a.col_a=b.col_a) a (col_a), t_b b where a.col_a=b.col_a and b.col_b= ?:? 
+select a.col_a, a.col_b from (select a.col_a, rank() over (partition by ? order by ?) as [col_b] from t_a a, t_b b where a.col_a=b.col_a) a (col_a, col_b), t_b b where a.col_a=b.col_a and b.col_b= ?:? 
 ===================================================
 0

--- a/sql/_33_elderberry/cbrd_24042/cbrd_24082/answers/analytic.answer
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_24082/answers/analytic.answer
@@ -20,11 +20,8 @@ nl-join (inner join)
                sargs: term[?]
                cost:  ? card ?
     cost:  ? card ?
-Analytic functions:
-    run[?]: sort with key (? asc nulls first, ? asc nulls first)
-           func[?]: rank partition by (? asc nulls first) order by (? asc nulls first)
 Query stmt:
-(select a.col_a, rank() over (partition by ? order by ?) from t_a a, t_b b where (a.col_a=b.col_a))
+(select a.col_a from t_a a, t_b b where (a.col_a=b.col_a))
 Query plan:
 nl-join (inner join)
     edge:  term[?]
@@ -37,7 +34,7 @@ nl-join (inner join)
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select a.col_a from (select a.col_a, rank() over (partition by ? order by ?) from t_a a, t_b b where (a.col_a=b.col_a)) a (col_a, col_b), t_b b where a.col_a=b.col_a and b.col_b= ?:? 
+select a.col_a from (select a.col_a from t_a a, t_b b where (a.col_a=b.col_a)) a (col_a), t_b b where a.col_a=b.col_a and b.col_b= ?:? 
 ===================================================
 0
 ===================================================
@@ -54,11 +51,8 @@ nl-join (inner join)
                sargs: term[?]
                cost:  ? card ?
     cost:  ? card ?
-Analytic functions:
-    run[?]: sort with key (? asc nulls first, ? asc nulls first)
-           func[?]: rank partition by (? asc nulls first) order by (? asc nulls first)
 Query stmt:
-(select a.col_a, rank() over (partition by ? order by ?) from t_a a, t_b b where a.col_a=b.col_a)
+(select a.col_a from t_a a, t_b b where a.col_a=b.col_a)
 Query plan:
 nl-join (inner join)
     edge:  term[?]
@@ -71,6 +65,6 @@ nl-join (inner join)
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select a.col_a from (select a.col_a, rank() over (partition by ? order by ?) as [col_b] from t_a a, t_b b where a.col_a=b.col_a) a (col_a, col_b), t_b b where a.col_a=b.col_a and b.col_b= ?:? 
+select a.col_a from (select a.col_a from t_a a, t_b b where a.col_a=b.col_a) a (col_a), t_b b where a.col_a=b.col_a and b.col_b= ?:? 
 ===================================================
 0

--- a/sql/_33_elderberry/cbrd_24042/cbrd_24082/cases/analytic.sql
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_24082/cases/analytic.sql
@@ -25,7 +25,7 @@ AS
          t_b b
   WHERE  a.col_a = b.col_a;
 
-SELECT /*+ recompile */ a.col_a
+SELECT /*+ recompile */ a.col_a, a.col_b
 FROM   v a,
        t_b b
 WHERE  a.col_a = b.col_a
@@ -33,7 +33,7 @@ WHERE  a.col_a = b.col_a
 DROP VIEW v; 
 
 -- Convert the view to an inline view (unmergable)
-SELECT /*+ recompile */ a.col_a
+SELECT /*+ recompile */ a.col_a, a.col_b
 FROM   (SELECT a.col_a,
                RANK() 
 		 over (


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25531

서브쿼리에 분석 함수가 포함된 경우, 외부에서 참조하지 않더라도 select-list에서 제거되지 않는 문제를 수정하였습니다.
이로 인해, 분석 함수가 포함된 서브쿼리에 대해 뷰 머징이 불가능함을 검증하는 테스트 케이스가 실패하게 되었습니다.

해당 테스트 케이스에서 분석 함수가 명시적으로 참조되도록 수정하였습니다.