### PR TITLE
[CBRD-25785] Problem with view merging when ORDER BY clause in the subquery and the main query, and rownum is in the main query select list

### DIFF
--- a/sql/_13_issues/_12_1h/answers/bug_bts_6060.answer
+++ b/sql/_13_issues/_12_1h/answers/bug_bts_6060.answer
@@ -125,11 +125,11 @@ orderby_num()    event_code    athlete    host_year    score    unit
 
 ===================================================
 inst_num()    event_code    athlete    host_year    score    unit    
-4     20012     Ngeny Noah     2000     3     time     
-3     20017     Korzeniowski Robert     2000     1     time     
-2     20043     Zelezny Jan     2000     90     meter     
-5     20048     Takahashi Naoko     2000     2     time     
-1     20284     Thorpe Ian     2000     3     time     
+1     20012     Ngeny Noah     2000     3     time     
+2     20017     Korzeniowski Robert     2000     1     time     
+3     20043     Zelezny Jan     2000     90     meter     
+4     20048     Takahashi Naoko     2000     2     time     
+5     20284     Thorpe Ian     2000     3     time     
 
 ===================================================
 orderby_num()    host_year    

--- a/sql/_18_index_enhancement_qa/_02_full_test/_06_optimizing_limit/answers/_54_topn_create_view.answer
+++ b/sql/_18_index_enhancement_qa/_02_full_test/_06_optimizing_limit/answers/_54_topn_create_view.answer
@@ -118,10 +118,19 @@ temp(order by)
     subplan: sscan
                  class: v node[?]
                  cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select v.id from t v order by ?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v node[?]
+                 cost:  ? card ?
     sort:  ? desc
     cost:  ? card ?
 Query stmt:
-select v.id from t v order by ? desc  for orderby_num()<= ?:? 
+select v.id from (select v.id from t v order by ?) v (id) order by ? desc  for orderby_num()<= ?:? 
 ===================================================
 0
 ===================================================

--- a/sql/_31_cherry/issue_22162_more_json_functions/answers/json_table_group_concat.answer
+++ b/sql/_31_cherry/issue_22162_more_json_functions/answers/json_table_group_concat.answer
@@ -23,6 +23,15 @@ i    j    i    j    k    a    b
 
 Query plan:
 temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select v?.i, v?.j, (v?.i+v?.j) from foo v? order by ?)
+Query plan:
+temp(order by)
     subplan: nl-join (cross join)
                  outer: nl-join (cross join)
                             outer: sscan
@@ -39,7 +48,7 @@ temp(order by)
     sort:  ? asc, ? desc, ? asc, ? asc, ? asc, ? asc, ? asc
     cost:  ? card ?
 Query stmt:
-select foo.i, foo.j, v?.i, v?.j, (v?.i+v?.j), jt.a, jt.b from foo foo, foo v?, (json_table ('[ {"a": ?, "b": [?,?]}, {"a": ?, "b": [?,?]}, {"a":?}]', '$[*]' columns (a integer PATH '$."a"' NULL ON EMPTY NULL ON ERROR, nested path '$."b"[*]' columns (b integer PATH '$' NULL ON EMPTY NULL ON ERROR ) )) as jt) order by ?, ? desc , ?, ?, ?, ?, ? for orderby_num()<= ?:? 
+select foo.i, foo.j, v?.i, v?.j, v?.k, jt.a, jt.b from foo foo, (select v?.i, v?.j, (v?.i+v?.j) from foo v? order by ?) v? (i, j, k), (json_table ('[ {"a": ?, "b": [?,?]}, {"a": ?, "b": [?,?]}, {"a":?}]', '$[*]' columns (a integer PATH '$."a"' NULL ON EMPTY NULL ON ERROR, nested path '$."b"[*]' columns (b integer PATH '$' NULL ON EMPTY NULL ON ERROR ) )) as jt) order by ?, ? desc , ?, ?, ?, ?, ? for orderby_num()<= ?:? 
 ===================================================
 count(foo.i)    group_concat(distinct jt.a)    b    
 9     3     null     


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25785

backport #2055

If the subquery has an ORDER BY clause, and the main query has rownum and orderby_num(), the result will be affected by the data order. In this case, modify it so that it is not view merged.
```
as-is: Check whether WHERE of the subquery has rownum
to-be: Check the subquery's select-list and where clause
```
