### PR TITLE
[CBRD-26151] Modify db_auth view to show only current user's grantor–grantee privileges, and update TCs accordingly

### DIFF
--- a/sql/_13_issues/_23_1h/answers/cbrd_24419.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24419.answer
@@ -4301,21 +4301,6 @@ c4     t3     U4     INSTANCE     OBJECT     0     0     0     t3_d     U4
 
 ===================================================
 grantor_name    grantee_name    object_type    object_name    owner_name    auth_type    is_grantable    
-U4     U5     CLASS     t1     U4     SELECT     YES     
-U4     U5     CLASS     t2_h     U4     SELECT     YES     
-U4     U5     CLASS     t2_h__p__p0     U4     SELECT     YES     
-U4     U5     CLASS     t2_h__p__p1     U4     SELECT     YES     
-U4     U5     CLASS     t2_l     U4     SELECT     YES     
-U4     U5     CLASS     t2_l__p__p0     U4     SELECT     YES     
-U4     U5     CLASS     t2_l__p__p1     U4     SELECT     YES     
-U4     U5     CLASS     t2_r     U4     SELECT     YES     
-U4     U5     CLASS     t2_r__p__p0     U4     SELECT     YES     
-U4     U5     CLASS     t2_r__p__p1     U4     SELECT     YES     
-U4     U5     CLASS     t3     U4     SELECT     YES     
-U4     U5     CLASS     t4     U4     SELECT     YES     
-U4     U5     CLASS     t5     U4     SELECT     YES     
-U4     U5     CLASS     t5_c     U4     SELECT     YES     
-U4     U5     VCLASS     v1     U4     SELECT     YES     
 U5     U6     CLASS     t1     U4     SELECT     NO     
 U5     U6     CLASS     t2_h     U4     SELECT     NO     
 U5     U6     CLASS     t2_h__p__p0     U4     SELECT     NO     

--- a/sql/_13_issues/_25_1h/answers/cbrd_25923.answer
+++ b/sql/_13_issues/_25_1h/answers/cbrd_25923.answer
@@ -37,7 +37,6 @@ null
 ===================================================
 grantor_name    grantee_name    object_type    object_name    owner_name    auth_type    is_grantable    
 U1     U2     CLASS     tbl1     U1     SELECT     YES     
-U1     U3     CLASS     tbl1     U1     INSERT     YES     
 U2     U3     CLASS     tbl1     U1     SELECT     YES     
 
 ===================================================
@@ -71,7 +70,6 @@ ERROR: UPDATE authorization failure
 Error:-159
 ===================================================
 grantor_name    grantee_name    object_type    object_name    owner_name    auth_type    is_grantable    
-U1     U2     CLASS     tbl1     U1     SELECT     YES     
 U1     U3     CLASS     tbl1     U1     INSERT     YES     
 U2     U3     CLASS     tbl1     U1     SELECT     YES     
 U3     U2     CLASS     tbl1     U1     SELECT     NO     
@@ -391,7 +389,6 @@ ERROR: Cannot issue GRANT/REVOKE to owner of a class
 Error:-146
 ===================================================
 grantor_name    grantee_name    object_type    object_name    owner_name    auth_type    is_grantable    
-U1     U2     CLASS     tbl1     U1     SELECT     YES     
 U1     U3     CLASS     tbl1     U1     INSERT     NO     
 U2     U3     CLASS     tbl1     U1     SELECT     NO     
 

--- a/sql/_35_fig_cake/cbrd_25574/answers/02_drop_last_granted_user.answer
+++ b/sql/_35_fig_cake/cbrd_25574/answers/02_drop_last_granted_user.answer
@@ -40,7 +40,6 @@ null
 grantor_name    grantee_name    object_type    object_name    owner_name    auth_type    is_grantable    
 U1     U2     FUNCTION     hello     U1     EXECUTE     NO     
 U1     U2     CLASS     tbl     U1     SELECT     YES     
-U1     U3     FUNCTION     hello     U1     EXECUTE     NO     
 U2     U3     CLASS     tbl     U1     SELECT     YES     
 
 ===================================================

--- a/sql/_35_fig_cake/cbrd_25574/answers/03_drop_mid_granted_user.answer
+++ b/sql/_35_fig_cake/cbrd_25574/answers/03_drop_mid_granted_user.answer
@@ -78,8 +78,6 @@ null
 0
 ===================================================
 grantor_name    grantee_name    object_type    object_name    owner_name    auth_type    is_grantable    
-U1     U2     CLASS     tbl     U1     INSERT     YES     
-U1     U2     CLASS     tbl     U1     SELECT     YES     
 U1     U3     VCLASS     v1_tbl     U1     SELECT     NO     
 U2     U3     CLASS     tbl     U1     INSERT     NO     
 U2     U3     CLASS     tbl     U1     SELECT     YES     

--- a/sql/_35_fig_cake/grant_revoke_redefine/answers/cbrd_25486_05.answer
+++ b/sql/_35_fig_cake/grant_revoke_redefine/answers/cbrd_25486_05.answer
@@ -126,12 +126,6 @@ success: drop u1.t1_l
 
 ===================================================
 grantor_name    grantee_name    object_type    object_name    owner_name    auth_type    is_grantable    
