### PR TITLE
[CBRD-26265] Remove redundant IS NOT NULL predicates on columns declared NOT NULL

### DIFF
--- a/sql/_13_issues/_12_2h/answers/bug_bts_7088.answer
+++ b/sql/_13_issues/_12_2h/answers/bug_bts_7088.answer
@@ -3449,11 +3449,10 @@ j    k    l
 Query plan:
 iscan
     class: t node[?]
-    index: idx term[?] AND term[?] (index skip scan)
-    sargs: term[?]
+    index: idx term[?] AND term[?] (covers) (index skip scan)
     cost:  ? card ?
 Query stmt:
-select /*+ INDEX_SS */ t.j, t.k, t.l from t t where t.i is not null  and t.k= ?:?  and t.j= ?:? 
+select /*+ INDEX_SS */ t.j, t.k, t.l from t t where t.k= ?:?  and t.j= ?:? 
 ===================================================
 j    k    l    
 

--- a/sql/_13_issues/_23_1h/answers/cbrd_24843_4.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24843_4.answer
@@ -142,7 +142,7 @@ Query Plan:
     TABLE SCAN (p)
     INDEX SCAN (c.fk_t_child_p_a_p_b) (key range: c.p_b=p.bkey range: c.p_a=p.a)
 
-  rewritten query: select c.a, c.b, c.p_a, c.p_b from [dba.t_parent] p, [dba.t_child] c where  cast(p.a as varchar) like  cast(? as varchar) and c.p_a=p.a and c.p_b=p.b
+  rewritten query: select c.a, c.b, c.p_a, c.p_b from [dba.t_parent] p, [dba.t_child] c where  cast(p.a as varchar)= cast(? as varchar) and c.p_a=p.a and c.p_b=p.b
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -162,7 +162,7 @@ Query Plan:
     TABLE SCAN (p)
     INDEX SCAN (c.fk_t_child_p_a_p_b) (key range: c.p_a=p.akey range: c.p_b=p.b)
 
-  rewritten query: select c.a, c.b, c.p_a, c.p_b from [dba.t_child] c, [dba.t_parent] p where c.p_a=p.a and c.p_b=p.b and  cast(p.a as varchar) like  cast(? as varchar)
+  rewritten query: select c.a, c.b, c.p_a, c.p_b from [dba.t_child] c, [dba.t_parent] p where c.p_a=p.a and c.p_b=p.b and  cast(p.a as varchar)= cast(? as varchar)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)

--- a/sql/_18_index_enhancement_qa/_02_full_test/_08_ordering_index/answers/_t113_01_all_types.answer
+++ b/sql/_18_index_enhancement_qa/_02_full_test/_08_ordering_index/answers/_t113_01_all_types.answer
@@ -45,11 +45,10 @@ Query plan:
 iscan
     class: t node[?]
     index: i_t_smallint 
-    filtr: term[?]
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t where t.col_smallint is not null  order by ?
+select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t order by ?
 /* ---> skip ORDER BY */
 ===================================================
 col_smallint    col_integer    col_bigint    col_float    col_double    col_monetary    col_numeric_9_2    col_char_9    col_varchar_92    col_string    col_nchar_9    col_nvarnchar_92    col_date    col_time    col_timestamp    col_datetime    col_bit    col_varbit    col_set    col_set_int    col_seq    col_multiset    
@@ -58,11 +57,10 @@ Query plan:
 iscan
     class: t node[?]
     index: i_t_integer 
-    filtr: term[?]
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t where t.col_integer is not null  order by ?
+select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t order by ?
 /* ---> skip ORDER BY */
 ===================================================
 col_smallint    col_integer    col_bigint    col_float    col_double    col_monetary    col_numeric_9_2    col_char_9    col_varchar_92    col_string    col_nchar_9    col_nvarnchar_92    col_date    col_time    col_timestamp    col_datetime    col_bit    col_varbit    col_set    col_set_int    col_seq    col_multiset    
@@ -71,11 +69,10 @@ Query plan:
 iscan
     class: t node[?]
     index: i_t_bigint 
-    filtr: term[?]
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t where t.col_bigint is not null  order by ?
+select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t order by ?
 /* ---> skip ORDER BY */
 ===================================================
 col_smallint    col_integer    col_bigint    col_float    col_double    col_monetary    col_numeric_9_2    col_char_9    col_varchar_92    col_string    col_nchar_9    col_nvarnchar_92    col_date    col_time    col_timestamp    col_datetime    col_bit    col_varbit    col_set    col_set_int    col_seq    col_multiset    
@@ -84,11 +81,10 @@ Query plan:
 iscan
     class: t node[?]
     index: i_t_float 
