### PR TITLE
[CBRD-26264] count(not null column)을 count(*)로 재작성

### DIFF
--- a/sql/_18_index_enhancement_qa/_02_full_test/_01_covering_index/answers/_t110_17_basic.answer
+++ b/sql/_18_index_enhancement_qa/_02_full_test/_01_covering_index/answers/_t110_17_basic.answer
@@ -70,11 +70,11 @@ count(a.user_id)
 Query plan:
 iscan
     class: a node[?]
-    index: idx_t?_age_name term[?]
+    index: idx_t?_age_name term[?] (covers)
     filtr: term[?]
     cost:  ? card ?
 Query stmt:
-select count(a.user_id) from t? a where (a.age> ?:? ) and a.user_name is not null 
+select count(*) from t? a where (a.age> ?:? ) and a.user_name is not null 
 ===================================================
 count(a.user_id)    
 16     
@@ -83,7 +83,7 @@ Query plan:
 nl-join (cross join)
     outer: iscan
                class: a node[?]
-               index: idx_t?_age_name term[?]
+               index: idx_t?_age_name term[?] (covers)
                filtr: term[?]
                cost:  ? card ?
     inner: iscan
@@ -92,7 +92,7 @@ nl-join (cross join)
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select /*+ ORDERED */ count(a.user_id) from t? a, t? b where (a.age> ?:? ) and a.user_name is not null  and (b.age> ?:? )
+select /*+ ORDERED */ count(*) from t? a, t? b where (a.age> ?:? ) and a.user_name is not null  and (b.age> ?:? )
 ===================================================
 0
 ===================================================

--- a/sql/_23_apricot_qa/_02_performance/_01_filtered_index/answers/filtered_index_basicfunction_Alter.answer
+++ b/sql/_23_apricot_qa/_02_performance/_01_filtered_index/answers/filtered_index_basicfunction_Alter.answer
@@ -72,13 +72,12 @@ count(topicId)
 1     
 
 Query plan:
-iscan
+sscan
     class: blogtopic node[?]
-    index: my_filter_index 
     sargs: term[?]
     cost:  ? card ?
 Query stmt:
-select count(blogtopic.topicId) from blogtopic blogtopic where blogtopic.closedDate is null  using index blogtopic.my_filter_index(+)
+select count(*) from blogtopic blogtopic where blogtopic.closedDate is null  using index blogtopic.my_filter_index(+)
 ===================================================
 0
 ===================================================
@@ -99,7 +98,7 @@ iscan
     index: my_filter_index term[?] (covers)
     cost:  ? card ?
 Query stmt:
-select count(blogtopic.topicId) from blogtopic blogtopic where (blogtopic.topicId> ?:? ) using index blogtopic.my_filter_index(+)
+select count(*) from blogtopic blogtopic where (blogtopic.topicId> ?:? ) using index blogtopic.my_filter_index(+)
 ===================================================
 0
 ===================================================
@@ -112,7 +111,7 @@ iscan
     index: my_filter_index term[?] (covers)
     cost:  ? card ?
 Query stmt:
-select count(blogtopic.topicId) from blogtopic blogtopic where (blogtopic.topicId> ?:? ) using index blogtopic.my_filter_index(+)
+select count(*) from blogtopic blogtopic where (blogtopic.topicId> ?:? ) using index blogtopic.my_filter_index(+)
 ===================================================
 0
 ===================================================
@@ -125,7 +124,7 @@ iscan
     index: my_filter_index term[?] (covers)
     cost:  ? card ?
 Query stmt:
-select count(blogtopic.topicId) from blogtopic blogtopic where (blogtopic.topicId> ?:? ) using index blogtopic.my_filter_index(+)
+select count(*) from blogtopic blogtopic where (blogtopic.topicId> ?:? ) using index blogtopic.my_filter_index(+)
 ===================================================
 0
 ===================================================
@@ -146,7 +145,7 @@ iscan
     index: my_filter_index term[?] (covers)
     cost:  ? card ?
 Query stmt:
-select count(blogtopic.topicId) from blogtopic blogtopic where (blogtopic.topicId> ?:? )
+select count(*) from blogtopic blogtopic where (blogtopic.topicId> ?:? )
 ===================================================
 0
 ===================================================
@@ -159,7 +158,7 @@ iscan
     index: my_filter_index term[?] (covers)
     cost:  ? card ?
 Query stmt:
-select count(blogtopic.topicId) from blogtopic blogtopic where (blogtopic.topicId> ?:? )
+select count(*) from blogtopic blogtopic where (blogtopic.topicId> ?:? )
 ===================================================
 0
 ===================================================

--- a/sql/_23_apricot_qa/_02_performance/_01_filtered_index/answers/filtered_index_basicfunction_Alter.answer
+++ b/sql/_23_apricot_qa/_02_performance/_01_filtered_index/answers/filtered_index_basicfunction_Alter.answer
@@ -72,12 +72,13 @@ count(topicId)
 1     
 
 Query plan:
-sscan
+iscan
     class: blogtopic node[?]
+    index: my_filter_index 
     sargs: term[?]
     cost:  ? card ?
 Query stmt:
-select count(*) from blogtopic blogtopic where blogtopic.closedDate is null  using index blogtopic.my_filter_index(+)
+select count(blogtopic.topicId) from blogtopic blogtopic where blogtopic.closedDate is null  using index blogtopic.my_filter_index(+)
 ===================================================
 0
 ===================================================
@@ -98,7 +99,7 @@ iscan
     index: my_filter_index term[?] (covers)
     cost:  ? card ?
 Query stmt:
-select count(*) from blogtopic blogtopic where (blogtopic.topicId> ?:? ) using index blogtopic.my_filter_index(+)
+select count(blogtopic.topicId) from blogtopic blogtopic where (blogtopic.topicId> ?:? ) using index blogtopic.my_filter_index(+)
 ===================================================
 0
 ===================================================
@@ -111,7 +112,7 @@ iscan
     index: my_filter_index term[?] (covers)
     cost:  ? card ?
 Query stmt:
-select count(*) from blogtopic blogtopic where (blogtopic.topicId> ?:? ) using index blogtopic.my_filter_index(+)
+select count(blogtopic.topicId) from blogtopic blogtopic where (blogtopic.topicId> ?:? ) using index blogtopic.my_filter_index(+)
 ===================================================
 0
 ===================================================
@@ -124,7 +125,7 @@ iscan
     index: my_filter_index term[?] (covers)
     cost:  ? card ?
 Query stmt:
-select count(*) from blogtopic blogtopic where (blogtopic.topicId> ?:? ) using index blogtopic.my_filter_index(+)
+select count(blogtopic.topicId) from blogtopic blogtopic where (blogtopic.topicId> ?:? ) using index blogtopic.my_filter_index(+)
 ===================================================
 0
 ===================================================

--- a/sql/_23_apricot_qa/_03_i18n/_01_common/_00_issues/answers/bug_bts_6652.answer
+++ b/sql/_23_apricot_qa/_03_i18n/_01_common/_00_issues/answers/bug_bts_6652.answer
@@ -11,11 +11,12 @@ count(topicId)
 1     
 
 Query plan:
-sscan
+iscan
     class: blogtopic node[?]
+    index: my_filter_index 
     sargs: term[?]
     cost:  ? card ?
 Query stmt:
-select count(*) from blogtopic blogtopic where blogtopic.closedDate is null  using index blogtopic.my_filter_index(+)
+select count(blogtopic.topicId) from blogtopic blogtopic where blogtopic.closedDate is null  using index blogtopic.my_filter_index(+)
 ===================================================
 0

--- a/sql/_23_apricot_qa/_03_i18n/_01_common/_00_issues/answers/bug_bts_6652.answer
+++ b/sql/_23_apricot_qa/_03_i18n/_01_common/_00_issues/answers/bug_bts_6652.answer
@@ -11,12 +11,11 @@ count(topicId)
 1     
 
 Query plan:
-iscan
+sscan
     class: blogtopic node[?]
-    index: my_filter_index 
     sargs: term[?]
     cost:  ? card ?
 Query stmt:
-select count(blogtopic.topicId) from blogtopic blogtopic where blogtopic.closedDate is null  using index blogtopic.my_filter_index(+)
+select count(*) from blogtopic blogtopic where blogtopic.closedDate is null  using index blogtopic.my_filter_index(+)
 ===================================================
 0

--- a/sql/_34_fig/cbrd_24516/answers/cbrd_24516.answer
+++ b/sql/_34_fig/cbrd_24516/answers/cbrd_24516.answer
@@ -103,11 +103,11 @@ trace
 Query Plan:
   TABLE SCAN (dba.tbl)
 
-  rewritten query: select count([dba.tbl].id), max([dba.tbl].id) from [dba.tbl] [dba.tbl]
+  rewritten query: select count(*), max([dba.tbl].id) from [dba.tbl] [dba.tbl]
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tbl_id)
+    SCAN (table: dba.tbl), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tbl_id)
      
 
 ===================================================
@@ -120,11 +120,11 @@ trace
 Query Plan:
   TABLE SCAN (dba.tbl)
 
-  rewritten query: select count([dba.tbl].a), max([dba.tbl].b) from [dba.tbl] [dba.tbl]
+  rewritten query: select count(*), max([dba.tbl].b) from [dba.tbl] [dba.tbl]
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tbl_id)
      
 
 ===================================================
@@ -137,11 +137,11 @@ trace
 Query Plan:
   TABLE SCAN (dba.tbl)
 
-  rewritten query: select count([dba.tbl].id), min([dba.tbl].id), max([dba.tbl].id) from [dba.tbl] [dba.tbl]
+  rewritten query: select count(*), min([dba.tbl].id), max([dba.tbl].id) from [dba.tbl] [dba.tbl]
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tbl_id)
+    SCAN (table: dba.tbl), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tbl_id)
      
 
 ===================================================
@@ -154,11 +154,11 @@ trace
 Query Plan:
   TABLE SCAN (dba.tbl)
 
-  rewritten query: select count([dba.tbl].a), min([dba.tbl].b), max([dba.tbl].c) from [dba.tbl] [dba.tbl]
+  rewritten query: select count(*), min([dba.tbl].b), max([dba.tbl].c) from [dba.tbl] [dba.tbl]
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tbl_id)
      
 
 ===================================================
@@ -167,11 +167,6 @@ count(*)    max(id)
 
 ===================================================
 trace    
-
-Query Plan:
-  TABLE SCAN (dba.tbl)
-
-  rewritten query: select count(*), max([dba.tbl].id) from [dba.tbl] [dba.tbl]
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -201,11 +196,6 @@ count(*)    min(id)    max(id)
 
 ===================================================
 trace    
-
-Query Plan:
-  TABLE SCAN (dba.tbl)
-
-  rewritten query: select count(*), min([dba.tbl].id), max([dba.tbl].id) from [dba.tbl] [dba.tbl]
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26264

Purpose

count(column) 에서 column이 not null constraint (PK, not null, ...)을 지닌 경우, count(*)로 재작성합니다.