### PR TITLE
[CBRD-26313] Backport from develop to 11.4 - Added Test Case for CBRD-26257, CBRD-26313

### DIFF
--- a/sql/_33_elderberry/cbrd_24042/cbrd_26257/answers/cbrd_26257.answer
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_26257/answers/cbrd_26257.answer
@@ -78,12 +78,19 @@ rn    cola    colb
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: Z node[?]
+                 class: a node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select (orderby_num()), Z.cola, Z.colb from ta Z order by ? for (orderby_num()) between  ?:?  and  ?:? 
+(select (orderby_num()), a.cola, a.colb from ta a order by ?)
+Query plan:
+sscan
+    class: Z node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+select Z.rn, Z.cola, Z.colb from (select (orderby_num()), a.cola, a.colb from ta a order by ?) Z (rn, cola, colb) where (Z.rn>= ?:?  and Z.rn<= ?:? )
 ===================================================
     
 4. Basic BETWEEN with constant range     
@@ -104,12 +111,19 @@ rn    cola    colb
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: Z node[?]
+                 class: a node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select (orderby_num()), Z.cola, Z.colb from ta Z order by ? for (orderby_num()) between  ?:?  and  ?:? 
+(select (orderby_num()), a.cola, a.colb from ta a order by ?)
+Query plan:
+sscan
+    class: Z node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+select Z.rn, Z.cola, Z.colb from (select (orderby_num()), a.cola, a.colb from ta a order by ?) Z (rn, cola, colb) where (Z.rn>= ?:?  and Z.rn<= ?:? )
 ===================================================
     
 5. Single-row range (BETWEEN same values)     
@@ -121,12 +135,19 @@ rn    cola    colb
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: Z node[?]
+                 class: a node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select (orderby_num()), Z.cola, Z.colb from ta Z order by ? for (orderby_num()) between  ?:?  and  ?:? 
+(select (orderby_num()), a.cola, a.colb from ta a order by ?)
+Query plan:
+sscan
+    class: Z node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+select Z.rn, Z.cola, Z.colb from (select (orderby_num()), a.cola, a.colb from ta a order by ?) Z (rn, cola, colb) where (Z.rn>= ?:?  and Z.rn<= ?:? )
 ===================================================
     
 6. BETWEEN including NULL     
@@ -137,12 +158,19 @@ rn    cola    colb
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: Z node[?]
+                 class: a node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select (orderby_num()), Z.cola, Z.colb from ta Z order by ? for (orderby_num()) between null and  ?:? 
+(select (orderby_num()), a.cola, a.colb from ta a order by ?)
+Query plan:
+sscan
+    class: Z node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+select Z.rn, Z.cola, Z.colb from (select (orderby_num()), a.cola, a.colb from ta a order by ?) Z (rn, cola, colb) where (Z.rn>=null and Z.rn<= ?:? )
 ===================================================
     
 7. Combined with additional condition (filter first)     
@@ -262,15 +290,6 @@ select Z.cola from (select a.cola, (orderby_num()) from ta a order by ?) Z (cola
 ===================================================
 rn    cola    colb    
 
-Query plan:
-temp(order by)
-    subplan: sscan
-                 class: Z node[?]
-                 cost:  ? card ?
-    sort:  ? asc
-    cost:  ? card ?
-Query stmt:
-select (orderby_num()), Z.cola, Z.colb from ta Z order by ? for (orderby_num()) between  ?:?  and  ?:? 
 ===================================================
     
 12. BETWEEN with negative and positive range     
@@ -286,12 +305,19 @@ rn    cola    colb
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: Z node[?]
+                 class: a node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select (orderby_num()), Z.cola, Z.colb from ta Z order by ? for (orderby_num()) between  ?:?  and  ?:? 
+(select (orderby_num()), a.cola, a.colb from ta a order by ?)
+Query plan:
+sscan
+    class: Z node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+select Z.rn, Z.cola, Z.colb from (select (orderby_num()), a.cola, a.colb from ta a order by ?) Z (rn, cola, colb) where (Z.rn>= ?:?  and Z.rn<= ?:? )
 ===================================================
     
 13. BETWEEN combined with OR condition     
@@ -363,7 +389,7 @@ Query plan:
 temp(order by)
     subplan: idx-join (inner join)
                  outer: sscan
-                            class: Z node[?]
+                            class: a node[?]
                             cost:  ? card ?
                  inner: iscan
                             class: tb node[?]
@@ -373,7 +399,14 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select (orderby_num()), Z.cola, Z.colb from ta Z, tb tb where Z.cola=tb.k order by ? for (orderby_num()) between  ?:?  and  ?:? 
+(select (orderby_num()), a.cola, a.colb from ta a, tb tb where a.cola=tb.k order by ?)
+Query plan:
+sscan
+    class: Z node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+select Z.rn, Z.cola, Z.colb from (select (orderby_num()), a.cola, a.colb from ta a, tb tb where a.cola=tb.k order by ?) Z (rn, cola, colb) where (Z.rn>= ?:?  and Z.rn<= ?:? )
 ===================================================
     
 15. BETWEEN with expressions instead of constants     
@@ -433,6 +466,15 @@ rn    cola    colb
 51     51     51     
 
 Query plan:
+temp(order by)
+    subplan: sscan
+                 class: a node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select (orderby_num()), a.cola, a.colb from ta a order by ?)
+Query plan:
 sscan
     class: tb node[?]
     cost:  ? card ?