-    filtr: term[?]
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t where t.col_float is not null  order by ?
+select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t order by ?
 /* ---> skip ORDER BY */
 ===================================================
 col_smallint    col_integer    col_bigint    col_float    col_double    col_monetary    col_numeric_9_2    col_char_9    col_varchar_92    col_string    col_nchar_9    col_nvarnchar_92    col_date    col_time    col_timestamp    col_datetime    col_bit    col_varbit    col_set    col_set_int    col_seq    col_multiset    
@@ -110,11 +106,10 @@ Query plan:
 iscan
     class: t node[?]
     index: i_t_monetary 
-    filtr: term[?]
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t where t.col_monetary is not null  order by ?
+select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t order by ?
 /* ---> skip ORDER BY */
 ===================================================
 col_smallint    col_integer    col_bigint    col_float    col_double    col_monetary    col_numeric_9_2    col_char_9    col_varchar_92    col_string    col_nchar_9    col_nvarnchar_92    col_date    col_time    col_timestamp    col_datetime    col_bit    col_varbit    col_set    col_set_int    col_seq    col_multiset    
@@ -136,11 +131,10 @@ Query plan:
 iscan
     class: t node[?]
     index: i_t_char_? 
-    filtr: term[?]
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t where t.col_char_? is not null  order by ?
+select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t order by ?
 /* ---> skip ORDER BY */
 ===================================================
 col_smallint    col_integer    col_bigint    col_float    col_double    col_monetary    col_numeric_9_2    col_char_9    col_varchar_92    col_string    col_nchar_9    col_nvarnchar_92    col_date    col_time    col_timestamp    col_datetime    col_bit    col_varbit    col_set    col_set_int    col_seq    col_multiset    
@@ -162,11 +156,10 @@ Query plan:
 iscan
     class: t node[?]
     index: i_t_string 
-    filtr: term[?]
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t where t.col_string is not null  order by ?
+select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t order by ?
 /* ---> skip ORDER BY */
 ===================================================
 col_smallint    col_integer    col_bigint    col_float    col_double    col_monetary    col_numeric_9_2    col_char_9    col_varchar_92    col_string    col_nchar_9    col_nvarnchar_92    col_date    col_time    col_timestamp    col_datetime    col_bit    col_varbit    col_set    col_set_int    col_seq    col_multiset    
@@ -201,11 +194,10 @@ Query plan:
 iscan
     class: t node[?]
     index: i_t_date 
-    filtr: term[?]
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t where t.col_date is not null  order by ?
+select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t order by ?
 /* ---> skip ORDER BY */
 ===================================================
 col_smallint    col_integer    col_bigint    col_float    col_double    col_monetary    col_numeric_9_2    col_char_9    col_varchar_92    col_string    col_nchar_9    col_nvarnchar_92    col_date    col_time    col_timestamp    col_datetime    col_bit    col_varbit    col_set    col_set_int    col_seq    col_multiset    
@@ -214,11 +206,10 @@ Query plan:
 iscan
     class: t node[?]
     index: i_t_time 
-    filtr: term[?]
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t where t.col_time is not null  order by ?
+select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t order by ?
 /* ---> skip ORDER BY */
 ===================================================
 col_smallint    col_integer    col_bigint    col_float    col_double    col_monetary    col_numeric_9_2    col_char_9    col_varchar_92    col_string    col_nchar_9    col_nvarnchar_92    col_date    col_time    col_timestamp    col_datetime    col_bit    col_varbit    col_set    col_set_int    col_seq    col_multiset    
@@ -253,11 +244,10 @@ Query plan:
 iscan
     class: t node[?]
     index: i_t_bit 
-    filtr: term[?]
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t where t.col_bit is not null  order by ?
+select t.col_smallint, t.col_integer, t.col_bigint, t.col_float, t.col_double, t.col_monetary, t.col_numeric_?_?, t.col_char_?, t.col_varchar_?, t.col_string, t.col_nchar_?, t.col_nvarnchar_?, t.col_date, t.col_time, t.col_timestamp, t.col_datetime, t.col_bit, t.col_varbit, t.col_set, t.col_set_int, t.col_seq, t.col_multiset from t t order by ?
 /* ---> skip ORDER BY */
 ===================================================
 col_smallint    col_integer    col_bigint    col_float    col_double    col_monetary    col_numeric_9_2    col_char_9    col_varchar_92    col_string    col_nchar_9    col_nvarnchar_92    col_date    col_time    col_timestamp    col_datetime    col_bit    col_varbit    col_set    col_set_int    col_seq    col_multiset    