-U1     U2     CLASS     t1_h     U1     SELECT     YES     
-U1     U2     CLASS     t1_h__p__p0     U1     SELECT     YES     
-U1     U2     CLASS     t1_h__p__p1     U1     SELECT     YES     
-U1     U2     CLASS     t1_r     U1     SELECT     YES     
-U1     U2     CLASS     t1_r__p__p0     U1     SELECT     YES     
-U1     U2     CLASS     t1_r__p__p1     U1     SELECT     YES     
 U2     U3     CLASS     t1_h     U1     SELECT     YES     
 U2     U3     CLASS     t1_h__p__p0     U1     SELECT     YES     
 U2     U3     CLASS     t1_h__p__p1     U1     SELECT     YES     

--- a/sql/_35_fig_cake/grant_revoke_redefine/answers/cbrd_25582.answer
+++ b/sql/_35_fig_cake/grant_revoke_redefine/answers/cbrd_25582.answer
@@ -74,8 +74,6 @@ null
 0
 ===================================================
 grantor_name    grantee_name    object_type    object_name    owner_name    auth_type    is_grantable    
-U1     U2     CLASS     tbl     U1     SELECT     YES     
-U2     U3     CLASS     tbl     U1     SELECT     YES     
 U3     U4     CLASS     tbl     U1     SELECT     YES     
 U4     U5     CLASS     tbl     U1     SELECT     YES     
 
@@ -158,9 +156,6 @@ null
 0
 ===================================================
 grantor_name    grantee_name    object_type    object_name    owner_name    auth_type    is_grantable    
-U1     U2     CLASS     tbl     U1     SELECT     YES     
-U1     U3     CLASS     tbl     U1     SELECT     YES     
-U2     U3     CLASS     tbl     U1     SELECT     YES     
 U3     U4     CLASS     tbl     U1     SELECT     YES     
 U4     U5     CLASS     tbl     U1     SELECT     YES     
 
@@ -239,14 +234,6 @@ null
 0
 ===================================================
 grantor_name    grantee_name    object_type    object_name    owner_name    auth_type    is_grantable    
-U1     U2     CLASS     tbl     U1     ALTER     YES     
-U1     U2     CLASS     tbl     U1     DELETE     YES     
-U1     U2     CLASS     tbl     U1     EXECUTE     YES     
-U1     U2     CLASS     tbl     U1     INDEX     YES     
-U1     U2     CLASS     tbl     U1     INSERT     YES     
-U1     U2     CLASS     tbl     U1     SELECT     YES     
-U1     U2     CLASS     tbl     U1     UPDATE     YES     
-U2     U3     CLASS     tbl     U1     SELECT     YES     
 U3     U4     CLASS     tbl     U1     SELECT     YES     
 U4     U5     CLASS     tbl     U1     SELECT     YES     
 
@@ -456,18 +443,9 @@ Error:-146
 0
 ===================================================
 grantor_name    grantee_name    object_type    object_name    owner_name    auth_type    is_grantable    
-U1     U2     CLASS     tbl     U1     SELECT     YES     
-U1     U3     CLASS     tbl     U1     SELECT     YES     
-U1     U4     CLASS     tbl     U1     SELECT     YES     
 U1     U5     CLASS     tbl     U1     SELECT     YES     
-U2     U3     CLASS     tbl     U1     SELECT     YES     
-U2     U4     CLASS     tbl     U1     SELECT     YES     
 U2     U5     CLASS     tbl     U1     SELECT     YES     
-U3     U2     CLASS     tbl     U1     SELECT     YES     
-U3     U4     CLASS     tbl     U1     SELECT     YES     
 U3     U5     CLASS     tbl     U1     SELECT     YES     
-U4     U2     CLASS     tbl     U1     SELECT     YES     
-U4     U3     CLASS     tbl     U1     SELECT     YES     
 U4     U5     CLASS     tbl     U1     SELECT     YES     
 U5     U2     CLASS     tbl     U1     SELECT     YES     
 U5     U3     CLASS     tbl     U1     SELECT     YES     


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26151

### Purpose
테스트 케이스(TC) 수정 중 발견된 이슈입니다. (CBRD-25923)
CUBRID 9.3 ~ 11.4 버전에서 db_auth 뷰는 로그인 사용자가 테이블에 SELECT 권한만 보유해도 해당 테이블의 모든 권한이 출력되는 문제가 있습니다. (Stored procedure의 경우에도 EXECUTE 권한만 있어도 동일한 문제가 발생합니다.)

이를 해결하기 위해 db_auth 뷰를 수정하여, 로그인 사용자(CURRENT_USER)가 grantor 또는 grantee로 참여하는 권한만 반환하도록 범위를 제한했습니다.

수정 후 동작은 다음 네 가지 경우로 구분됩니다.
1. DBA 또는 DBA 그룹 멤버
    - 모든 객체의 권한을 확인할 수 있어야 한다.
2. OWNER 또는 OWNER 그룹 멤버
    - 자신이 소유한 객체에 대해서만 모든 권한을 확인할 수 있어야 한다.
    - OWNER 그룹 멤버는 OWNER의 객체에 대해 모든 권한을 확인할 수 있다.
3. Grantor
    - 로그인한 사용자가 부여한 권한(grantor)인 경우 해당 권한을 확인할 수 있어야 한다.
4. Grantee
    - 로그인한 사용자가 부여받은 권한(grantee)인 경우 해당 권한을 확인할 수 있어야 한다.