### PR TITLE
[CUBRIDQA-1136] Stabilize Test Case by Adding 'wait until C2 ready'

### DIFF
--- a/isolation/_05_ReadCommitted_RepeatableRead/index_column/composite_index/basic_sql/insert_select_01_complex.ctl
+++ b/isolation/_05_ReadCommitted_RepeatableRead/index_column/composite_index/basic_sql/insert_select_01_complex.ctl
@@ -119,6 +119,7 @@ MC: wait until C2 ready;
 C1: select count(*) from t;
 C1: commit;
 C2: insert into t values(1,1);
+C2: wait until C2 ready;
 
 /* expected 100 */
 C6: select count(*) from t where col=1;


### PR DESCRIPTION
- C2 insert 구문 이후 `MC: wait until C2 ready;` 구문을 추가함
- 이유: 답지에서 `C6: select count(*) from t where col=1;` 결과보다 간헐적으로 더 늦게 출력되어 fail이 자주 발생하는 문제가 있었음
- 약간의 여유 시간을 두어 실행 순서를 안정화하기 위함