### PR TITLE
[CBRD-26258] Revised cci answers for Improve to allow Skip ORDER BY even for joins without index scan predicates

### DIFF
--- a/sql/_13_issues/_12_1h/answers/bug_bts_7761_6.answer_cci
+++ b/sql/_13_issues/_12_1h/answers/bug_bts_7761_6.answer_cci
@@ -169,7 +169,6 @@ temp(order by)
     subplan: iscan
                  class: t node[?]
                  index: i_t_i term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc, ? asc, ? asc
     cost:  ? card ?
@@ -349,7 +348,6 @@ temp(order by)
     subplan: iscan
                  class: t? node[?]
                  index: i_t_i term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc, ? asc, ? asc
     cost:  ? card ?

--- a/sql/_13_issues/_18_2h/answers/cbrd_22419.answer_cci
+++ b/sql/_13_issues/_18_2h/answers/cbrd_22419.answer_cci
@@ -36,7 +36,6 @@ temp(order by)
     subplan: iscan
                  class: t node[?]
                  index: i_i? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc, ? desc
     cost:  ? card ?
@@ -58,7 +57,6 @@ temp(order by)
     subplan: iscan
                  class: t node[?]
                  index: i_i? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc, ? asc, ? asc
     cost:  ? card ?
@@ -80,7 +78,6 @@ temp(order by)
     subplan: iscan
                  class: t node[?]
                  index: i_i? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc, ? desc
     cost:  ? card ?
@@ -102,7 +99,6 @@ temp(order by)
     subplan: iscan
                  class: t node[?]
                  index: i_i? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc, ? desc
     cost:  ? card ?
@@ -124,7 +120,6 @@ temp(order by)
     subplan: iscan
                  class: t node[?]
                  index: i_i? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc, ? desc
     cost:  ? card ?
@@ -146,7 +141,6 @@ temp(order by)
     subplan: iscan
                  class: t node[?]
                  index: i_i? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc, ? desc
     cost:  ? card ?
@@ -168,7 +162,6 @@ temp(order by)
     subplan: iscan
                  class: t node[?]
                  index: i_i? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc, ? desc
     cost:  ? card ?
@@ -190,7 +183,6 @@ temp(order by)
     subplan: iscan
                  class: t node[?]
                  index: i_i? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc, ? desc
     cost:  ? card ?

--- a/sql/_18_index_enhancement_qa/_02_full_test/_06_optimizing_limit/answers/_61_topn_multiplekey_jointables.answer_cci
+++ b/sql/_18_index_enhancement_qa/_02_full_test/_06_optimizing_limit/answers/_61_topn_multiplekey_jointables.answer_cci
@@ -148,7 +148,6 @@ temp(order by)
                             class: s node[?]
                             index: i_s_all term[?] (covers)
                             cost:  ? card ?
-                 sort:  ? asc, ? desc
                  cost:  ? card ?
     sort:  ? desc
     cost:  ? card ?

--- a/sql/_18_index_enhancement_qa/_02_full_test/_06_optimizing_limit_multirange/answers/_67_multirange_scan_jointables.answer_cci
+++ b/sql/_18_index_enhancement_qa/_02_full_test/_06_optimizing_limit_multirange/answers/_67_multirange_scan_jointables.answer_cci
@@ -163,7 +163,6 @@ temp(order by)
                             class: s node[?]
                             index: i_s_all term[?] (covers)
                             cost:  ? card ?
-                 sort:  ? asc, ? desc
                  cost:  ? card ?
     sort:  ? desc
     cost:  ? card ?

--- a/sql/_19_apricot/_03_index_skip_scan/answers/_14_iss_choice.answer_cci
+++ b/sql/_19_apricot/_03_index_skip_scan/answers/_14_iss_choice.answer_cci
@@ -105,7 +105,6 @@ temp(order by)
     subplan: iscan
                  class: t node[?]
                  index: i_t_j_k term[?]
-                 sort:  ? asc, ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -143,7 +142,6 @@ temp(order by)
                  class: t node[?]
                  index: i_t_j_k term[?]
                  sargs: term[?]
-                 sort:  ? asc, ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?

--- a/sql/_19_apricot/_06_filter_index/answers/_02_partial_index_usage.answer_cci
+++ b/sql/_19_apricot/_06_filter_index/answers/_02_partial_index_usage.answer_cci
@@ -89,7 +89,6 @@ temp(order by)
     subplan: iscan
                  class: t node[?]
                  index: idx_t_description term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -129,7 +128,6 @@ temp(order by)
     subplan: iscan
                  class: t node[?]
                  index: idx_t_description term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -764,7 +762,6 @@ temp(order by)
     subplan: iscan
                  class: t node[?]
                  index: idx_t_description term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?

