### PR TITLE
[CBRD-26415] join elimination is prohibited when the unique is broken by a function expression.

### DIFF
--- a/sql/_33_elderberry/cbrd_24042/cbrd_24182/answers/complex_predicate.answer
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_24182/answers/complex_predicate.answer
@@ -24,12 +24,19 @@ count(*)
 1     
 
 Query plan:
-sscan
-    class: a node[?]
-    sargs: term[?]
+nl-join (left outer join)
+    edge:  term[?] AND term[?]
+    outer: sscan
+               class: a node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               sargs: term[?] AND term[?]
+               cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select count(*) from t a where a.c_c= ?:? 
+select count(*) from t a left outer join t b on a.c_b=b.c_b and a.c_a+a.c_b=nvl(b.c_a, ?) where a.c_c= ?:? 
 ===================================================
 count(*)    
 1     

--- a/sql/_33_elderberry/cbrd_24042/cbrd_26263/answers/cbrd_26263.answer
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_26263/answers/cbrd_26263.answer
@@ -363,11 +363,19 @@ count(*)
 6     
 
 Query plan:
-sscan
-    class: a node[?]
+nl-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: iscan
+               class: b node[?]
+               index: pk term[?] (covers)
+               filtr: term[?]
+               cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select count(*) from tbl a
+select count(*) from tbl a left outer join tbl b on b.cola= ?:?  and  cast(a.colb as varchar(?))= cast(b.colb as varchar(?))
 ===================================================
     
 Case 19: HAVING uses right-side column (aggregate) -> elimination not allowed     


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26415

REVERSE, CONCAT, PLUS, MINUS, 자동 생성된 CAST 함수를 제외한 나머지 함수들은 조인 제거 최적화에서 제외하면서 변경되는 케이스