### PR TITLE
[CBRD-25582] fix one TC to remove an unstablility

### DIFF
--- a/sql/_35_fig_cake/grant_revoke_redefine/cases/cbrd_25582.sql
+++ b/sql/_35_fig_cake/grant_revoke_redefine/cases/cbrd_25582.sql
@@ -109,14 +109,14 @@ evaluate 'connect to u4, u1.tbl grant to u5';
 call login('u4','') on class db_user;
 GRANT SELECT ON u1.TBL TO u5 WITH GRANT OPTION;
 
-select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, grantee_name, auth_type;
+select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, auth_type, grantee_name;
 
 
 evaluate 'connect to u2, revoke to u1.tbl from u3';
 call login('u2','') on class db_user;
 REVOKE SELECT ON u1.TBL FROM u3;
 
-select * from db_auth where grantee_name != 'PUBLIC'  order by grantor_name, grantee_name, auth_type;
+select * from db_auth where grantee_name != 'PUBLIC'  order by grantor_name, auth_type, grantee_name;
 
 
 evaluate 'connect to u1, test for cascade';
@@ -126,19 +126,19 @@ GRANT ALL PRIVILEGES ON u1.TBL TO u3 WITH GRANT OPTION;
 evaluate 'grant SELECT, UPDATE, INSERT, DELETE on u1.tbl to u4';
 GRANT SELECT, UPDATE, INSERT, DELETE ON u1.TBL TO u4 WITH GRANT OPTION;
 
-select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, grantee_name, auth_type;
+select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, auth_type, grantee_name;
 
 
 evaluate 'connect to dba, revoke to u1.tbl(SELECT) from u2 (cascade test)';
 call login('dba','') on class db_user;
 REVOKE SELECT ON u1.TBL FROM u2;
 
-select * from db_auth where grantee_name != 'PUBLIC'  order by grantor_name, grantee_name, auth_type;
+select * from db_auth where grantee_name != 'PUBLIC'  order by grantor_name, auth_type, grantee_name;
 
 evaluate 'init test: revoke to u1.tbl(ALL PRIVILEGES) from u2 (cascade test)';
 REVOKE ALL PRIVILEGES ON u1.TBL FROM u2;
 
-select * from db_auth where grantee_name != 'PUBLIC'  order by grantor_name, grantee_name, auth_type;
+select * from db_auth where grantee_name != 'PUBLIC'  order by grantor_name, auth_type, grantee_name;
 
 
 

--- a/sql/_35_fig_cake/grant_revoke_redefine/cases/cbrd_25582.sql
+++ b/sql/_35_fig_cake/grant_revoke_redefine/cases/cbrd_25582.sql
@@ -109,14 +109,14 @@ evaluate 'connect to u4, u1.tbl grant to u5';
 call login('u4','') on class db_user;
 GRANT SELECT ON u1.TBL TO u5 WITH GRANT OPTION;
 
-select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, auth_type;
+select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, grantee_name, auth_type;
 
 
 evaluate 'connect to u2, revoke to u1.tbl from u3';
 call login('u2','') on class db_user;
 REVOKE SELECT ON u1.TBL FROM u3;
 
-select * from db_auth where grantee_name != 'PUBLIC'  order by grantor_name, auth_type;
+select * from db_auth where grantee_name != 'PUBLIC'  order by grantor_name, grantee_name, auth_type;
 
 
 evaluate 'connect to u1, test for cascade';
@@ -126,19 +126,19 @@ GRANT ALL PRIVILEGES ON u1.TBL TO u3 WITH GRANT OPTION;
 evaluate 'grant SELECT, UPDATE, INSERT, DELETE on u1.tbl to u4';
 GRANT SELECT, UPDATE, INSERT, DELETE ON u1.TBL TO u4 WITH GRANT OPTION;
 
-select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, auth_type;
+select * from db_auth where grantee_name != 'PUBLIC' order by grantor_name, grantee_name, auth_type;
 
 
 evaluate 'connect to dba, revoke to u1.tbl(SELECT) from u2 (cascade test)';
 call login('dba','') on class db_user;
 REVOKE SELECT ON u1.TBL FROM u2;
 
-select * from db_auth where grantee_name != 'PUBLIC'  order by grantor_name, auth_type;
+select * from db_auth where grantee_name != 'PUBLIC'  order by grantor_name, grantee_name, auth_type;
 
 evaluate 'init test: revoke to u1.tbl(ALL PRIVILEGES) from u2 (cascade test)';
 REVOKE ALL PRIVILEGES ON u1.TBL FROM u2;
 
-select * from db_auth where grantee_name != 'PUBLIC'  order by grantor_name, auth_type;
+select * from db_auth where grantee_name != 'PUBLIC'  order by grantor_name, grantee_name, auth_type;
 
 
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25582

CI 테스트 중 unstable 한 부분이 하나 발견되어 (https://app.circleci.com/pipelines/github/CUBRID/cubrid/20618/workflows/e9642427-74e7-473d-a0d1-ca8331565592/jobs/98973 )
order by 조건을 하나 추가하였습니다. 