### PR TITLE
[CBRD-25975] Modified a sql test case to ensure evaluate statements with special characters don't cause issues in non-local environments

### DIFF
--- a/sql/_13_issues/_25_2h/answers/cbrd_25975.answer
+++ b/sql/_13_issues/_25_2h/answers/cbrd_25975.answer
@@ -146,7 +146,7 @@ Query stmt:
 select tbl_a.col_a from tbl_a tbl_a
 ===================================================
     
-8 - Foreign language: [SELECT /*+ recompile use_hash (ááááá) */ * FROM tbl_a;]     
+8 - Foreign language: [SELECT /*+ recompile use_hash (~~~~~) */ * FROM tbl_a;]     
 
 ===================================================
 col_a    
@@ -719,7 +719,7 @@ Error:-493
 1
 ===================================================
     
-24 - Korean identifiers: [SELECT /*+ recompile use_hash("íì´ë¸","ì¡°ì¸") */ * FROM "íì´ë¸" JOIN "ì¡°ì¸" USING (col_d);]     
+24 - Korean identifiers: [SELECT /*+ recompile use_hash("~~~","~~") */ * FROM "~~~" JOIN "~~" USING (col_d);]     
 
 ===================================================
 Error:-493

--- a/sql/_13_issues/_25_2h/cases/cbrd_25975.sql
+++ b/sql/_13_issues/_25_2h/cases/cbrd_25975.sql
@@ -44,7 +44,7 @@ evaluate '7 - Special characters: [SELECT /*+ recompile use_hash(@!$%) */ * FROM
 -- Expected: Hint ignored; no crash
 SELECT /*+ recompile use_hash(@!$%) */ * FROM tbl_a;
 
-evaluate '8 - Foreign language: [SELECT /*+ recompile use_hash (កខគឃង) */ * FROM tbl_a;]';
+evaluate '8 - Foreign language: [SELECT /*+ recompile use_hash (~~~~~) */ * FROM tbl_a;]';
 -- Expected : Query runs normally; no effect
 SELECT /*+ recompile use_hash (កខគឃង) */ * FROM tbl_a;
 
@@ -187,7 +187,7 @@ CREATE TABLE "조인" (col_d INT);
 INSERT INTO "테이블" VALUES (1);
 INSERT INTO "조인" VALUES (1);
 
-evaluate '24 - Korean identifiers: [SELECT /*+ recompile use_hash("테이블","조인") */ * FROM "테이블" JOIN "조인" USING (col_d);]';
+evaluate '24 - Korean identifiers: [SELECT /*+ recompile use_hash("~~~","~~") */ * FROM "~~~" JOIN "~~" USING (col_d);]';
 -- Expected: Runs if Unicode identifiers supported or else syntax error
 SELECT /*+ recompile use_hash("테이블","조인") */ * FROM "테이블" JOIN "조인" USING (col_d);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25975

Original PR: https://github.com/CUBRID/cubrid-testcases/pull/2269

현재 evaluate문의 answer 파일 출력형태가 circleCI 환경에서는 예상이랑 다르게 나와서 수정을 진행합니다.

https://app.circleci.com/pipelines/github/CUBRID/cubrid/22319/workflows/4f721407-c50b-4c51-8297-f5af4db7f151/jobs/104107/tests
