### PR TITLE
[CBRD-25447] Revised cci answers for Support parallel heap scan (refactor)

### DIFF
--- a/sql/_13_issues/_20_2h/answers/cbrd_23665.answer_cci
+++ b/sql/_13_issues/_20_2h/answers/cbrd_23665.answer_cci
@@ -890,17 +890,17 @@ trace
 Query Plan:
   TABLE SCAN (dba.t?)
 
-  rewritten query: (select [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? ))
+  rewritten query: (select /*+ NO_PARALLEL_HEAP_SCAN */ [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? ))
 
   TABLE SCAN (dba.t?)
 
-  rewritten query: (select [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? ))
+  rewritten query: (select /*+ NO_PARALLEL_HEAP_SCAN */ [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? ))
 
   NESTED LOOPS (inner join)
     TABLE SCAN (a)
     TABLE SCAN (b)
 
-  rewritten query: select /*+ ORDERED */ count(*) from (select [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? )) a (a, b, c), (select [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? )) b (a, b, c) where a.a=b.a and a.b=b.b and a.c=b.c
+  rewritten query: select /*+ ORDERED */ count(*) from (select /*+ NO_PARALLEL_HEAP_SCAN */ [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? )) a (a, b, c), (select /*+ NO_PARALLEL_HEAP_SCAN */ [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? )) b (a, b, c) where a.a=b.a and a.b=b.b and a.c=b.c
 
 
 Trace Statistics:
@@ -911,10 +911,8 @@ Trace Statistics:
              (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-             (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-             (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
      
 
 ===================================================
@@ -932,10 +930,8 @@ Trace Statistics:
              (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-             (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-             (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
      
 
 ===================================================
@@ -950,17 +946,17 @@ trace
 Query Plan:
   TABLE SCAN (dba.t?)
 
-  rewritten query: (select [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? ))
+  rewritten query: (select /*+ NO_PARALLEL_HEAP_SCAN */ [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? ))
 
   TABLE SCAN (dba.t?)
 
-  rewritten query: (select [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? ))
+  rewritten query: (select /*+ NO_PARALLEL_HEAP_SCAN */ [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? ))
 
   NESTED LOOPS (inner join)
     TABLE SCAN (a)
     TABLE SCAN (b)
 
-  rewritten query: select /*+ ORDERED */ count(*) from (select [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? )) a (a, b, c), (select [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? )) b (a, b, c) where a.a=b.a and a.b=b.b and a.c=b.c
+  rewritten query: select /*+ ORDERED */ count(*) from (select /*+ NO_PARALLEL_HEAP_SCAN */ [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? )) a (a, b, c), (select /*+ NO_PARALLEL_HEAP_SCAN */ [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? )) b (a, b, c) where a.a=b.a and a.b=b.b and a.c=b.c
 
 
 Trace Statistics:
@@ -971,10 +967,8 @@ Trace Statistics:
              (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-             (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-             (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
      
 
 ===================================================
@@ -994,10 +988,8 @@ Trace Statistics:
              (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-             (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-             (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
      
 
 ===================================================
@@ -1010,17 +1002,17 @@ trace
 Query Plan:
   TABLE SCAN (dba.t?)
 
-  rewritten query: (select [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? ))
+  rewritten query: (select /*+ NO_PARALLEL_HEAP_SCAN */ [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? ))
 
   TABLE SCAN (dba.t?)
 
-  rewritten query: (select [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? ))
+  rewritten query: (select /*+ NO_PARALLEL_HEAP_SCAN */ [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? ))
 
   NESTED LOOPS (inner join)
     TABLE SCAN (a)
     TABLE SCAN (b)
 
-  rewritten query: select /*+ ORDERED NO_HASH_LIST_SCAN */ count(*) from (select [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? )) a (a, b, c), (select [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? )) b (a, b, c) where a.a=b.a and a.b=b.b and a.c=b.c
+  rewritten query: select /*+ ORDERED NO_HASH_LIST_SCAN */ count(*) from (select /*+ NO_PARALLEL_HEAP_SCAN */ [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? )) a (a, b, c), (select /*+ NO_PARALLEL_HEAP_SCAN */ [dba.t?].a, [dba.t?].b, [dba.t?].c from [dba.t?] [dba.t?] where (inst_num()<= ?:? )) b (a, b, c) where a.a=b.a and a.b=b.b and a.c=b.c
 
 
 Trace Statistics:
@@ -1031,10 +1023,8 @@ Trace Statistics:
              (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-             (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-             (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
      
 
 ===================================================

--- a/sql/_36_guava/cbrd_25447/answers/cbrd_25447.answer_cci
+++ b/sql/_36_guava/cbrd_25447/answers/cbrd_25447.answer_cci
@@ -8,7 +8,7 @@
 0
 ===================================================
     
-1. talbe full scan (should work) -> row by row     
+1. table full scan (should work) -> row by row     
 
 ===================================================
 count(*)    
@@ -796,7 +796,7 @@ Trace Statistics:
 
 ===================================================
     
-19. no select list from table, no predicate from table (should not work)     
+19. no select list from table, no predicate from table (should work)     
 
 ===================================================
 count(*)    
@@ -813,6 +813,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
      
 
 ===================================================
@@ -831,6 +832,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
      
 
 ===================================================
@@ -865,7 +867,7 @@ Trace Statistics:
 
 ===================================================
     
-21. when query contains interpolation (should work) -> row by row     
+21. when query contains interpolation (should work) -> mergeable list     
 
 ===================================================
 median(cola)    
@@ -887,7 +889,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
     GROUPBY (time: ?, hash: false, sort: true, page: ?, ioread: ?, rows: ?)
      
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25447

sql_by_cci revision of: https://github.com/CUBRID/cubrid-testcases/pull/2376


수정 후, 두 파일의 sql (.answer)과 sql_by_cci (.answer_cci)의 차이점은 소수점입니다.

ex)
`1.0000000000` (sql) vs `1.0` (sql_by_cci) 