### PR TITLE
[CBRD-26221] Adjust evaluation threshold for Hash Group By to Sort Group By transition

### DIFF
--- a/sql/_13_issues/_23_1h/answers/cbrd_24906_1.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24906_1.answer
@@ -697,7 +697,7 @@ Trace Statistics:
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
           SCAN (index: dba.tbl_b.pk_tbl_b_col_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-        GROUPBY (time: ?, hash: partial, sort: true, page: ?, ioread: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -727,7 +727,7 @@ Trace Statistics:
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
           SCAN (index: dba.tbl_b.pk_tbl_b_col_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-        GROUPBY (time: ?, hash: partial, sort: true, page: ?, ioread: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================

--- a/sql/_13_issues/_23_1h/answers/cbrd_24906_2.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24906_2.answer
@@ -787,7 +787,7 @@ Trace Statistics:
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
           SCAN (index: dba.tbl_b.pk_tbl_b_col_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-        GROUPBY (time: ?, hash: partial, sort: true, page: ?, ioread: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -821,7 +821,7 @@ Trace Statistics:
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
           SCAN (index: dba.tbl_b.pk_tbl_b_col_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-        GROUPBY (time: ?, hash: partial, sort: true, page: ?, ioread: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26221
https://github.com/CUBRID/cubrid/pull/6356

GROUP BY 는 해시 방식으로 수행되다가, 200개 튜플을 읽은 경우 선택도를 평가하여 해시 + 정렬 방식 또는 해시 방식을 그대로 유지할 지 선택합니다.
이 임계값(HASH_AGGREGATE_VH_SELECTIVITY_TUPLE_THRESHOLD )을 2000 을 변경했기 때문에, trace 정보에서 group by 관련 정보가 다르게 출력됩니다.