### PR TITLE
[CUBRIDQA-1287] basicdb: switch charset to UTF-8 and update SQL test cases - 25

### DIFF
--- a/sql/_13_issues/_12_2h/answers/bug_bts_10106.answer
+++ b/sql/_13_issues/_12_2h/answers/bug_bts_10106.answer
@@ -18,11 +18,15 @@ id    s    collation(s)    collation(_iso88591'金')    coercibility(s)    coerc
 ===================================================
 0
 ===================================================
+0
+===================================================
 2
 ===================================================
 0
 ===================================================
-id    s    cast(s as varchar)    collation(s)    collation('金')    coercibility(s)    coercibility('金')    hex(s)    hex( cast('金' as varchar collate iso88591_bin))    
+id    s    cast(s as varchar)    collation(s)    collation(_iso88591'金')    coercibility(s)    coercibility(_iso88591'金')    hex(s)    hex( cast('金' as varchar collate iso88591_bin))    
+1     金     金     utf8_bin     iso88591_bin     3     10     E98791     3F     
+2     가     가     utf8_bin     iso88591_bin     3     10     EAB080     3F     
 
 ===================================================
 0

--- a/sql/_13_issues/_12_2h/cases/bug_bts_10106.sql
+++ b/sql/_13_issues/_12_2h/cases/bug_bts_10106.sql
@@ -6,9 +6,10 @@ set names iso88591;
 select id,s,collation(s),collation('金'),coercibility(s),coercibility('金'),hex(s),hex(cast(_iso88591'金' as string collate utf8_bin)) from t where s > '金' order by 1;
 
 drop t;
+set names utf8;
 create table t(id int, s string);
 insert into t values(1,'金'),(2,'가');
-set names utf8;
+set names iso88591;
 select id,s,cast(s as string collate utf8_bin),collation(s),collation('金'),coercibility(s),coercibility('金'),hex(s),hex(cast(_utf8'金' as string collate iso88591_bin))   from t where s > '金';
 
 drop t;


### PR DESCRIPTION
-추가수정-

http://jira.cubrid.org/browse/CUBRIDSUS-10106 테스트 목적에 맞게 수정합니다.
두번째 테스트 시나리오에서 data  insert시 iso88591 세션에 걸려 데이터가 깨진 상태로 저장되므로 테스트 의도(“상수 변환”)와 달라짐
insert되는 data는 SET NAMES utf8로 고정하고, 비교 구간에만 SET NAMES iso88591을 적용
이렇게 해야 JIRA 이슈의 본취지(iso 상수 -> utf8 컬럼 콜레이션으로 변환되는지)를 검증할 수 있음