### PR TITLE
[CBRD-26286] Add RECOMPILE hint to stabilize related regexp test cases

### DIFF
--- a/sql/_32_damson/cbrd_22783_REGEXP_functions/cases/REGEXP_COUNT_unicode.sql
+++ b/sql/_32_damson/cbrd_22783_REGEXP_functions/cases/REGEXP_COUNT_unicode.sql
@@ -3,15 +3,15 @@ set system parameters 'regexp_engine=cppstd';
 
 --REGEXP_COUNT
 SET NAMES utf8 COLLATE utf8_ko_cs;
-SELECT REGEXP_COUNT('가나다가나다가나다라', '(가나)다', 1);
-SELECT REGEXP_COUNT('가나 가나다라 마바사아 자차카타 파하', '[[:alpha:]]+', 1);
-SELECT REGEXP_COUNT('11억 8112만 5400 won 더하기 420만 4432 won', '[[:alpha:]]', 8);
-SELECT REGEXP_COUNT('Kłak Aleksander', '[[:alpha:]]+', 1);
-SELECT REGEXP_COUNT(_euckr'가나다라' COLLATE euckr_bin, _utf8' [가-나]' COLLATE utf8_ko_cs);
-SELECT REGEXP_COUNT('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs);
+SELECT /*+ RECOMPILE */ REGEXP_COUNT('가나다가나다가나다라', '(가나)다', 1);
+SELECT /*+ RECOMPILE */ REGEXP_COUNT('가나 가나다라 마바사아 자차카타 파하', '[[:alpha:]]+', 1);
+SELECT /*+ RECOMPILE */ REGEXP_COUNT('11억 8112만 5400 won 더하기 420만 4432 won', '[[:alpha:]]', 8);
+SELECT /*+ RECOMPILE */ REGEXP_COUNT('Kłak Aleksander', '[[:alpha:]]+', 1);
+SELECT /*+ RECOMPILE */ REGEXP_COUNT(_euckr'가나다라' COLLATE euckr_bin, _utf8' [가-나]' COLLATE utf8_ko_cs);
+SELECT /*+ RECOMPILE */ REGEXP_COUNT('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs);
 
 SET NAMES iso88591;
-SELECT REGEXP_COUNT('Kłak Aleksander', '[[:alpha:]]+', 1);
+SELECT /*+ RECOMPILE */ REGEXP_COUNT('Kłak Aleksander', '[[:alpha:]]+', 1);
 
 SET NAMES utf8;
 set system parameters 'regexp_engine=default';

--- a/sql/_32_damson/cbrd_22783_REGEXP_functions/cases/REGEXP_INSTR_unicode.sql
+++ b/sql/_32_damson/cbrd_22783_REGEXP_functions/cases/REGEXP_INSTR_unicode.sql
@@ -3,15 +3,15 @@ set system parameters 'regexp_engine=cppstd';
 
 --REGEXP_INSTR
 SET NAMES utf8 COLLATE utf8_ko_cs;
-SELECT REGEXP_INSTR('삼성로 86길, 강남구, 서울특별시', ',[^,]+,', 1, 1);
-SELECT REGEXP_INSTR('삼성로 86길, 강남구, 서울특별시', '[[:alpha:]]+', 1, 3);
-SELECT REGEXP_INSTR('11억 8112만 5400원', '\d+[[:alpha:]]', 3, 1);
-SELECT REGEXP_INSTR('Kłak Aleksander', '[[:alpha:]]+', 1, 1);
-SELECT REGEXP_INSTR (_euckr'가나다라' COLLATE euckr_bin, _utf8' [가-나]{4}' COLLATE utf8_ko_cs);
-SELECT REGEXP_INSTR ('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs);
+SELECT /*+ RECOMPILE */ REGEXP_INSTR('삼성로 86길, 강남구, 서울특별시', ',[^,]+,', 1, 1);
+SELECT /*+ RECOMPILE */ REGEXP_INSTR('삼성로 86길, 강남구, 서울특별시', '[[:alpha:]]+', 1, 3);
+SELECT /*+ RECOMPILE */ REGEXP_INSTR('11억 8112만 5400원', '\d+[[:alpha:]]', 3, 1);
+SELECT /*+ RECOMPILE */ REGEXP_INSTR('Kłak Aleksander', '[[:alpha:]]+', 1, 1);
+SELECT /*+ RECOMPILE */ REGEXP_INSTR (_euckr'가나다라' COLLATE euckr_bin, _utf8' [가-나]{4}' COLLATE utf8_ko_cs);
+SELECT /*+ RECOMPILE */ REGEXP_INSTR ('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs);
 
 SET NAMES iso88591;
-SELECT REGEXP_INSTR('Kłak Aleksander', '[[:alpha:]]+', 1, 1);
+SELECT /*+ RECOMPILE */ REGEXP_INSTR('Kłak Aleksander', '[[:alpha:]]+', 1, 1);
 
 SET NAMES utf8;
 set system parameters 'regexp_engine=default';

--- a/sql/_32_damson/cbrd_22783_REGEXP_functions/cases/REGEXP_LIKE_unicode.sql
+++ b/sql/_32_damson/cbrd_22783_REGEXP_functions/cases/REGEXP_LIKE_unicode.sql
@@ -3,15 +3,15 @@ set system parameters 'regexp_engine=cppstd';
 
 --REGEXP_LIKE
 SET NAMES utf8 COLLATE utf8_ko_cs;
-SELECT REGEXP_LIKE('가나다가나다가나다라', '(가나)다');
-SELECT REGEXP_LIKE('가나 가나다라 마바사아 자차카타 파하', '[[:alpha:]]+');
-SELECT REGEXP_LIKE('11억 1111', '[[:alpha:]]');
-SELECT REGEXP_LIKE('Kłak Aleksander', '[[:alpha:]]');
-SELECT REGEXP_LIKE(_euckr'가나다라' COLLATE euckr_bin, _utf8' [가-나]' COLLATE utf8_ko_cs);
-SELECT REGEXP_LIKE('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs);
+SELECT /*+ RECOMPILE */ REGEXP_LIKE('가나다가나다가나다라', '(가나)다');
+SELECT /*+ RECOMPILE */ REGEXP_LIKE('가나 가나다라 마바사아 자차카타 파하', '[[:alpha:]]+');
+SELECT /*+ RECOMPILE */ REGEXP_LIKE('11억 1111', '[[:alpha:]]');
+SELECT /*+ RECOMPILE */ REGEXP_LIKE('Kłak Aleksander', '[[:alpha:]]');
+SELECT /*+ RECOMPILE */ REGEXP_LIKE(_euckr'가나다라' COLLATE euckr_bin, _utf8' [가-나]' COLLATE utf8_ko_cs);
+SELECT /*+ RECOMPILE */ REGEXP_LIKE('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs);
 
 SET NAMES iso88591;
-SELECT REGEXP_LIKE('Kłak Aleksander', '[[:alpha:]]');
+SELECT /*+ RECOMPILE */ REGEXP_LIKE('Kłak Aleksander', '[[:alpha:]]');
 
 SET NAMES utf8;
 set system parameters 'regexp_engine=default';

--- a/sql/_32_damson/cbrd_22783_REGEXP_functions/cases/REGEXP_REPLACE_unicode.sql
+++ b/sql/_32_damson/cbrd_22783_REGEXP_functions/cases/REGEXP_REPLACE_unicode.sql
@@ -3,26 +3,26 @@ set system parameters 'regexp_engine=cppstd';
 
 --REGEXP
 SET NAMES utf8 COLLATE utf8_ko_cs;
-SELECT '가나다라' REGEXP '가';
-SELECT '가나다라' REGEXP '마';
-SELECT '가나다' REGEXP '[[:alpha:]]';
-SELECT '123' REGEXP '[[:alpha:]]';
+SELECT /*+ RECOMPILE */ '가나다라' REGEXP '가';
+SELECT /*+ RECOMPILE */ '가나다라' REGEXP '마';
+SELECT /*+ RECOMPILE */ '가나다' REGEXP '[[:alpha:]]';
+SELECT /*+ RECOMPILE */ '123' REGEXP '[[:alpha:]]';
 
 --REGEXP_REPLACE
 SET NAMES utf8 COLLATE utf8_ko_cs;
-SELECT REGEXP_REPLACE('가나다라', '[가-나]{4}', '한글');
-SELECT REGEXP_REPLACE('가나다라', '[가-라]{4}', '한글');
-SELECT REGEXP_REPLACE('가나다라', '[[:alpha:]]', '한글');
-SELECT REGEXP_REPLACE('a1가b2나다라', '[가-다]', '#', 6);
-SELECT REGEXP_REPLACE('a1가b2나다라', '[가-다]', '#', 1, 3);
-SELECT REGEXP_REPLACE(_euckr'가나다라', _utf8' [가-나]{4}', _utf8'다른 문자셋');
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE('가나다라', '[가-나]{4}', '한글');
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE('가나다라', '[가-라]{4}', '한글');
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE('가나다라', '[[:alpha:]]', '한글');
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE('a1가b2나다라', '[가-다]', '#', 6);
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE('a1가b2나다라', '[가-다]', '#', 1, 3);
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE(_euckr'가나다라', _utf8' [가-나]{4}', _utf8'다른 문자셋');
 --According to CBRD-23641 do not include
 --SELECT REGEXP_REPLACE(_euckr'가나다라' collate euckr_bin, _utf8' [가-나]{4}', _utf8'다른 문자셋');
 
 SET NAMES utf8; 
-SELECT REGEXP_REPLACE('Kłak Aleksander', '[[:alpha:]]+','#', 1, 1);
-SELECT REGEXP_REPLACE(_euckr'가나다라', _utf8' [가-나]{4}', _utf8'다른 문자셋');
-SELECT REGEXP_REPLACE('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs, 'INVALID');
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE('Kłak Aleksander', '[[:alpha:]]+','#', 1, 1);
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE(_euckr'가나다라', _utf8' [가-나]{4}', _utf8'다른 문자셋');
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs, 'INVALID');
 
 --According to CBRD-23641 do not include
 --SET NAMES iso88591;

--- a/sql/_32_damson/cbrd_22783_REGEXP_functions/cases/REGEXP_SUBSTR_unicode.sql
+++ b/sql/_32_damson/cbrd_22783_REGEXP_functions/cases/REGEXP_SUBSTR_unicode.sql
@@ -3,15 +3,15 @@ set system parameters 'regexp_engine=cppstd';
 
 --REGEXP_SUBSTR
 SET NAMES utf8 COLLATE utf8_ko_cs;
-SELECT REGEXP_SUBSTR('삼성로 86길, 강남구, 서울특별시', ',[^,]+,', 1, 1);
-SELECT REGEXP_SUBSTR('삼성로 86길, 강남구, 서울특별시', '[[:alpha:]]+', 1, 3);
-SELECT REGEXP_SUBSTR('11억 8112만 5400원', '\d+[[:alpha:]]', 3, 1);
-SELECT REGEXP_SUBSTR('Kłak Aleksander', '[[:alpha:]]+', 1, 1);
-SELECT REGEXP_SUBSTR(_euckr'가나다라' COLLATE euckr_bin, _utf8' [가-나]{4}' COLLATE utf8_ko_cs);
-SELECT REGEXP_SUBSTR('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs);
+SELECT /*+ RECOMPILE */ REGEXP_SUBSTR('삼성로 86길, 강남구, 서울특별시', ',[^,]+,', 1, 1);
+SELECT /*+ RECOMPILE */ REGEXP_SUBSTR('삼성로 86길, 강남구, 서울특별시', '[[:alpha:]]+', 1, 3);
+SELECT /*+ RECOMPILE */ REGEXP_SUBSTR('11억 8112만 5400원', '\d+[[:alpha:]]', 3, 1);
+SELECT /*+ RECOMPILE */ REGEXP_SUBSTR('Kłak Aleksander', '[[:alpha:]]+', 1, 1);
+SELECT /*+ RECOMPILE */ REGEXP_SUBSTR(_euckr'가나다라' COLLATE euckr_bin, _utf8' [가-나]{4}' COLLATE utf8_ko_cs);
+SELECT /*+ RECOMPILE */ REGEXP_SUBSTR('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs);
 
 SET NAMES iso88591;
-SELECT REGEXP_SUBSTR('Kłak Aleksander', '[[:alpha:]]+', 1, 1);
+SELECT /*+ RECOMPILE */ REGEXP_SUBSTR('Kłak Aleksander', '[[:alpha:]]+', 1, 1);
 
 SET NAMES utf8;
 set system parameters 'regexp_engine=default';

--- a/sql/_34_fig/cbrd_24563/cases/REGEXP_COUNT_unicode.sql
+++ b/sql/_34_fig/cbrd_24563/cases/REGEXP_COUNT_unicode.sql
@@ -3,20 +3,20 @@ set system parameters 'regexp_engine=re2';
 
 --REGEXP_COUNT
 SET NAMES utf8 COLLATE utf8_ko_cs;
-SELECT REGEXP_COUNT('가나다가나다가나다라', '(가나)다', 1);
-SELECT REGEXP_COUNT('가나 가나다라 마바사아 자차카타 파하', '[[:alpha:]]+', 1);
-SELECT REGEXP_COUNT('11억 8112만 5400 won 더하기 420만 4432 won', '[[:alpha:]]', 8);
-SELECT REGEXP_COUNT('Kłak Aleksander', '[[:alpha:]]+', 1);
-SELECT REGEXP_COUNT(_euckr'가나다라' COLLATE euckr_bin, _utf8' [가-나]' COLLATE utf8_ko_cs);
-SELECT REGEXP_COUNT('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs);
+SELECT /*+ RECOMPILE */ REGEXP_COUNT('가나다가나다가나다라', '(가나)다', 1);
+SELECT /*+ RECOMPILE */ REGEXP_COUNT('가나 가나다라 마바사아 자차카타 파하', '[[:alpha:]]+', 1);
+SELECT /*+ RECOMPILE */ REGEXP_COUNT('11억 8112만 5400 won 더하기 420만 4432 won', '[[:alpha:]]', 8);
+SELECT /*+ RECOMPILE */ REGEXP_COUNT('Kłak Aleksander', '[[:alpha:]]+', 1);
+SELECT /*+ RECOMPILE */ REGEXP_COUNT(_euckr'가나다라' COLLATE euckr_bin, _utf8' [가-나]' COLLATE utf8_ko_cs);
+SELECT /*+ RECOMPILE */ REGEXP_COUNT('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs);
 
 --re2 library unicode verification
-SELECT REGEXP_COUNT('가나 가나다라 마바사아 자차카타 파하', '\p{Hangul}+', 1);
-SELECT REGEXP_COUNT('11억 8112만 5400 won 더하기 420만 4432 won', '\p{Hangul}', 8);
-SELECT REGEXP_COUNT('Kłak Aleksander', '\p{Hangul}+', 1);
+SELECT /*+ RECOMPILE */ REGEXP_COUNT('가나 가나다라 마바사아 자차카타 파하', '\p{Hangul}+', 1);
+SELECT /*+ RECOMPILE */ REGEXP_COUNT('11억 8112만 5400 won 더하기 420만 4432 won', '\p{Hangul}', 8);
+SELECT /*+ RECOMPILE */ REGEXP_COUNT('Kłak Aleksander', '\p{Hangul}+', 1);
 
 SET NAMES iso88591;
-SELECT REGEXP_COUNT('Kłak Aleksander', '[[:alpha:]]+', 1);
+SELECT /*+ RECOMPILE */ REGEXP_COUNT('Kłak Aleksander', '[[:alpha:]]+', 1);
 
 SET NAMES utf8;
 set system parameters 'regexp_engine=default';

--- a/sql/_34_fig/cbrd_24563/cases/REGEXP_INSTR_unicode.sql
+++ b/sql/_34_fig/cbrd_24563/cases/REGEXP_INSTR_unicode.sql
@@ -3,20 +3,20 @@ set system parameters 'regexp_engine=re2';
 
 --REGEXP_INSTR
 SET NAMES utf8 COLLATE utf8_ko_cs;
-SELECT REGEXP_INSTR('삼성로 86길, 강남구, 서울특별시', ',[^,]+,', 1, 1);
-SELECT REGEXP_INSTR('삼성로 86길, 강남구, 서울특별시', '[[:alpha:]]+', 1, 3);
-SELECT REGEXP_INSTR('11억 8112만 5400원', '\d+[[:alpha:]]', 3, 1);
-SELECT REGEXP_INSTR('Kłak Aleksander', '[[:alpha:]]+', 1, 1);
-SELECT REGEXP_INSTR (_euckr'가나다라' COLLATE euckr_bin, _utf8' [가-나]{4}' COLLATE utf8_ko_cs);
-SELECT REGEXP_INSTR ('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs);
+SELECT /*+ RECOMPILE */ REGEXP_INSTR('삼성로 86길, 강남구, 서울특별시', ',[^,]+,', 1, 1);
+SELECT /*+ RECOMPILE */ REGEXP_INSTR('삼성로 86길, 강남구, 서울특별시', '[[:alpha:]]+', 1, 3);
+SELECT /*+ RECOMPILE */ REGEXP_INSTR('11억 8112만 5400원', '\d+[[:alpha:]]', 3, 1);
+SELECT /*+ RECOMPILE */ REGEXP_INSTR('Kłak Aleksander', '[[:alpha:]]+', 1, 1);
+SELECT /*+ RECOMPILE */ REGEXP_INSTR (_euckr'가나다라' COLLATE euckr_bin, _utf8' [가-나]{4}' COLLATE utf8_ko_cs);
+SELECT /*+ RECOMPILE */ REGEXP_INSTR ('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs);
 
 --re2 library unicode verification
-SELECT REGEXP_INSTR('삼성로 86길, 강남구, 서울특별시', '\p{Hangul}+', 1, 3);
-SELECT REGEXP_INSTR('11억 8112만 5400원', '\d+\p{Hangul}', 3, 1);
-SELECT REGEXP_INSTR('Kłak Aleksander', '\p{Hangul}+', 1, 1);
+SELECT /*+ RECOMPILE */ REGEXP_INSTR('삼성로 86길, 강남구, 서울특별시', '\p{Hangul}+', 1, 3);
+SELECT /*+ RECOMPILE */ REGEXP_INSTR('11억 8112만 5400원', '\d+\p{Hangul}', 3, 1);
+SELECT /*+ RECOMPILE */ REGEXP_INSTR('Kłak Aleksander', '\p{Hangul}+', 1, 1);
 
 SET NAMES iso88591;
-SELECT REGEXP_INSTR('Kłak Aleksander', '[[:alpha:]]+', 1, 1);
+SELECT /*+ RECOMPILE */ REGEXP_INSTR('Kłak Aleksander', '[[:alpha:]]+', 1, 1);
 
 SET NAMES utf8;
 set system parameters 'regexp_engine=default';

--- a/sql/_34_fig/cbrd_24563/cases/REGEXP_LIKE_unicode.sql
+++ b/sql/_34_fig/cbrd_24563/cases/REGEXP_LIKE_unicode.sql
@@ -3,20 +3,20 @@ set system parameters 'regexp_engine=re2';
 
 --REGEXP_LIKE
 SET NAMES utf8 COLLATE utf8_ko_cs;
-SELECT REGEXP_LIKE('가나다가나다가나다라', '(가나)다');
-SELECT REGEXP_LIKE('가나 가나다라 마바사아 자차카타 파하', '[[:alpha:]]+');
-SELECT REGEXP_LIKE('11억 1111', '[[:alpha:]]');
-SELECT REGEXP_LIKE('Kłak Aleksander', '[[:alpha:]]');
-SELECT REGEXP_LIKE(_euckr'가나다라' COLLATE euckr_bin, _utf8' [가-나]' COLLATE utf8_ko_cs);
-SELECT REGEXP_LIKE('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs);
+SELECT /*+ RECOMPILE */ REGEXP_LIKE('가나다가나다가나다라', '(가나)다');
+SELECT /*+ RECOMPILE */ REGEXP_LIKE('가나 가나다라 마바사아 자차카타 파하', '[[:alpha:]]+');
+SELECT /*+ RECOMPILE */ REGEXP_LIKE('11억 1111', '[[:alpha:]]');
+SELECT /*+ RECOMPILE */ REGEXP_LIKE('Kłak Aleksander', '[[:alpha:]]');
+SELECT /*+ RECOMPILE */ REGEXP_LIKE(_euckr'가나다라' COLLATE euckr_bin, _utf8' [가-나]' COLLATE utf8_ko_cs);
+SELECT /*+ RECOMPILE */ REGEXP_LIKE('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs);
 
 --unicode verification
-SELECT REGEXP_LIKE('가나 가나다라 마바사아 자차카타 파하', '\p{Hangul}+');
-SELECT REGEXP_LIKE('11억 1111', '\p{Hangul}');
-SELECT REGEXP_LIKE('Kłak Aleksander', '\p{Hangul}');
+SELECT /*+ RECOMPILE */ REGEXP_LIKE('가나 가나다라 마바사아 자차카타 파하', '\p{Hangul}+');
+SELECT /*+ RECOMPILE */ REGEXP_LIKE('11억 1111', '\p{Hangul}');
+SELECT /*+ RECOMPILE */ REGEXP_LIKE('Kłak Aleksander', '\p{Hangul}');
 
 SET NAMES iso88591;
-SELECT REGEXP_LIKE('Kłak Aleksander', '[[:alpha:]]');
+SELECT /*+ RECOMPILE */ REGEXP_LIKE('Kłak Aleksander', '[[:alpha:]]');
 
 SET NAMES utf8;
 set system parameters 'regexp_engine=default';

--- a/sql/_34_fig/cbrd_24563/cases/REGEXP_REPLACE_unicode.sql
+++ b/sql/_34_fig/cbrd_24563/cases/REGEXP_REPLACE_unicode.sql
@@ -3,34 +3,34 @@ set system parameters 'regexp_engine=re2';
 
 --REGEXP
 SET NAMES utf8 COLLATE utf8_ko_cs;
-SELECT '가나다라' REGEXP '가';
-SELECT '가나다라' REGEXP '마';
-SELECT '가나다' REGEXP '[[:alpha:]]';
-SELECT '123' REGEXP '[[:alpha:]]';
+SELECT /*+ RECOMPILE */ '가나다라' REGEXP '가';
+SELECT /*+ RECOMPILE */ '가나다라' REGEXP '마';
+SELECT /*+ RECOMPILE */ '가나다' REGEXP '[[:alpha:]]';
+SELECT /*+ RECOMPILE */ '123' REGEXP '[[:alpha:]]';
 
 --re2 library unicode verification.
-SELECT '가나다' REGEXP '\p{Hangul}';
-SELECT '123' REGEXP '\p{Hangul}';
+SELECT /*+ RECOMPILE */ '가나다' REGEXP '\p{Hangul}';
+SELECT /*+ RECOMPILE */ '123' REGEXP '\p{Hangul}';
 
 
 --REGEXP_REPLACE
 SET NAMES utf8 COLLATE utf8_ko_cs;
-SELECT REGEXP_REPLACE('가나다라', '[가-나]{4}', '한글');
-SELECT REGEXP_REPLACE('가나다라', '[가-라]{4}', '한글');
-SELECT REGEXP_REPLACE('가나다라', '[[:alpha:]]', '한글');
-SELECT REGEXP_REPLACE('a1가b2나다라', '[가-다]', '#', 6);
-SELECT REGEXP_REPLACE('a1가b2나다라', '[가-다]', '#', 1, 3);
-SELECT REGEXP_REPLACE(_euckr'가나다라', _utf8' [가-나]{4}', _utf8'다른 문자셋');
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE('가나다라', '[가-나]{4}', '한글');
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE('가나다라', '[가-라]{4}', '한글');
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE('가나다라', '[[:alpha:]]', '한글');
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE('a1가b2나다라', '[가-다]', '#', 6);
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE('a1가b2나다라', '[가-다]', '#', 1, 3);
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE(_euckr'가나다라', _utf8' [가-나]{4}', _utf8'다른 문자셋');
 --According to CBRD-23641 do not include
 --SELECT REGEXP_REPLACE(_euckr'가나다라' collate euckr_bin, _utf8' [가-나]{4}', _utf8'다른 문자셋');
 
 --re2 library unicode verification.
-SELECT REGEXP_REPLACE('가나다라', '\p{Hangul}', '한글');
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE('가나다라', '\p{Hangul}', '한글');
 
 SET NAMES utf8; 
-SELECT REGEXP_REPLACE('Kłak Aleksander', '[[:alpha:]]+','#', 1, 1);
-SELECT REGEXP_REPLACE(_euckr'가나다라', _utf8' [가-나]{4}', _utf8'다른 문자셋');
-SELECT REGEXP_REPLACE('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs, 'INVALID');
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE('Kłak Aleksander', '[[:alpha:]]+','#', 1, 1);
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE(_euckr'가나다라', _utf8' [가-나]{4}', _utf8'다른 문자셋');
+SELECT /*+ RECOMPILE */ REGEXP_REPLACE('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs, 'INVALID');
 
 --According to CBRD-23641 do not include
 --SET NAMES iso88591;

--- a/sql/_34_fig/cbrd_24563/cases/REGEXP_SUBSTR_unicode.sql
+++ b/sql/_34_fig/cbrd_24563/cases/REGEXP_SUBSTR_unicode.sql
@@ -3,20 +3,20 @@ set system parameters 'regexp_engine=re2';
 
 --REGEXP_SUBSTR
 SET NAMES utf8 COLLATE utf8_ko_cs;
-SELECT REGEXP_SUBSTR('삼성로 86길, 강남구, 서울특별시', ',[^,]+,', 1, 1);
-SELECT REGEXP_SUBSTR('삼성로 86길, 강남구, 서울특별시', '[[:alpha:]]+', 1, 3);
-SELECT REGEXP_SUBSTR('11억 8112만 5400원', '\d+[[:alpha:]]', 3, 1);
-SELECT REGEXP_SUBSTR('Kłak Aleksander', '[[:alpha:]]+', 1, 1);
-SELECT REGEXP_SUBSTR(_euckr'가나다라' COLLATE euckr_bin, _utf8' [가-나]{4}' COLLATE utf8_ko_cs);
-SELECT REGEXP_SUBSTR('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs);
+SELECT /*+ RECOMPILE */ REGEXP_SUBSTR('삼성로 86길, 강남구, 서울특별시', ',[^,]+,', 1, 1);
+SELECT /*+ RECOMPILE */ REGEXP_SUBSTR('삼성로 86길, 강남구, 서울특별시', '[[:alpha:]]+', 1, 3);
+SELECT /*+ RECOMPILE */ REGEXP_SUBSTR('11억 8112만 5400원', '\d+[[:alpha:]]', 3, 1);
+SELECT /*+ RECOMPILE */ REGEXP_SUBSTR('Kłak Aleksander', '[[:alpha:]]+', 1, 1);
+SELECT /*+ RECOMPILE */ REGEXP_SUBSTR(_euckr'가나다라' COLLATE euckr_bin, _utf8' [가-나]{4}' COLLATE utf8_ko_cs);
+SELECT /*+ RECOMPILE */ REGEXP_SUBSTR('가나다라' COLLATE utf8_ko_cs,  _utf8' [த]' COLLATE utf8_tr_cs);
 
 --re2 library unicode verification
-SELECT REGEXP_SUBSTR('삼성로 86길, 강남구, 서울특별시', '\p{Hangul}+', 1, 3);
-SELECT REGEXP_SUBSTR('11억 8112만 5400원', '\d+\p{Hangul}', 3, 1);
-SELECT REGEXP_SUBSTR('Kłak Aleksander', '\p{Hangul}+', 1, 1);
+SELECT /*+ RECOMPILE */ REGEXP_SUBSTR('삼성로 86길, 강남구, 서울특별시', '\p{Hangul}+', 1, 3);
+SELECT /*+ RECOMPILE */ REGEXP_SUBSTR('11억 8112만 5400원', '\d+\p{Hangul}', 3, 1);
+SELECT /*+ RECOMPILE */ REGEXP_SUBSTR('Kłak Aleksander', '\p{Hangul}+', 1, 1);
 
 SET NAMES iso88591;
-SELECT REGEXP_SUBSTR('Kłak Aleksander', '[[:alpha:]]+', 1, 1);
+SELECT /*+ RECOMPILE */ REGEXP_SUBSTR('Kłak Aleksander', '[[:alpha:]]+', 1, 1);
 
 SET NAMES utf8;
 set system parameters 'regexp_engine=default';


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-26286
(버그는 아니지만 히스토리 추적 편의상, cubridqa-1136이 아닌 해당 이슈를 헤더 이슈로 작성합니다.)

REGEXP_*_unicode 관련 TC들 에서 regexp_engine 파라미터 변경 직후 동일 SQL을 실행할 경우,
  plan cache 에 의해 이전 엔진 설정이 그대로 적용되는 현상이 있었습니다.

- 예시) `_32_damson/cbrd_22783_REGEXP_functions/cases/REGEXP_COUNT_unicode.sql` 수행 직후 `_34_fig/cbrd_24563/cases/REGEXP_COUNT_unicode.sql` 수행이 되면(동일한 질의의 경우), set parameter 를 다르게 설정했음에도 불구하고 직전 수행되었던 TC에서 캐시되었던 결과가 나오게 됩니다.

이는 정상 동작이며(이슈 comment 참조), plan cache 를 무효화하기 위해서는 /*+ RECOMPILE */ 힌트가 필요합니다.
한 세션 내에서 _32_damson, _34_fig 의 TC가 동시에 수행되면 불안정한 결과가 발생하는 것으로 보입니다. (circle-ci, sql_by_cci)
테스트 결과의 일관성을 위해 해당 TC에 RECOMPILE 힌트를 추가하여 안정화했습니다.