@@ -445,14 +487,12 @@ sscan
 Query stmt:
 (select max(tb.k) from tb tb)
 Query plan:
-temp(order by)
-    subplan: sscan
-                 class: Z node[?]
-                 cost:  ? card ?
-    sort:  ? asc
+sscan
+    class: Z node[?]
+    sargs: term[?]
     cost:  ? card ?
 Query stmt:
-select (orderby_num()), Z.cola, Z.colb from ta Z order by ? for (orderby_num()) between (select min(tb.k) from tb tb) and (select max(tb.k) from tb tb)
+select Z.rn, Z.cola, Z.colb from (select (orderby_num()), a.cola, a.colb from ta a order by ?) Z (rn, cola, colb) where (Z.rn>=(select min(tb.k) from tb tb) and Z.rn<=(select max(tb.k) from tb tb))
 ===================================================
     
 16. Prepared statement with AND range     
@@ -505,12 +545,19 @@ rn    cola    colb
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: Z node[?]
+                 class: a node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select (orderby_num()), Z.cola, Z.colb from ta Z order by ? for (orderby_num()) between  ?:?  and  ?:? 
+(select (orderby_num()), a.cola, a.colb from ta a order by ?)
+Query plan:
+sscan
+    class: Z node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+select Z.rn, Z.cola, Z.colb from (select (orderby_num()), a.cola, a.colb from ta a order by ?) Z (rn, cola, colb) where (Z.rn>= ?:?  and Z.rn<= ?:? )
 ===================================================
 0
 ===================================================