--- a/sql/_19_apricot/_10_enum_type/answers/trac_344_03.answer_cci
+++ b/sql/_19_apricot/_10_enum_type/answers/trac_344_03.answer_cci
@@ -821,7 +821,6 @@ temp(order by)
     subplan: iscan
                  class: t? node[?]
                  index: idx? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -837,7 +836,6 @@ temp(order by)
     subplan: iscan
                  class: t? node[?]
                  index: idx? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -854,7 +852,6 @@ temp(order by)
     subplan: iscan
                  class: t? node[?]
                  index: idx? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -934,7 +931,6 @@ temp(order by)
     subplan: iscan
                  class: t? node[?]
                  index: idx? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -950,7 +946,6 @@ temp(order by)
     subplan: iscan
                  class: t? node[?]
                  index: idx? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -967,7 +962,6 @@ temp(order by)
     subplan: iscan
                  class: t? node[?]
                  index: idx? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?

--- a/sql/_19_apricot/_12_collation/_09_index/answers/_04_index_iss.answer_cci
+++ b/sql/_19_apricot/_12_collation/_09_index/answers/_04_index_iss.answer_cci
@@ -82,7 +82,6 @@ temp(order by)
     subplan: iscan
                  class: t? node[?]
                  index: i_t?_s?_i? term[?] (covers) (index skip scan)
-                 sort:  ? asc collate utf?_en_ci, ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -139,7 +138,6 @@ temp(order by)
     subplan: iscan
                  class: t? node[?]
                  index: i_t?_s?_i? term[?] (covers) (index skip scan)
-                 sort:  ? asc collate utf?_en_ci, ? asc
                  cost:  ? card ?
     sort:  ? desc collate utf?_en_ci, ? asc
     cost:  ? card ?

--- a/sql/_23_apricot_qa/_01_sql_extension3/_02_new_sql_types/_01_enum/answers/_20_enum_operators02.answer_cci
+++ b/sql/_23_apricot_qa/_01_sql_extension3/_02_new_sql_types/_01_enum/answers/_20_enum_operators02.answer_cci
@@ -137,7 +137,6 @@ temp(order by)
                             class: t? node[?]
                             sargs: term[?]
                             cost:  ? card ?
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc, ? asc
     cost:  ? card ?
@@ -490,7 +489,6 @@ temp(order by)
                  index: u_oper?_id term[?]
                  sargs: term[?]
                  subqs: ?
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc, ? asc, ? asc
     cost:  ? card ?

--- a/sql/_23_apricot_qa/_02_performance/_01_filtered_index/answers/filtered_index_select_basic_008.answer_cci
+++ b/sql/_23_apricot_qa/_02_performance/_01_filtered_index/answers/filtered_index_select_basic_008.answer_cci
@@ -91,7 +91,6 @@ temp(order by)
     subplan: iscan
                  class: t node[?]
                  index: idx_t_description term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -131,7 +130,6 @@ temp(order by)
     subplan: iscan
                  class: t node[?]
                  index: idx_t_description term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -766,7 +764,6 @@ temp(order by)
     subplan: iscan
                  class: t node[?]
                  index: idx_t_description term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?

--- a/sql/_23_apricot_qa/_02_performance/_03_index_skip_scan/answers/function_index_skip_scan_iss_choice.answer_cci
+++ b/sql/_23_apricot_qa/_02_performance/_03_index_skip_scan/answers/function_index_skip_scan_iss_choice.answer_cci
@@ -105,7 +105,6 @@ temp(order by)
     subplan: iscan
                  class: t node[?]
                  index: idx? term[?]
-                 sort:  ? asc, ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -143,7 +142,6 @@ temp(order by)
                  class: t node[?]
                  index: idx? term[?]
                  sargs: term[?]
-                 sort:  ? asc, ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -295,7 +293,6 @@ temp(order by)
     subplan: iscan
                  class: t node[?]
                  index: idx? term[?]
-                 sort:  ? asc, ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -323,7 +320,6 @@ temp(order by)
                  class: t node[?]
                  index: idx? term[?]
                  sargs: term[?]
-                 sort:  ? asc, ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?

--- a/sql/_27_banana_qa/issue_5765_timezone_support/_01_table_operations/_04_select/answers/_08_index_dt.answer_cci
+++ b/sql/_27_banana_qa/issue_5765_timezone_support/_01_table_operations/_04_select/answers/_08_index_dt.answer_cci
@@ -84,7 +84,6 @@ temp(order by)
     subplan: iscan
                  class: tz_test node[?]
                  index: idx? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -153,7 +152,6 @@ temp(order by)
                  class: tz_test node[?]
                  index: idx? term[?]
                  filtr: term[?]