--- a/sql/_19_apricot/_03_index_skip_scan/answers/_01_iss_basics.answer
+++ b/sql/_19_apricot/_03_index_skip_scan/answers/_01_iss_basics.answer
@@ -3492,10 +3492,9 @@ Query plan:
 iscan
     class: t node[?]
     index: idx term[?] AND term[?] (covers) (index skip scan)
-    filtr: term[?]
     cost:  ? card ?
 Query stmt:
-select /*+ INDEX_SS */ t.i, t.j, t.k, t.l from t t where t.i is not null  and t.k= ?:?  and t.j= ?:? 
+select /*+ INDEX_SS */ t.i, t.j, t.k, t.l from t t where t.k= ?:?  and t.j= ?:? 
 ===================================================
 i    j    k    l    
 

--- a/sql/_23_apricot_qa/_02_performance/_01_filtered_index/answers/filtered_index_constrain_notnull.answer
+++ b/sql/_23_apricot_qa/_02_performance/_01_filtered_index/answers/filtered_index_constrain_notnull.answer
@@ -65,10 +65,9 @@ Query plan:
 iscan
     class: tb node[?]
     index: i_tb_all (covers)
-    filtr: term[?]
     cost:  ? card ?
 Query stmt:
-select tb.b from tb tb where tb.a is not null  using index tb.i_tb_all(+)
+select tb.b from tb tb using index tb.i_tb_all(+)
 ===================================================
 b    
 1     

--- a/sql/_23_apricot_qa/_02_performance/_01_filtered_index/answers/filtered_index_constrain_pk.answer
+++ b/sql/_23_apricot_qa/_02_performance/_01_filtered_index/answers/filtered_index_constrain_pk.answer
@@ -38,10 +38,9 @@ Query plan:
 iscan
     class: tb node[?]
     index: i_tb_all (covers)
-    filtr: term[?]
     cost:  ? card ?
 Query stmt:
-select tb.a, tb.b from tb tb where tb.a is not null  using index tb.i_tb_all(+)
+select tb.a, tb.b from tb tb using index tb.i_tb_all(+)
 ===================================================
 a    b    
 1     1     

--- a/sql/_23_apricot_qa/_02_performance/_01_filtered_index/answers/filtered_index_select_basic_007.answer
+++ b/sql/_23_apricot_qa/_02_performance/_01_filtered_index/answers/filtered_index_select_basic_007.answer
@@ -181,11 +181,11 @@ Query plan:
 iscan
     class: tb node[?]
     index: i_tb_all (covers)
-    filtr: term[?] AND term[?]
+    filtr: term[?]
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select tb.a from tb tb where (tb.b> ?:? ) and tb.a is not null  using index tb.i_tb_a(+), tb.i_tb_all(+), tb.i_tb_b(+) order by ?
+select tb.a from tb tb where (tb.b> ?:? ) using index tb.i_tb_a(+), tb.i_tb_all(+), tb.i_tb_b(+) order by ?
 /* ---> skip ORDER BY */
 ===================================================
 a    
@@ -195,12 +195,11 @@ Query plan:
 iscan
     class: tb node[?]
     index: i_tb_a  (desc_index)
-    filtr: term[?]
     sargs: term[?]
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select tb.a from tb tb where (tb.b> ?:? ) and tb.a is not null  using index tb.i_tb_a(+), tb.i_tb_b(+) order by ?
+select tb.a from tb tb where (tb.b> ?:? ) using index tb.i_tb_a(+), tb.i_tb_b(+) order by ?
 /* ---> skip ORDER BY */
 ===================================================
 b    
@@ -225,12 +224,11 @@ temp(order by)
     subplan: iscan
                  class: tb node[?]
                  index: i_tb_all term[?] (covers)
-                 filtr: term[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select tb.b from tb tb where (tb.a> ?:? ) and tb.b is not null  using index tb.i_tb_a(+), tb.i_tb_all(+), tb.i_tb_b(+) order by ?
+select tb.b from tb tb where (tb.a> ?:? ) using index tb.i_tb_a(+), tb.i_tb_all(+), tb.i_tb_b(+) order by ?
 ===================================================
 0
 ===================================================


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26265
https://github.com/CUBRID/cubrid/pull/6401

NOT NULL 인 컬럼에 대해  `IS NOT NULL` 조건절이 사용되었다면, 의미 없으므로 해당 조건절은 제거될 수 있도록 수정했습니다.
NOT NULL 인 컬럼에 대해 `LIKE '%'` 조건절을 사용한 경우, `IS NOT NULL` 로 재작성되고, 제거될 수 있도록 수정했습니다.
이로 인해 다르게 출력되는 실행계획을 수정합니다.