--- a/sql/_33_elderberry/cbrd_24042/cbrd_26257/answers/cbrd_26257.answer
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_26257/answers/cbrd_26257.answer
@@ -1,0 +1,551 @@
+===================================================
+0
+===================================================
+0
+===================================================
+1000
+===================================================
+    
+1. Range condition using AND     
+
+===================================================
+rn    cola    colb    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: Z node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), Z.cola, Z.colb from ta Z order by ? for (orderby_num())>= ?:?  and (orderby_num())<= ?:? 
+===================================================
+    
+2. Condition with additional filters (excluding ROWNUM)     
+
+===================================================
+rn    cola    colb    
+2     2     2     
+4     4     4     
+6     6     6     
+8     8     8     
+10     10     10     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: a node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select (orderby_num()), a.cola, a.colb from ta a order by ?)
+Query plan:
+sscan
+    class: Z node[?]
+    sargs: term[?] AND term[?]
+    cost:  ? card ?
+Query stmt:
+select Z.rn, Z.cola, Z.colb from (select (orderby_num()), a.cola, a.colb from ta a order by ?) Z (rn, cola, colb) where (Z.rn>= ?:?  and Z.rn<= ?:? ) and Z.colb mod ?=?
+===================================================
+    
+3. BETWEEN expression (constant + arithmetic)     
+
+===================================================
+rn    cola    colb    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: Z node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), Z.cola, Z.colb from ta Z order by ? for (orderby_num()) between  ?:?  and  ?:? 
+===================================================
+    
+4. Basic BETWEEN with constant range     
+
+===================================================
+rn    cola    colb    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: Z node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), Z.cola, Z.colb from ta Z order by ? for (orderby_num()) between  ?:?  and  ?:? 
+===================================================
+    
+5. Single-row range (BETWEEN same values)     
+
+===================================================
+rn    cola    colb    
+100     100     100     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: Z node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), Z.cola, Z.colb from ta Z order by ? for (orderby_num()) between  ?:?  and  ?:? 
+===================================================
+    
+6. BETWEEN including NULL     
+
+===================================================
+rn    cola    colb    
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: Z node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), Z.cola, Z.colb from ta Z order by ? for (orderby_num()) between null and  ?:? 
+===================================================
+    
+7. Combined with additional condition (filter first)     
+
+===================================================
+rn    cola    colb    
+52     52     52     
+54     54     54     
+56     56     56     
+58     58     58     
+60     60     60     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: a node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select (orderby_num()), a.cola, a.colb from ta a order by ?)
+Query plan:
+sscan
+    class: Z node[?]
+    sargs: term[?] AND term[?]
+    cost:  ? card ?
+Query stmt:
+select Z.rn, Z.cola, Z.colb from (select (orderby_num()), a.cola, a.colb from ta a order by ?) Z (rn, cola, colb) where Z.colb mod ?=? and (Z.rn>= ?:?  and Z.rn<= ?:? )
+===================================================
+    
+8. Combined with additional condition (between first)     
+
+===================================================
+rn    cola    colb    
+52     52     52     
+54     54     54     
+56     56     56     
+58     58     58     
+60     60     60     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: a node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select (orderby_num()), a.cola, a.colb from ta a order by ?)
+Query plan:
+sscan
+    class: Z node[?]
+    sargs: term[?] AND term[?]
+    cost:  ? card ?
+Query stmt:
+select Z.rn, Z.cola, Z.colb from (select (orderby_num()), a.cola, a.colb from ta a order by ?) Z (rn, cola, colb) where (Z.rn>= ?:?  and Z.rn<= ?:? ) and Z.colb mod ?=?
+===================================================
+    
+9. Two BETWEEN predicates (ROWNUM + column)     
+
+===================================================
+rn    cola    colb    
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: a node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select (orderby_num()), a.cola, a.colb from ta a order by ?)
+Query plan:
+sscan
+    class: Z node[?]
+    sargs: term[?] AND term[?]
+    cost:  ? card ?
+Query stmt:
+select Z.rn, Z.cola, Z.colb from (select (orderby_num()), a.cola, a.colb from ta a order by ?) Z (rn, cola, colb) where (Z.rn>= ?:?  and Z.rn<= ?:? ) and (Z.cola>= ?:?  and Z.cola<= ?:? )
+===================================================
+    
+10. BETWEEN in WHERE + HAVING (groupby_num)     
+
+===================================================
+cola    
+19     
+18     
+17     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: a node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select a.cola, (orderby_num()) from ta a order by ?)
+Query plan:
+temp(group by)
+    subplan: sscan
+                 class: Z node[?]
+                 sargs: term[?]
+                 cost:  ? card ?
+    sort:  ? desc
+    cost:  ? card ?
+Query stmt:
+select Z.cola from (select a.cola, (orderby_num()) from ta a order by ?) Z (cola, rn) where (Z.rn>= ?:?  and Z.rn<= ?:? ) group by Z.cola desc  having groupby_num() between ? and ?
+===================================================
+    
+11. Reversed BETWEEN boundaries     
+
+===================================================
+rn    cola    colb    
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: Z node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), Z.cola, Z.colb from ta Z order by ? for (orderby_num()) between  ?:?  and  ?:? 
+===================================================
+    
+12. BETWEEN with negative and positive range     
+
+===================================================
+rn    cola    colb    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: Z node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), Z.cola, Z.colb from ta Z order by ? for (orderby_num()) between  ?:?  and  ?:? 
+===================================================
+    
+13. BETWEEN combined with OR condition     
+
+===================================================
+rn    cola    colb    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+50     50     50     
+51     51     51     
+52     52     52     
+53     53     53     
+54     54     54     
+55     55     55     
+56     56     56     
+57     57     57     
+58     58     58     
+59     59     59     
+60     60     60     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: a node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select (orderby_num()), a.cola, a.colb from ta a order by ?)
+Query plan:
+sscan
+    class: Z node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+select Z.rn, Z.cola, Z.colb from (select (orderby_num()), a.cola, a.colb from ta a order by ?) Z (rn, cola, colb) where ((Z.rn>= ?:?  and Z.rn<= ?:? ) or (Z.colb>= ?:?  and Z.colb<= ?:? ))
+===================================================
+0
+===================================================
+0
+===================================================
+51
+===================================================
+    
+14. BETWEEN with join     
+
+===================================================
+rn    cola    colb    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+
+Query plan:
+temp(order by)
+    subplan: idx-join (inner join)
+                 outer: sscan
+                            class: Z node[?]
+                            cost:  ? card ?
+                 inner: iscan
+                            class: tb node[?]
+                            index: pk_tb_k term[?] (covers)
+                            cost:  ? card ?
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), Z.cola, Z.colb from ta Z, tb tb where Z.cola=tb.k order by ? for (orderby_num()) between  ?:?  and  ?:? 
+===================================================
+    
+15. BETWEEN with expressions instead of constants     
+
+===================================================
+rn    cola    colb    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+11     11     11     
+12     12     12     
+13     13     13     
+14     14     14     
+15     15     15     
+16     16     16     
+17     17     17     
+18     18     18     
+19     19     19     
+20     20     20     
+21     21     21     
+22     22     22     
+23     23     23     
+24     24     24     
+25     25     25     
+26     26     26     
+27     27     27     
+28     28     28     
+29     29     29     
+30     30     30     
+31     31     31     
+32     32     32     
+33     33     33     
+34     34     34     
+35     35     35     
+36     36     36     
+37     37     37     
+38     38     38     
+39     39     39     
+40     40     40     
+41     41     41     
+42     42     42     
+43     43     43     
+44     44     44     
+45     45     45     
+46     46     46     
+47     47     47     
+48     48     48     
+49     49     49     
+50     50     50     
+51     51     51     
+
+Query plan:
+sscan
+    class: tb node[?]
+    cost:  ? card ?
+Query stmt:
+(select min(tb.k) from tb tb)
+Query plan:
+sscan
+    class: tb node[?]
+    cost:  ? card ?
+Query stmt:
+(select max(tb.k) from tb tb)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: Z node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), Z.cola, Z.colb from ta Z order by ? for (orderby_num()) between (select min(tb.k) from tb tb) and (select max(tb.k) from tb tb)
+===================================================
+    
+16. Prepared statement with AND range     
+
+===================================================
+0
+===================================================
+rn    cola    colb    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: Z node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), Z.cola, Z.colb from ta Z order by ? for (orderby_num())>= ?:?  and (orderby_num())<= ?:? 
+===================================================
+0
+===================================================
+    
+17. Prepared statement with BETWEEN expression     
+
+===================================================
+0
+===================================================
+rn    cola    colb    
+1     1     1     
+2     2     2     
+3     3     3     
+4     4     4     
+5     5     5     
+6     6     6     
+7     7     7     
+8     8     8     
+9     9     9     
+10     10     10     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: Z node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select (orderby_num()), Z.cola, Z.colb from ta Z order by ? for (orderby_num()) between  ?:?  and  ?:? 
+===================================================
+0
+===================================================
+    
+18. Prepared statement with BETWEEN + additional filter     
+
+===================================================
+0
+===================================================
+rn    cola    colb    
+52     52     52     
+54     54     54     
+56     56     56     
+58     58     58     
+60     60     60     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: a node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select (orderby_num()), a.cola, a.colb from ta a order by ?)
+Query plan:
+sscan
+    class: Z node[?]
+    sargs: term[?] AND term[?]
+    cost:  ? card ?
+Query stmt:
+select Z.rn, Z.cola, Z.colb from (select (orderby_num()), a.cola, a.colb from ta a order by ?) Z (rn, cola, colb) where (Z.rn>= ?:?  and Z.rn<= ?:? ) and Z.colb mod ?=?
+===================================================
+0
+===================================================
+0
+===================================================
+0

