### PR TITLE
[CBRD-26114] Partition table에 대한 parallel heap scan trace가 출력되지 않음

### DIFF
--- a/sql/_35_fig_cake/cbrd_24044/cbrd_24702/answers/cbrd_24702.answer
+++ b/sql/_35_fig_cake/cbrd_24044/cbrd_24702/answers/cbrd_24702.answer
@@ -87,6 +87,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (table: dba.t), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
            PARTITION (table: dba.t__p__p?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
            PARTITION (table: dba.t__p__p?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
            PARTITION (table: dba.t__p__p?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26114

Purpose

현재 CUBRID에서는 파티션에 대한 힙 스캔을 수행할 때, parallel heap scan이 실행되었음에도 불구하고 해당 작업에 대한 trace 정보가 출력되지 않는 문제가 있습니다. 이 문제를 해결합니다.

Implementation

파티션 스캔의 경우 마지막 partitioned_table에 대한 open_scan 시 S_HEAP_SCAN으로 변경되기 때문에, S_HEAP_SCAN인 경우에도 perf_monitor가 있는지 확인하고 출력합니다.

Remarks

SCAN_ID는 sizeof(SCAN_ID) 만큼 memset(0)을 수행하기 때문에, 일반 힙 스캔의 경우 perf_monitor는 nullptr이여야 합니다.