### PR TITLE
[CUBRIDQA-1136] Minor Fix: Correct C2 to MC

### DIFF
--- a/isolation/_05_ReadCommitted_RepeatableRead/index_column/composite_index/basic_sql/insert_select_01_complex.ctl
+++ b/isolation/_05_ReadCommitted_RepeatableRead/index_column/composite_index/basic_sql/insert_select_01_complex.ctl
@@ -119,7 +119,7 @@ MC: wait until C2 ready;
 C1: select count(*) from t;
 C1: commit;
 C2: insert into t values(1,1);
-C2: wait until C2 ready;
+MC: wait until C2 ready;
 
 /* expected 100 */
 C6: select count(*) from t where col=1;


### PR DESCRIPTION
C2가 아니라 MC여야 정상수행됩니다.
오타 수정입니다.