### PR TITLE
[CBRD-26099] Add sql testcase for Join method hint ignored for LEFT OUTER JOIN with empty inline view result

### DIFF
--- a/sql/_13_issues/_25_2h/answers/cbrd_26099.answer
+++ b/sql/_13_issues/_25_2h/answers/cbrd_26099.answer
@@ -1,0 +1,1304 @@
+===================================================
+0
+===================================================
+0
+===================================================
+1000000
+===================================================
+    
+1. If there is no result of the inline view with the "= NULL" condition     
+
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: av? node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select null from table({}) av? (av_?) where ? <> ?)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select null from table({}) av? (av_?) where ? <> ?) b (cola) on a.cola=b.cola and null
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: av? node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select null from table({}) av? (av_?) where ? <> ?)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select null from table({}) av? (av_?) where ? <> ?) b (cola) on a.cola=b.cola and null
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: av? node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select null from table({}) av? (av_?) where ? <> ?)
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         sargs: term[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select null from table({}) av? (av_?) where ? <> ?) b (cola) on a.cola=b.cola and null
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: av? node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select null from table({}) av? (av_?) where ? <> ?)
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         sargs: term[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select null from table({}) av? (av_?) where ? <> ?) b (cola) on a.cola=b.cola and null
+===================================================
+    
+"1=0" condition     
+
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: av? node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select null from table({}) av? (av_?) where ?=?)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select null from table({}) av? (av_?) where ?=?) b (cola) on a.cola=b.cola and null
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: av? node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select null from table({}) av? (av_?) where ?=?)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select null from table({}) av? (av_?) where ?=?) b (cola) on a.cola=b.cola and null
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: av? node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select null from table({}) av? (av_?) where ?=?)
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         sargs: term[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select null from table({}) av? (av_?) where ?=?) b (cola) on a.cola=b.cola and null
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: av? node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select null from table({}) av? (av_?) where ?=?)
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         sargs: term[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select null from table({}) av? (av_?) where ?=?) b (cola) on a.cola=b.cola and null
+===================================================
+    
+1-1. Create a view and use it instead of an inline view.     
+
+===================================================
+0
+===================================================
+Error:-494
+===================================================
+Error:-494
+===================================================
+Error:-494
+===================================================
+Error:-494
+===================================================
+    
+"1=0" condition     
+
+===================================================
+0
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: av? node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select null from table({}) av? (av_?) where ?=?)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select null from table({}) av? (av_?) where ?=?) b (cola) on a.cola=b.cola
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: av? node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select null from table({}) av? (av_?) where ?=?)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select null from table({}) av? (av_?) where ?=?) b (cola) on a.cola=b.cola
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: av? node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select null from table({}) av? (av_?) where ?=?)
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select null from table({}) av? (av_?) where ?=?) b (cola) on a.cola=b.cola
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: av? node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select null from table({}) av? (av_?) where ?=?)
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select null from table({}) av? (av_?) where ?=?) b (cola) on a.cola=b.cola
+===================================================
+    
+2. If there is a constant equality condition for the join column of the inline view     
+
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: tbl node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select tbl.cola from tbl tbl where tbl.cola= ?:? )
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select tbl.cola from tbl tbl where tbl.cola= ?:? ) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: tbl node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select tbl.cola from tbl tbl where tbl.cola= ?:? )
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select tbl.cola from tbl tbl where tbl.cola= ?:? ) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: tbl node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select tbl.cola from tbl tbl where tbl.cola= ?:? )
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 during:term[?]
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select tbl.cola from tbl tbl where tbl.cola= ?:? ) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: tbl node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select tbl.cola from tbl tbl where tbl.cola= ?:? )
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 during:term[?]
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select tbl.cola from tbl tbl where tbl.cola= ?:? ) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+    
+2-1. Create a view and use it instead of an inline view.     
+
+===================================================
+0
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: b node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select b.cola from tbl b where (b.cola= ?:? ))
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select b.cola from tbl b where (b.cola= ?:? )) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: b node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select b.cola from tbl b where (b.cola= ?:? ))
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select b.cola from tbl b where (b.cola= ?:? )) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: b node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select b.cola from tbl b where (b.cola= ?:? ))
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 during:term[?]
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select b.cola from tbl b where (b.cola= ?:? )) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: b node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select b.cola from tbl b where (b.cola= ?:? ))
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 during:term[?]
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select b.cola from tbl b where (b.cola= ?:? )) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+    
+3. If the SELECT clause of the inline view is a constant     
+
+===================================================
+count(*)    
+1999999     
+
+Query plan:
+sscan
+    class: tbl node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl tbl)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl tbl) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1999999     
+
+Query plan:
+sscan
+    class: tbl node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl tbl)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl tbl) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1999999     
+
+Query plan:
+sscan
+    class: tbl node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl tbl)
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 during:term[?]
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select ? from tbl tbl) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1999999     
+
+Query plan:
+sscan
+    class: tbl node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl tbl)
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 during:term[?]
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select ? from tbl tbl) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+    
+multi constant     
+
+===================================================
+count(*)    
+1999999     
+
+Query plan:
+sscan
+    class: tbl node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl tbl)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl tbl) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1999999     
+
+Query plan:
+sscan
+    class: tbl node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl tbl)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl tbl) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1999999     
+
+Query plan:
+sscan
+    class: tbl node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl tbl)
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 during:term[?]
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select ? from tbl tbl) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1999999     
+
+Query plan:
+sscan
+    class: tbl node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl tbl)
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 during:term[?]
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select ? from tbl tbl) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+    
+single row     
+
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: dual node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from dual dual)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from dual dual) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: dual node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from dual dual)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from dual dual) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: dual node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from dual dual)
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 during:term[?]
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select ? from dual dual) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: dual node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from dual dual)
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 during:term[?]
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select ? from dual dual) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+    
+3-1. Create a view and use it instead of an inline view.     
+
+===================================================
+0
+===================================================
+count(*)    
+1999999     
+
+Query plan:
+sscan
+    class: b node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl b)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl b) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1999999     
+
+Query plan:
+sscan
+    class: b node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl b)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl b) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1999999     
+
+Query plan:
+sscan
+    class: b node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl b)
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 during:term[?]
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select ? from tbl b) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1999999     
+
+Query plan:
+sscan
+    class: b node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl b)
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 during:term[?]
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select ? from tbl b) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+    
+multi constant     
+
+===================================================
+0
+===================================================
+count(*)    
+1999999     
+
+Query plan:
+sscan
+    class: b node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl b)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl b) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1999999     
+
+Query plan:
+sscan
+    class: b node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl b)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl b) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1999999     
+
+Query plan:
+sscan
+    class: b node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl b)
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 during:term[?]
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select ? from tbl b) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1999999     
+
+Query plan:
+sscan
+    class: b node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl b)
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 during:term[?]
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select ? from tbl b) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+    
+single row     
+
+===================================================
+0
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: b node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from db_root b)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from db_root b) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: b node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from db_root b)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from db_root b) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: b node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from db_root b)
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 during:term[?]
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select ? from db_root b) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+count(*)    
+1000000     
+
+Query plan:
+sscan
+    class: b node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from db_root b)
+Query plan:
+temp
+    order: UNORDERED
+    subplan: m-join (left outer join)
+                 edge:  term[?]
+                 outer: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: a node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 inner: temp
+                            order: cola[?]
+                            subplan: sscan
+                                         class: b node[?]
+                                         cost:  ? card ?
+                            cost:  ? card ?
+                 during:term[?]
+                 cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_MERGE */ count(*) from tbl a left outer join (select ? from db_root b) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+0
+===================================================
+0