-                 sort:  ? asc, ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -277,7 +275,6 @@ temp(order by)
     subplan: iscan
                  class: tz_test node[?]
                  index: filter_idx? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc, ? asc
     cost:  ? card ?
@@ -302,7 +299,6 @@ temp(order by)
     subplan: iscan
                  class: tz_test node[?]
                  index: filter_idx? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -318,7 +314,6 @@ temp(order by)
     subplan: iscan
                  class: tz_test node[?]
                  index: filter_idx? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?

--- a/sql/_27_banana_qa/issue_5765_timezone_support/_01_table_operations/_04_select/answers/_08_index_t.answer_cci
+++ b/sql/_27_banana_qa/issue_5765_timezone_support/_01_table_operations/_04_select/answers/_08_index_t.answer_cci
@@ -89,7 +89,6 @@ temp(order by)
     subplan: iscan
                  class: tz_test node[?]
                  index: idx? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -153,7 +152,6 @@ temp(order by)
                  class: tz_test node[?]
                  index: idx? term[?]
                  filtr: term[?]
-                 sort:  ? asc, ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -259,7 +257,6 @@ temp(order by)
     subplan: iscan
                  class: tz_test node[?]
                  index: filter_idx? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc, ? asc
     cost:  ? card ?
@@ -282,7 +279,6 @@ temp(order by)
     subplan: iscan
                  class: tz_test node[?]
                  index: filter_idx? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -296,7 +292,6 @@ temp(order by)
     subplan: iscan
                  class: tz_test node[?]
                  index: filter_idx? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?

--- a/sql/_27_banana_qa/issue_5765_timezone_support/_01_table_operations/_04_select/answers/_08_index_ts.answer_cci
+++ b/sql/_27_banana_qa/issue_5765_timezone_support/_01_table_operations/_04_select/answers/_08_index_ts.answer_cci
@@ -84,7 +84,6 @@ temp(order by)
     subplan: iscan
                  class: tz_test node[?]
                  index: idx? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -153,7 +152,6 @@ temp(order by)
                  class: tz_test node[?]
                  index: idx? term[?]
                  filtr: term[?]
-                 sort:  ? asc, ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -275,7 +273,6 @@ temp(order by)
     subplan: iscan
                  class: tz_test node[?]
                  index: filter_idx? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc, ? asc
     cost:  ? card ?
@@ -300,7 +297,6 @@ temp(order by)
     subplan: iscan
                  class: tz_test node[?]
                  index: filter_idx? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -316,7 +312,6 @@ temp(order by)
     subplan: iscan
                  class: tz_test node[?]
                  index: filter_idx? term[?]
-                 sort:  ? asc
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?

--- a/sql/_28_features_930/issue_13613_hint_index_ss/answers/_01_plain_table.answer_cci
+++ b/sql/_28_features_930/issue_13613_hint_index_ss/answers/_01_plain_table.answer_cci
@@ -330,12 +330,11 @@ temp(order by)
                             class: t? node[?]
                             sargs: term[?]
                             cost:  ? card ?
-                 sort:  ? asc, ? asc
                  cost:  ? card ?
-    sort:  ? asc
+    sort:  ? asc, ? asc
     cost:  ? card ?
 Query stmt:
-(select /*+ ORDERED INDEX_SS(t?) */ t?.id, t?.a, t?.b, t?.c from t? t?, t? t? where (t?.b< ?:? ) and (t?.c< ?:? ) and (t?.c< ?:? ) order by ? for orderby_num()<= ?:? )
+(select /*+ ORDERED INDEX_SS(t?) */ t?.id, t?.a, t?.b, t?.c from t? t?, t? t? where (t?.b< ?:? ) and (t?.c< ?:? ) and (t?.c< ?:? ) order by ?, ? for orderby_num()<= ?:? )
 Query plan:
 temp(order by)
     subplan: nl-join (cross join)
@@ -348,16 +347,16 @@ temp(order by)
                             index: i_ac term[?] (covers) (index skip scan)
                             cost:  ? card ?
                  cost:  ? card ?
-    sort:  ? desc
+    sort:  ? desc, ? desc
     cost:  ? card ?
 Query stmt:
-(select /*+ ORDERED INDEX_SS(t?) */ t?.id, t?.a, t?.b, t?.c from t? t?, t? t? where (t?.b< ?:? ) and (t?.c< ?:? ) and (t?.c< ?:? ) order by ? desc  for orderby_num()<= ?:? )
+(select /*+ ORDERED INDEX_SS(t?) */ t?.id, t?.a, t?.b, t?.c from t? t?, t? t? where (t?.b< ?:? ) and (t?.c< ?:? ) and (t?.c< ?:? ) order by ? desc , ? desc  for orderby_num()<= ?:? )
 Query plan:
 sscan
     class: __t? node[?]
     cost:  ? card ?
 Query stmt:
-select /*+ INDEX_SS */ [__t?].id, [__t?].a, [__t?].b, [__t?].c from ((select /*+ ORDERED INDEX_SS(t?) */ t?.id, t?.a, t?.b, t?.c from t? t?, t? t? where (t?.b< ?:? ) and (t?.c< ?:? ) and (t?.c< ?:? ) order by ? for orderby_num()<= ?:? ) union (select /*+ ORDERED INDEX_SS(t?) */ t?.id, t?.a, t?.b, t?.c from t? t?, t? t? where (t?.b< ?:? ) and (t?.c< ?:? ) and (t?.c< ?:? ) order by ? desc  for orderby_num()<= ?:? )) [__t?] (id, a, b, c)
+select /*+ INDEX_SS */ [__t?].id, [__t?].a, [__t?].b, [__t?].c from ((select /*+ ORDERED INDEX_SS(t?) */ t?.id, t?.a, t?.b, t?.c from t? t?, t? t? where (t?.b< ?:? ) and (t?.c< ?:? ) and (t?.c< ?:? ) order by ?, ? for orderby_num()<= ?:? ) union (select /*+ ORDERED INDEX_SS(t?) */ t?.id, t?.a, t?.b, t?.c from t? t?, t? t? where (t?.b< ?:? ) and (t?.c< ?:? ) and (t?.c< ?:? ) order by ? desc , ? desc  for orderby_num()<= ?:? )) [__t?] (id, a, b, c)
 ===================================================
 0
 ===================================================

--- a/sql/_28_features_930/issue_9024_loose_index_scan/answers/_05_groupby_expression.answer_cci
+++ b/sql/_28_features_930/issue_9024_loose_index_scan/answers/_05_groupby_expression.answer_cci
@@ -27,7 +27,6 @@ temp(distinct)
                               class: t? node[?]
                               index: i_t?_all (covers) (loose index scan on prefix ?)
                               filtr: term[?]
-                              sort:  ? asc collate iso?_en_cs
                               cost:  ? card ?
                  sort:  
                  cost:  ? card ?
@@ -47,7 +46,6 @@ temp(distinct)
                               class: t? node[?]
                               index: i_t?_all (covers) (loose index scan on prefix ?)
                               filtr: term[?]
-                              sort:  ? asc collate iso?_en_cs
                               cost:  ? card ?
                  sort:  
                  cost:  ? card ?
@@ -346,7 +344,6 @@ temp(group by)
                  class: w node[?]
                  index: i_t?_all (covers) (loose index scan on prefix ?)
                  filtr: term[?]
-                 sort:  ? asc collate iso?_en_cs
                  cost:  ? card ?
     sort:  
     cost:  ? card ?
@@ -364,7 +361,6 @@ temp(group by)
                  class: w node[?]
                  index: i_t?_all (covers) (loose index scan on prefix ?)
                  filtr: term[?]
-                 sort:  ? asc collate iso?_en_cs
                  cost:  ? card ?
     sort:  
     cost:  ? card ?
@@ -384,7 +380,6 @@ temp(group by)
                  class: w node[?]
                  index: i_t?_all (covers) (loose index scan on prefix ?)
                  filtr: term[?]
-                 sort:  ? asc collate iso?_en_cs
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -410,7 +405,6 @@ temp(group by)
                  class: w node[?]
                  index: i_t?_all (covers) (loose index scan on prefix ?)
                  filtr: term[?]
-                 sort:  ? asc collate iso?_en_cs
                  cost:  ? card ?
     sort:  
     cost:  ? card ?


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26258

CCI revision of: https://github.com/CUBRID/cubrid-testcases/pull/2383
위 PR에는 `sql/_19_apricot/_10_enum_type/answers/trac_344_03.answer_cci`의 SQL(JDBC) 답지인 `sql/_19_apricot/_10_enum_type/answers/trac_344_03.answer`는 수정이 되지않았던 이유는, CTP에서 cci 드라이버로 실행했을때는 (이 PR에서 수정된) 쿼리 플랜이 출력되지만, 일반 SQL(JDBC)에는 쿼리 플랜이 출력이 되지않아서 기존 답지에서 제외됐었습니다.

요약: 
- `trac_344_03.answer`는 쿼리플랜 X  ->  답지수정 필요 X

- `trac_344_03.answer_cci`는 쿼리플랜 ✓  ->   답지수정 필요 ✓