--- a/sql/_33_elderberry/cbrd_24042/cbrd_26257/cases/cbrd_26257.sql
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_26257/cases/cbrd_26257.sql
@@ -1,8 +1,12 @@
--- Verification for CBRD-26257, CBRD-26313
--- View-merge optimization is restricted when using the BETWEEN operator.
--- In Oracle-style partial range processing, view-merge is applied,
--- but BETWEEN was previously excluded. This test verifies that
--- BETWEEN is now included in the optimization.
+-- Verification for CBRD-26257 and CBRD-26313
+-- Issue summary:
+--   CBRD-26257 : Extends view-merge optimization to include the BETWEEN operator.
+--   CBRD-26313 : Fixes an issue where view-merge was applied even when
+--                   additional filters existed beyond the ROWNUM condition.
+--                   (Only test case #2 applies to this issue.)
+-- Note:
+--   - Only CBRD-26313 is included in the 11.4 Patch 2 backport.
+--   - The rest of the test cases belong to CBRD-26257 (feature extension).
 
 drop table if exists ta;
 create table ta(cola int, colb int);
@@ -11,6 +15,7 @@ insert into ta select rownum,rownum from db_class a, db_class b limit 1000;
 evaluate '1. Range condition using AND';
 SELECT /*+ recompile */ * FROM ( SELECT ROWNUM rn, a.* FROM (select * from ta order by cola) a) Z WHERE rn >= 0 + 1 AND rn <= 0 + 10;
 
+-- [CBRD-26313] Case: View-merge applied with extra filter beyond ROWNUM condition.
 evaluate '2. Condition with additional filters (excluding ROWNUM)';
 SELECT /*+ recompile */ * FROM ( SELECT ROWNUM rn, a.* FROM (select * from ta order by cola) a) Z WHERE rn >= 0 + 1 AND rn <= 0 + 10 AND colb % 2 = 0;
 

--- a/sql/_33_elderberry/cbrd_24042/cbrd_26257/cases/cbrd_26257.sql
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_26257/cases/cbrd_26257.sql
@@ -1,0 +1,89 @@
+-- Verification for CBRD-26257, CBRD-26313
+-- View-merge optimization is restricted when using the BETWEEN operator.
+-- In Oracle-style partial range processing, view-merge is applied,
+-- but BETWEEN was previously excluded. This test verifies that
+-- BETWEEN is now included in the optimization.
+
+drop table if exists ta;
+create table ta(cola int, colb int);
+insert into ta select rownum,rownum from db_class a, db_class b limit 1000;
+
+evaluate '1. Range condition using AND';
+SELECT /*+ recompile */ * FROM ( SELECT ROWNUM rn, a.* FROM (select * from ta order by cola) a) Z WHERE rn >= 0 + 1 AND rn <= 0 + 10;
+
+evaluate '2. Condition with additional filters (excluding ROWNUM)';
+SELECT /*+ recompile */ * FROM ( SELECT ROWNUM rn, a.* FROM (select * from ta order by cola) a) Z WHERE rn >= 0 + 1 AND rn <= 0 + 10 AND colb % 2 = 0;
+
+evaluate '3. BETWEEN expression (constant + arithmetic)';
+SELECT /*+ recompile */ * FROM ( SELECT ROWNUM rn, a.* FROM (select * from ta order by cola) a) Z WHERE rn BETWEEN 0 + 1 AND 0 + 10;
+
+evaluate '4. Basic BETWEEN with constant range';
+SELECT /*+ recompile */  * FROM ( SELECT ROWNUM rn, a.* FROM (select * from ta order by cola) a ) Z WHERE rn BETWEEN 1 AND 10;
+
+evaluate '5. Single-row range (BETWEEN same values)';
+SELECT /*+ recompile */ * FROM ( SELECT ROWNUM rn, a.* FROM (select * from ta order by cola) a ) Z WHERE rn BETWEEN 100 AND 100;
+
+evaluate '6. BETWEEN including NULL';
+SELECT /*+ recompile */ * FROM ( SELECT ROWNUM rn, a.* FROM (select * from ta order by cola) a ) Z WHERE rn BETWEEN NULL AND 10;
+
+evaluate '7. Combined with additional condition (filter first)';
+SELECT /*+ recompile */ * FROM ( SELECT ROWNUM rn, a.* FROM (SELECT * FROM ta ORDER BY cola) a) Z WHERE colb % 2 = 0 AND rn BETWEEN 51 AND 60;
+
+evaluate '8. Combined with additional condition (between first)';
+SELECT /*+ recompile */ * FROM ( SELECT ROWNUM rn, a.* FROM (select * from ta order by cola) a ) Z WHERE rn BETWEEN 51 AND 60 AND colb % 2 = 0;
+
+evaluate '9. Two BETWEEN predicates (ROWNUM + column)';
+SELECT /*+ recompile */ * FROM ( SELECT ROWNUM rn, a.* FROM (SELECT * FROM ta ORDER BY cola) a) Z WHERE rn BETWEEN 11 AND 20 AND cola BETWEEN 15 AND 18;
+
+evaluate '10. BETWEEN in WHERE + HAVING (groupby_num)';
+SELECT /*+ recompile */ cola FROM ( SELECT ROWNUM rn, a.* FROM (SELECT * FROM ta ORDER BY cola) a) Z WHERE rn BETWEEN 1 AND 20 GROUP BY cola DESC HAVING groupby_num() BETWEEN 2 AND 4;
+
+evaluate '11. Reversed BETWEEN boundaries';
+SELECT /*+ recompile */ * FROM ( SELECT ROWNUM rn, a.* FROM (select * from ta order by cola) a ) Z WHERE rn BETWEEN 10 AND 1;
+
+evaluate '12. BETWEEN with negative and positive range';
+SELECT /*+ recompile */ * FROM ( SELECT ROWNUM rn, a.* FROM (select * from ta order by cola) a ) Z WHERE rn BETWEEN -5 and 5;
+
+evaluate '13. BETWEEN combined with OR condition';
+SELECT /*+ recompile */ * FROM ( SELECT ROWNUM rn, a.* FROM (select * from ta order by cola) a ) Z WHERE rn BETWEEN 1 AND 10 OR colb BETWEEN 50 AND 60;
+
+drop table if exists tb;
+create table tb (
+  k int primary key
+);
+insert into tb select rownum from db_class limit 1000;
+
+evaluate '14. BETWEEN with join';
+SELECT /*+ recompile */ * FROM ( SELECT ROWNUM rn, a.* FROM (select ta.* from ta inner join tb on ta.cola = tb.k order by ta.cola) a) Z WHERE rn BETWEEN 1 AND 10;
+
+evaluate '15. BETWEEN with expressions instead of constants';
+SELECT /*+ recompile */ * 
+FROM ( SELECT ROWNUM rn, a.* FROM (select * from ta order by cola) a ) Z 
+WHERE rn BETWEEN (select min(k) from tb) AND (select max(k) from tb);
+
+evaluate '16. Prepared statement with AND range';
+prepare sa from 'SELECT /*+ recompile */ * 
+                 FROM ( SELECT ROWNUM rn, a.* FROM (select * from ta order by cola) a) Z 
+                 WHERE rn >= ? AND rn <= ?';
+--@queryplan
+execute sa using 1, 10;
+deallocate prepare sa;
+
+evaluate '17. Prepared statement with BETWEEN expression';
+prepare sb from 'SELECT /*+ recompile */ * 
+                 FROM ( SELECT ROWNUM rn, a.* FROM (select * from ta order by cola) a) Z 
+                 WHERE rn BETWEEN ? AND ?';
+--@queryplan
+execute sb using 1, 10;
+deallocate prepare sb;
+
+evaluate '18. Prepared statement with BETWEEN + additional filter';
+prepare sc from 'SELECT /*+ recompile */ * 
+                 FROM ( SELECT ROWNUM rn, a.* FROM (select * from ta order by cola) a) Z 
+                 WHERE rn BETWEEN ? AND ? AND colb % 2 = 0';
+--@queryplan
+execute sc using 51, 60;
+deallocate prepare sc;
+
+drop table if exists ta;
+drop table if exists tb;


### PR DESCRIPTION
Backport #2360

refer to http://jira.cubrid.org/browse/CBRD-26257
refer to http://jira.cubrid.org/browse/CBRD-26313


CBRD-26257 Test Case에 CBRD-26313 시나리오 하나가 추가되어있어, 두 개의 이슈가 하나의 TC로 작성되었습니다.
그런데 CBRD-26313만 11.4 patch 2 대상이므로 TC를 백포트 하되, 답지를 develop과 다르게 가져가야할 것 같습니다. (추후 11.4.2 빌드되면 테스트하여 답지 반영 후 merge할 예정입니다)
주석 및 JIRA comment 작성을 해두어 추후에 혼동되지 않도록 하겠습니다.