### PR TITLE
[CBRD-25776] Add Inline CTE Support (#2187) - fix missing testcase

### DIFF
--- a/sql/_36_guava/partition_table/answers/cbrd_25519.answer
+++ b/sql/_36_guava/partition_table/answers/cbrd_25519.answer
@@ -637,13 +637,13 @@ trace
 Query Plan:
   INDEX SCAN (a.pk_ta_range_ca_cd) (key range: (a.ca>= ?:?  and a.ca<= ?:? ))
 
-  rewritten query: select a.ca, a.cb, a.cc, a.cd from [dba.ta_range] a where (a.ca>= ?:?  and a.ca<= ?:? ) and (inst_num()<= ?:? )
+  rewritten query: select /*+ MATERIALIZE */ a.ca, a.cb, a.cc, a.cd from [dba.ta_range] a where (a.ca>= ?:?  and a.ca<= ?:? ) and (inst_num()<= ?:? )
 
   NESTED LOOPS (inner join)
     TABLE SCAN (a)
     INDEX SCAN (b.pk_ta_list_ca_cd) (key range: a.ca=b.cakey range: a.cd=b.cd, covered: true)
 
-  rewritten query: with cte(ca, cb, cc, cd) as (select a.ca, a.cb, a.cc, a.cd from [dba.ta_range] a where (a.ca>= ?:?  and a.ca<= ?:? ) and (inst_num()<= ?:? ))select /*+ ORDERED */ count(*) from [dba.cte] a, [dba.ta_list] b where a.ca=b.ca and a.cd=b.cd
+  rewritten query: with cte(ca, cb, cc, cd) as (select /*+ MATERIALIZE */ a.ca, a.cb, a.cc, a.cd from [dba.ta_range] a where (a.ca>= ?:?  and a.ca<= ?:? ) and (inst_num()<= ?:? ))select /*+ ORDERED */ count(*) from [dba.cte] a, [dba.ta_list] b where a.ca=b.ca and a.cd=b.cd
 
 
 Trace Statistics:

--- a/sql/_36_guava/partition_table/cases/cbrd_25519.sql
+++ b/sql/_36_guava/partition_table/cases/cbrd_25519.sql
@@ -229,7 +229,7 @@ show trace;
 do @i := @i + 1;
 evaluate concat ('####', lpad (@i, 3), '. pruning + cte');
 
-with cte as (select * from ta_range a where a.ca between 8 and 9 limit 1500)
+with cte as (select /*+ materialize */ * from ta_range a where a.ca between 8 and 9 limit 1500)
 select /*+ recompile ordered */ count(*)
 from  cte a, ta_list b
 where a.ca = b.ca and a.cd = b.cd;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25776

기존 CTE 관련 테스트케이스들은 materialized CTE를 기준으로 작성되었기 때문에, materialize 힌트를 명시적으로 추가합니다.
partition table의 trace 정보를 출력하는 케이스에 대한 수정이 누락되어 추가했습니다.