--- a/sql/_13_issues/_25_2h/cases/cbrd_26099.sql
+++ b/sql/_13_issues/_25_2h/cases/cbrd_26099.sql
@@ -1,0 +1,229 @@
+/**
+ * This test case verifies CBRD-26099.
+ * Verify that the issue where join method hints for LEFT OUTER JOIN with empty inline view results are ignored has been resolved.
+**/
+
+drop table if exists tbl;
+create table tbl (cola int,colb int);
+insert into tbl select rownum, rownum from db_class a,db_class b,db_class c,db_class d,db_class e limit 1000000;
+
+evaluate '1. If there is no result of the inline view with the "= NULL" condition';
+select /*+ recompile use_hash */ count(*)
+ from tbl a, (select * from tbl b where b.colb = NULL) b
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_hash */ count(*)
+ from tbl a left outer join (select * from tbl b where b.colb = NULL) b
+ on a.cola = b.cola;
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a, (select * from tbl b where b.colb = NULL) b
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a left outer join (select * from tbl b where b.colb = NULL) b
+ on a.cola = b.cola;
+
+evaluate '"1=0" condition';
+select /*+ recompile use_hash */ count(*)
+ from tbl a, (select * from tbl b where 1 = 0) b
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_hash */ count(*)
+ from tbl a left outer join (select * from tbl b where 1 = 0) b
+ on a.cola = b.cola;
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a, (select * from tbl b where 1 = 0) b
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a left outer join (select * from tbl b where 1 = 0) b
+ on a.cola = b.cola;
+
+evaluate '1-1. Create a view and use it instead of an inline view.';
+-- ERROR: operand must be logical expression.
+
+create or replace view v_tbl as select * from tbl b where b.colb = NULL;
+
+select /*+ recompile use_hash */ count(*)
+ from tbl a, v_tbl b
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_hash */ count(*)
+ from tbl a left outer join v_tbl b
+ on a.cola = b.cola;
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a, v_tbl b
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a left outer join v_tbl b
+ on a.cola = b.cola;
+
+evaluate '"1=0" condition';
+create or replace view v_tbl as select * from tbl b where 1 = 0;
+
+select /*+ recompile use_hash */ count(*)
+ from tbl a, v_tbl b
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_hash */ count(*)
+ from tbl a left outer join v_tbl b
+ on a.cola = b.cola;
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a, v_tbl b
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a left outer join v_tbl b
+ on a.cola = b.cola;
+
+evaluate '2. If there is a constant equality condition for the join column of the inline view';
+select /*+ recompile use_hash */ count(*) 
+ from tbl a, (select cola from tbl where cola=1) b 
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_hash */ count(*) 
+ from tbl a left outer join (select cola from tbl where cola=1) b 
+ on a.cola = b.cola;
+
+select /*+ recompile use_merge */ count(*) 
+ from tbl a, (select cola from tbl where cola=1) b 
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_merge */ count(*) 
+ from tbl a left outer join (select cola from tbl where cola=1) b 
+ on a.cola = b.cola;
+
+evaluate '2-1. Create a view and use it instead of an inline view.';
+create or replace view v_tbl as select * from tbl b where cola=1;
+
+select /*+ recompile use_hash */ count(*)
+ from tbl a, v_tbl b
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_hash */ count(*)
+ from tbl a left outer join v_tbl b
+ on a.cola = b.cola;
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a, v_tbl b
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a left outer join v_tbl b
+ on a.cola = b.cola;
+
+evaluate '3. If the SELECT clause of the inline view is a constant';
+select /*+ recompile use_hash */ count(*)
+ from tbl a, (select 1 cola from tbl) b 
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_hash */ count(*)
+ from tbl a left outer join (select 1 cola from tbl) b 
+ on a.cola = b.cola;
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a, (select 1 cola from tbl) b 
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a left outer join (select 1 cola from tbl) b 
+ on a.cola = b.cola;
+
+evaluate 'multi constant';
+select /*+ recompile use_hash */ count(*)
+ from tbl a, (select 1 cola, 'x' colb from tbl) b 
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_hash */ count(*)
+ from tbl a left outer join (select 1 cola, 'x' colb from tbl) b 
+ on a.cola = b.cola;
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a, (select 1 cola, 'x' colb from tbl) b 
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a left outer join (select 1 cola, 'x' colb from tbl) b 
+ on a.cola = b.cola;
+
+evaluate 'single row';
+select /*+ recompile use_hash */ count(*)
+ from tbl a, (select 1 cola) b 
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_hash */ count(*)
+ from tbl a left outer join (select 1 cola) b 
+ on a.cola = b.cola;
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a, (select 1 cola) b 
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a left outer join (select 1 cola) b 
+ on a.cola = b.cola;
+
+evaluate '3-1. Create a view and use it instead of an inline view.';
+create or replace view v_tbl as select 1 cola from tbl;
+
+select /*+ recompile use_hash */ count(*)
+ from tbl a, v_tbl b
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_hash */ count(*)
+ from tbl a left outer join v_tbl b
+ on a.cola = b.cola;
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a, v_tbl b
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a left outer join v_tbl b
+ on a.cola = b.cola;
+
+evaluate 'multi constant';
+create or replace view v_tbl as select 1 cola, 'x' colb from tbl;
+
+select /*+ recompile use_hash */ count(*)
+ from tbl a, v_tbl b
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_hash */ count(*)
+ from tbl a left outer join v_tbl b
+ on a.cola = b.cola;
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a, v_tbl b
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a left outer join v_tbl b
+ on a.cola = b.cola;
+
+evaluate 'single row';
+create or replace view v_tbl as select 1 cola;
+
+select /*+ recompile use_hash */ count(*)
+ from tbl a, v_tbl b
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_hash */ count(*)
+ from tbl a left outer join v_tbl b
+ on a.cola = b.cola;
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a, v_tbl b
+ where a.cola = b.cola(+);
+
+select /*+ recompile use_merge */ count(*)
+ from tbl a left outer join v_tbl b
+ on a.cola = b.cola;
+
+drop view if exists v_tbl;
+drop table if exists tbl;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26099

debug build에서 server down 현상이 발생하고 있는데, 이는 본 이슈와 상관 없는 것으로 http://jira.cubrid.org/browse/CBRD-25717 해결 시 함께 해결될 예정입니다. 따라서 CBRD-25717 merge 시 본 tc도 머지하겠습니다.

관련 링크 : http://jira.cubrid.org/browse/CBRD-26099?focusedCommentId=4771838&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4771838

 http://jira.cubrid.org/browse/CBRD-25717 이슈가 해결되어 머지합니다.
