### PR TITLE
[CBRD-26375] Add test for disabling view merge when LEFT OUTER JOIN join predicates are removed

### DIFF
--- a/sql/_33_elderberry/cbrd_24042/cbrd_26375/answers/cbrd_26375.answer
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_26375/answers/cbrd_26375.answer
@@ -71,7 +71,7 @@ select count(*) from tbl a left outer join (select ? from tbl b) b (cola) on a.c
 Case 2: LEFT OUTER JOIN where view returns a normal column (inline view vs view)     
 
 ===================================================
-Error:-493
+0
 ===================================================
     
 2-1. inline view     
@@ -99,14 +99,8 @@ select count(*) from tbl a left outer join tbl b on a.cola=b.cola
 
 ===================================================
 count(*)    
-19999     
+10000     
 
-Query plan:
-sscan
-    class: b node[?]
-    cost:  ? card ?
-Query stmt:
-(select ? from tbl b)
 Query plan:
 nl-join (left outer join)
     edge:  term[?]
@@ -115,12 +109,11 @@ nl-join (left outer join)
                cost:  ? card ?
     inner: sscan
                class: b node[?]
-               sargs: term[?] AND term[?]
+               sargs: term[?]
                cost:  ? card ?
-    during:term[?]
     cost:  ? card ?
 Query stmt:
-select count(*) from tbl a left outer join (select ? from tbl b) b (cola) on a.cola=b.cola and a.cola=?
+select count(*) from tbl a left outer join tbl b on a.cola=b.cola
 ===================================================
     
 Case 3: constant expression in view select with outer filter (inline view vs view)     

--- a/sql/_33_elderberry/cbrd_24042/cbrd_26375/answers/cbrd_26375.answer
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_26375/answers/cbrd_26375.answer
@@ -1,0 +1,290 @@
+===================================================
+0
+===================================================
+0
+===================================================
+10000
+===================================================
+    
+Case 1: LEFT OUTER JOIN with constant column (inline view vs view)     
+
+===================================================
+0
+===================================================
+    
+1-1. inline view     
+
+===================================================
+count(*)    
+19999     
+
+Query plan:
+sscan
+    class: tbl node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl tbl)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl tbl) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+    
+1-2. view     
+
+===================================================
+count(*)    
+19999     
+
+Query plan:
+sscan
+    class: b node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl b)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl b) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+    
+Case 2: LEFT OUTER JOIN where view returns a normal column (inline view vs view)     
+
+===================================================
+Error:-493
+===================================================
+    
+2-1. inline view     
+
+===================================================
+count(*)    
+10000     
+
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join tbl b on a.cola=b.cola
+===================================================
+    
+2-2. view     
+
+===================================================
+count(*)    
+19999     
+
+Query plan:
+sscan
+    class: b node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl b)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl b) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+    
+Case 3: constant expression in view select with outer filter (inline view vs view)     
+
+===================================================
+0
+===================================================
+    
+3-1. inline view     
+
+===================================================
+count(*)    
+10009     
+
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join tbl b on a.cola=(b.cola*?+?) where (a.cola>= ?:?  and a.cola<= ?:? )
+===================================================
+    
+3-2. view     
+
+===================================================
+count(*)    
+10009     
+
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join tbl b on a.cola=(b.cola*?+?) where (a.cola>= ?:?  and a.cola<= ?:? )
+===================================================
+    
+Case 4: grouped view with constant join column (inline view vs view)     
+
+===================================================
+0
+===================================================
+    
+4-1. inline view     
+
+===================================================
+count(*)    
+10000     
+
+Query plan:
+temp(group by)
+    subplan: sscan
+                 class: tbl node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl tbl group by ?)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl tbl group by ?) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+    
+4-2. view     
+
+===================================================
+count(*)    
+10000     
+
+Query plan:
+temp(group by)
+    subplan: sscan
+                 class: b node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl b group by ?)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl b group by ?) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+    
+Case 5: LEFT OUTER JOIN vs INNER JOIN with the same constant-key view     
+
+===================================================
+0
+===================================================
+    
+5-1. LEFT OUTER JOIN using the view     
+
+===================================================
+count(*)    
+10009     
+
+Query plan:
+sscan
+    class: b node[?]
+    sargs: term[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl b where (b.cola>= ?:?  and b.cola<= ?:? ))
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl b where (b.cola>= ?:?  and b.cola<= ?:? )) b (cola) on a.cola=b.cola and a.cola=?
+===================================================
+    
+5-2. INNER JOIN using the view     
+
+===================================================
+count(*)    
+10     
+
+Query plan:
+nl-join (cross join)
+    outer: sscan
+               class: a node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a, tbl b where (b.cola>= ?:?  and b.cola<= ?:? ) and a.cola= ?:? 
+===================================================
+0

--- a/sql/_33_elderberry/cbrd_24042/cbrd_26375/answers/cbrd_26375.answer
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_26375/answers/cbrd_26375.answer
@@ -351,4 +351,186 @@ nl-join (left outer join)
 Query stmt:
 select count(*) from tbl a left outer join (select b.cola from tbl b group by b.cola) b (cola) on a.cola=b.cola
 ===================================================
+    
+Case 7: LEFT OUTER JOIN where view has constant predicate on join key (cola=1)     
+
+===================================================
+0
+===================================================
+    
+7-1. inline view     
+
+===================================================
+count(*)    
+10000     
+
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join tbl b on a.cola=b.cola and b.cola= ?:?  and a.cola= ?:? 
+===================================================
+    
+7-2. view     
+
+===================================================
+count(*)    
+10000     
+
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join tbl b on a.cola=b.cola and b.cola= ?:?  and a.cola= ?:? 
+===================================================
+    
+Case 8: constant folding via CAST on join key in view     
+
+===================================================
+0
+===================================================
+    
+8-1. inline view     
+
+===================================================
+count(*)    
+19999     
+
+Query plan:
+sscan
+    class: tbl node[?]
+    cost:  ? card ?
+Query stmt:
+(select ( cast(? as integer)) from tbl tbl)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ( cast(? as integer)) from tbl tbl) b (cola) on a.cola=b.cola and a.cola=( cast(? as integer))
+===================================================
+    
+8-2. view     
+
+===================================================
+count(*)    
+19999     
+
+Query plan:
+sscan
+    class: b node[?]
+    cost:  ? card ?
+Query stmt:
+(select ( cast(? as integer)) from tbl b)
+Query plan:
+hash-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               cost:  ? card ?
+    during:term[?]
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ( cast(? as integer)) from tbl b) b (cola) on a.cola=b.cola and a.cola=( cast(? as integer))
+===================================================
+    
+Case 9: two-way join; one view join key becomes constant     
+
+===================================================
+0
+===================================================
+    
+9-1. inline view     
+
+===================================================
+count(*)    
+19999     
+
+Query plan:
+sscan
+    class: tbl node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl tbl)
+Query plan:
+hash-join (inner join)
+    edge:  term[?]
+    outer: hash-join (left outer join)
+               edge:  term[?]
+               outer: sscan
+                          class: a node[?]
+                          cost:  ? card ?
+               inner: sscan
+                          class: b node[?]
+                          cost:  ? card ?
+               during:term[?]
+               cost:  ? card ?
+    inner: sscan
+               class: c node[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl tbl) b (cola) on a.cola=b.cola and a.cola=?, tbl c where (a.cola=c.cola) and (a.cola=c.cola)
+===================================================
+    
+9-2. view     
+
+===================================================
+count(*)    
+19999     
+
+Query plan:
+sscan
+    class: b node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tbl b)
+Query plan:
+hash-join (inner join)
+    edge:  term[?]
+    outer: hash-join (left outer join)
+               edge:  term[?]
+               outer: sscan
+                          class: a node[?]
+                          cost:  ? card ?
+               inner: sscan
+                          class: b node[?]
+                          cost:  ? card ?
+               during:term[?]
+               cost:  ? card ?
+    inner: sscan
+               class: c node[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl b) b (cola) on a.cola=b.cola and a.cola=?, tbl c where (a.cola=c.cola) and (a.cola=c.cola)
+===================================================
 0

--- a/sql/_33_elderberry/cbrd_24042/cbrd_26375/answers/cbrd_26375.answer
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_26375/answers/cbrd_26375.answer
@@ -81,18 +81,17 @@ count(*)
 10000     
 
 Query plan:
-nl-join (left outer join)
+hash-join (left outer join)
     edge:  term[?]
     outer: sscan
                class: a node[?]
                cost:  ? card ?
     inner: sscan
                class: b node[?]
-               sargs: term[?]
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select count(*) from tbl a left outer join tbl b on a.cola=b.cola
+select /*+ USE_HASH */ count(*) from tbl a left outer join tbl b on a.cola=b.cola
 ===================================================
     
 2-2. view     
@@ -102,18 +101,17 @@ count(*)
 10000     
 
 Query plan:
-nl-join (left outer join)
+hash-join (left outer join)
     edge:  term[?]
     outer: sscan
                class: a node[?]
                cost:  ? card ?
     inner: sscan
                class: b node[?]
-               sargs: term[?]
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select count(*) from tbl a left outer join tbl b on a.cola=b.cola
+select /*+ USE_HASH */ count(*) from tbl a left outer join tbl b on a.cola=b.cola
 ===================================================
     
 Case 3: constant expression in view select with outer filter (inline view vs view)     
@@ -129,7 +127,7 @@ count(*)
 10009     
 
 Query plan:
-nl-join (left outer join)
+hash-join (left outer join)
     edge:  term[?]
     outer: sscan
                class: a node[?]
@@ -137,11 +135,10 @@ nl-join (left outer join)
                cost:  ? card ?
     inner: sscan
                class: b node[?]
-               sargs: term[?]
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select count(*) from tbl a left outer join tbl b on a.cola=(b.cola*?+?) where (a.cola>= ?:?  and a.cola<= ?:? )
+select /*+ USE_HASH */ count(*) from tbl a left outer join tbl b on a.cola=(b.cola*?+?) where (a.cola>= ?:?  and a.cola<= ?:? )
 ===================================================
     
 3-2. view     
@@ -151,7 +148,7 @@ count(*)
 10009     
 
 Query plan:
-nl-join (left outer join)
+hash-join (left outer join)
     edge:  term[?]
     outer: sscan
                class: a node[?]
@@ -159,11 +156,10 @@ nl-join (left outer join)
                cost:  ? card ?
     inner: sscan
                class: b node[?]
-               sargs: term[?]
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select count(*) from tbl a left outer join tbl b on a.cola=(b.cola*?+?) where (a.cola>= ?:?  and a.cola<= ?:? )
+select /*+ USE_HASH */ count(*) from tbl a left outer join tbl b on a.cola=(b.cola*?+?) where (a.cola>= ?:?  and a.cola<= ?:? )
 ===================================================
     
 Case 4: grouped view with constant join column (inline view vs view)     
@@ -288,5 +284,71 @@ nl-join (cross join)
     cost:  ? card ?
 Query stmt:
 select count(*) from tbl a, tbl b where (b.cola>= ?:?  and b.cola<= ?:? ) and a.cola= ?:? 
+===================================================
+    
+Case 6: Grouped view with normal column join column (inline view vs view)     
+
+===================================================
+0
+===================================================
+    
+6-1. inline view     
+
+===================================================
+count(*)    
+10000     
+
+Query plan:
+temp(group by)
+    subplan: sscan
+                 class: tbl node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select tbl.cola from tbl tbl group by tbl.cola)
+Query plan:
+nl-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select count(*) from tbl a left outer join (select tbl.cola from tbl tbl group by tbl.cola) b (cola) on a.cola=b.cola
+===================================================
+    
+6-2. view     
+
+===================================================
+count(*)    
+10000     
+
+Query plan:
+temp(group by)
+    subplan: sscan
+                 class: b node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select b.cola from tbl b group by b.cola)
+Query plan:
+nl-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select count(*) from tbl a left outer join (select b.cola from tbl b group by b.cola) b (cola) on a.cola=b.cola
 ===================================================
 0

--- a/sql/_33_elderberry/cbrd_24042/cbrd_26375/answers/cbrd_26375.answer
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_26375/answers/cbrd_26375.answer
@@ -25,18 +25,19 @@ sscan
 Query stmt:
 (select ? from tbl tbl)
 Query plan:
-hash-join (left outer join)
+nl-join (left outer join)
     edge:  term[?]
     outer: sscan
                class: a node[?]
                cost:  ? card ?
     inner: sscan
                class: b node[?]
+               sargs: term[?] AND term[?]
                cost:  ? card ?
     during:term[?]
     cost:  ? card ?
 Query stmt:
-select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl tbl) b (cola) on a.cola=b.cola and a.cola=?
+select count(*) from tbl a left outer join (select ? from tbl tbl) b (cola) on a.cola=b.cola and a.cola=?
 ===================================================
     
 1-2. view     
@@ -52,18 +53,19 @@ sscan
 Query stmt:
 (select ? from tbl b)
 Query plan:
-hash-join (left outer join)
+nl-join (left outer join)
     edge:  term[?]
     outer: sscan
                class: a node[?]
                cost:  ? card ?
     inner: sscan
                class: b node[?]
+               sargs: term[?] AND term[?]
                cost:  ? card ?
     during:term[?]
     cost:  ? card ?
 Query stmt:
-select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl b) b (cola) on a.cola=b.cola and a.cola=?
+select count(*) from tbl a left outer join (select ? from tbl b) b (cola) on a.cola=b.cola and a.cola=?
 ===================================================
     
 Case 2: LEFT OUTER JOIN where view returns a normal column (inline view vs view)     
@@ -79,17 +81,18 @@ count(*)
 10000     
 
 Query plan:
-hash-join (left outer join)
+nl-join (left outer join)
     edge:  term[?]
     outer: sscan
                class: a node[?]
                cost:  ? card ?
     inner: sscan
                class: b node[?]
+               sargs: term[?]
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select /*+ USE_HASH */ count(*) from tbl a left outer join tbl b on a.cola=b.cola
+select count(*) from tbl a left outer join tbl b on a.cola=b.cola
 ===================================================
     
 2-2. view     
@@ -105,18 +108,19 @@ sscan
 Query stmt:
 (select ? from tbl b)
 Query plan:
-hash-join (left outer join)
+nl-join (left outer join)
     edge:  term[?]
     outer: sscan
                class: a node[?]
                cost:  ? card ?
     inner: sscan
                class: b node[?]
+               sargs: term[?] AND term[?]
                cost:  ? card ?
     during:term[?]
     cost:  ? card ?
 Query stmt:
-select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl b) b (cola) on a.cola=b.cola and a.cola=?
+select count(*) from tbl a left outer join (select ? from tbl b) b (cola) on a.cola=b.cola and a.cola=?
 ===================================================
     
 Case 3: constant expression in view select with outer filter (inline view vs view)     
@@ -132,7 +136,7 @@ count(*)
 10009     
 
 Query plan:
-hash-join (left outer join)
+nl-join (left outer join)
     edge:  term[?]
     outer: sscan
                class: a node[?]
@@ -140,10 +144,11 @@ hash-join (left outer join)
                cost:  ? card ?
     inner: sscan
                class: b node[?]
+               sargs: term[?]
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select /*+ USE_HASH */ count(*) from tbl a left outer join tbl b on a.cola=(b.cola*?+?) where (a.cola>= ?:?  and a.cola<= ?:? )
+select count(*) from tbl a left outer join tbl b on a.cola=(b.cola*?+?) where (a.cola>= ?:?  and a.cola<= ?:? )
 ===================================================
     
 3-2. view     
@@ -153,7 +158,7 @@ count(*)
 10009     
 
 Query plan:
-hash-join (left outer join)
+nl-join (left outer join)
     edge:  term[?]
     outer: sscan
                class: a node[?]
@@ -161,10 +166,11 @@ hash-join (left outer join)
                cost:  ? card ?
     inner: sscan
                class: b node[?]
+               sargs: term[?]
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select /*+ USE_HASH */ count(*) from tbl a left outer join tbl b on a.cola=(b.cola*?+?) where (a.cola>= ?:?  and a.cola<= ?:? )
+select count(*) from tbl a left outer join tbl b on a.cola=(b.cola*?+?) where (a.cola>= ?:?  and a.cola<= ?:? )
 ===================================================
     
 Case 4: grouped view with constant join column (inline view vs view)     
@@ -189,18 +195,19 @@ temp(group by)
 Query stmt:
 (select ? from tbl tbl group by ?)
 Query plan:
-hash-join (left outer join)
+nl-join (left outer join)
     edge:  term[?]
     outer: sscan
                class: a node[?]
                cost:  ? card ?
     inner: sscan
                class: b node[?]
+               sargs: term[?] AND term[?]
                cost:  ? card ?
     during:term[?]
     cost:  ? card ?
 Query stmt:
-select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl tbl group by ?) b (cola) on a.cola=b.cola and a.cola=?
+select count(*) from tbl a left outer join (select ? from tbl tbl group by ?) b (cola) on a.cola=b.cola and a.cola=?
 ===================================================
     
 4-2. view     
@@ -219,18 +226,19 @@ temp(group by)
 Query stmt:
 (select ? from tbl b group by ?)
 Query plan:
-hash-join (left outer join)
+nl-join (left outer join)
     edge:  term[?]
     outer: sscan
                class: a node[?]
                cost:  ? card ?
     inner: sscan
                class: b node[?]
+               sargs: term[?] AND term[?]
                cost:  ? card ?
     during:term[?]
     cost:  ? card ?
 Query stmt:
-select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl b group by ?) b (cola) on a.cola=b.cola and a.cola=?
+select count(*) from tbl a left outer join (select ? from tbl b group by ?) b (cola) on a.cola=b.cola and a.cola=?
 ===================================================
     
 Case 5: LEFT OUTER JOIN vs INNER JOIN with the same constant-key view     
@@ -253,18 +261,19 @@ sscan
 Query stmt:
 (select ? from tbl b where (b.cola>= ?:?  and b.cola<= ?:? ))
 Query plan:
-hash-join (left outer join)
+nl-join (left outer join)
     edge:  term[?]
     outer: sscan
                class: a node[?]
                cost:  ? card ?
     inner: sscan
                class: b node[?]
+               sargs: term[?] AND term[?]
                cost:  ? card ?
     during:term[?]
     cost:  ? card ?
 Query stmt:
-select /*+ USE_HASH */ count(*) from tbl a left outer join (select ? from tbl b where (b.cola>= ?:?  and b.cola<= ?:? )) b (cola) on a.cola=b.cola and a.cola=?
+select count(*) from tbl a left outer join (select ? from tbl b where (b.cola>= ?:?  and b.cola<= ?:? )) b (cola) on a.cola=b.cola and a.cola=?
 ===================================================
     
 5-2. INNER JOIN using the view     
@@ -285,6 +294,6 @@ nl-join (cross join)
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select /*+ USE_HASH */ count(*) from tbl a, tbl b where (b.cola>= ?:?  and b.cola<= ?:? ) and a.cola= ?:? 
+select count(*) from tbl a, tbl b where (b.cola>= ?:?  and b.cola<= ?:? ) and a.cola= ?:? 
 ===================================================
 0

--- a/sql/_33_elderberry/cbrd_24042/cbrd_26375/cases/cbrd_26375.sql
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_26375/cases/cbrd_26375.sql
@@ -109,4 +109,57 @@ from tbl a,
      v_tbl_group_col b
 where a.cola = b.cola(+);
 
+evaluate 'Case 7: LEFT OUTER JOIN where view has constant predicate on join key (cola=1)';
+create or replace view v_tbl_pred_const as
+select cola
+from tbl
+where cola = 1;
+
+evaluate '7-1. inline view';
+select /*+ recompile use_hash */ count(*)
+from tbl a, (select cola from tbl where cola = 1) b
+where a.cola = b.cola(+);
+
+evaluate '7-2. view';
+select /*+ recompile use_hash */ count(*)
+from tbl a, v_tbl_pred_const b
+where a.cola = b.cola(+);
+
+evaluate 'Case 8: constant folding via CAST on join key in view';
+
+create or replace view v_tbl_cast_const as
+select cast(1 as int) as cola
+from tbl;
+
+evaluate '8-1. inline view';
+select /*+ recompile use_hash */ count(*)
+from tbl a, (select cast(1 as int) as cola from tbl) b
+where a.cola = b.cola(+);
+
+evaluate '8-2. view';
+select /*+ recompile use_hash */ count(*)
+from tbl a, v_tbl_cast_const b
+where a.cola = b.cola(+);
+
+evaluate 'Case 9: two-way join; one view join key becomes constant';
+
+create or replace view v_tbl_const as
+select 1 as cola from tbl;
+
+evaluate '9-1. inline view';
+select /*+ recompile use_hash */ count(*)
+from tbl a,
+     (select cola from tbl) c,
+     (select 1 as cola from tbl) b
+where a.cola = c.cola
+  and a.cola = b.cola(+);
+
+evaluate '9-2. view';
+select /*+ recompile use_hash */ count(*)
+from tbl a,
+     (select cola from tbl) c,
+     v_tbl_const b
+where a.cola = c.cola
+  and a.cola = b.cola(+);
+
 drop table if exists tbl;

--- a/sql/_33_elderberry/cbrd_24042/cbrd_26375/cases/cbrd_26375.sql
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_26375/cases/cbrd_26375.sql
@@ -23,7 +23,7 @@ where a.cola = b.cola(+);
 
 evaluate 'Case 2: LEFT OUTER JOIN where view returns a normal column (inline view vs view)';
 -- join key is not a constant; view merge should still be allowed
-acreate or replace view v_tbl as
+create or replace view v_tbl as
 select cola from tbl;
 
 evaluate '2-1. inline view';

--- a/sql/_33_elderberry/cbrd_24042/cbrd_26375/cases/cbrd_26375.sql
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_26375/cases/cbrd_26375.sql
@@ -27,12 +27,12 @@ create or replace view v_tbl as
 select cola from tbl;
 
 evaluate '2-1. inline view';
-select /*+ recompile */ count(*)
+select /*+ recompile use_hash */ count(*)
 from tbl a, (select cola from tbl) b
 where a.cola = b.cola(+);
 
 evaluate '2-2. view';
-select /*+ recompile */ count(*)
+select /*+ recompile use_hash */ count(*)
 from tbl a, v_tbl b
 where a.cola = b.cola(+);
 
@@ -42,14 +42,14 @@ select cola * 0 + 1 as cola_expr
 from tbl;
 
 evaluate '3-1. inline view';
-select /*+ recompile */ count(*)
+select /*+ recompile use_hash */ count(*)
 from tbl a,
      (select cola * 0 + 1 as cola_expr from tbl) b
 where a.cola = b.cola_expr(+)
   and a.cola between 1 and 10;
 
 evaluate '3-2. view';
-select /*+ recompile */ count(*)
+select /*+ recompile use_hash */ count(*)
 from tbl a,
      v_tbl_const_expr b
 where a.cola = b.cola_expr(+)
@@ -90,5 +90,23 @@ select /*+ recompile */ count(*)
 from tbl a
      inner join v_tbl_const_key b
        on a.cola = b.cola;
+
+evaluate 'Case 6: Grouped view with normal column join column (inline view vs view)';
+create or replace view v_tbl_group_col as
+select cola, max(colb) as cnt
+from tbl
+group by cola;
+
+evaluate '6-1. inline view';
+select /*+ recompile */ count(*)
+from tbl a,
+     (select cola, max(colb) as cnt from tbl group by cola) b
+where a.cola = b.cola(+);
+
+evaluate '6-2. view';
+select /*+ recompile */ count(*)
+from tbl a,
+     v_tbl_group_col b
+where a.cola = b.cola(+);
 
 drop table if exists tbl;

--- a/sql/_33_elderberry/cbrd_24042/cbrd_26375/cases/cbrd_26375.sql
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_26375/cases/cbrd_26375.sql
@@ -1,0 +1,94 @@
+-- Verification for CBRD-26375 : LEFT OUTER JOIN view merge restriction
+
+drop table if exists tbl;
+create table tbl (cola int,colb int);
+insert into tbl
+select rownum, rownum
+from db_class a, db_class b, db_class c, db_class d, db_class e
+limit 10000;
+
+evaluate 'Case 1: LEFT OUTER JOIN with constant column (inline view vs view)';
+create or replace view v_tbl as
+select 1 cola from tbl;
+
+evaluate '1-1. inline view';
+select /*+ recompile use_hash */ count(*)
+from tbl a, (select 1 cola from tbl) b
+where a.cola = b.cola(+);
+
+evaluate '1-2. view';
+select /*+ recompile use_hash */ count(*)
+from tbl a, v_tbl b
+where a.cola = b.cola(+);
+
+evaluate 'Case 2: LEFT OUTER JOIN where view returns a normal column (inline view vs view)';
+-- join key is not a constant; view merge should still be allowed
+acreate or replace view v_tbl as
+select cola from tbl;
+
+evaluate '2-1. inline view';
+select /*+ recompile use_hash */ count(*)
+from tbl a, (select cola from tbl) b
+where a.cola = b.cola(+);
+
+evaluate '2-2. view';
+select /*+ recompile use_hash */ count(*)
+from tbl a, v_tbl b
+where a.cola = b.cola(+);
+
+evaluate 'Case 3: constant expression in view select with outer filter (inline view vs view)';
+create or replace view v_tbl_const_expr as
+select cola * 0 + 1 as cola_expr
+from tbl;
+
+evaluate '3-1. inline view';
+select /*+ recompile use_hash */ count(*)
+from tbl a,
+     (select cola * 0 + 1 as cola_expr from tbl) b
+where a.cola = b.cola_expr(+)
+  and a.cola between 1 and 10;
+
+evaluate '3-2. view';
+select /*+ recompile use_hash */ count(*)
+from tbl a,
+     v_tbl_const_expr b
+where a.cola = b.cola_expr(+)
+  and a.cola between 1 and 10;
+
+evaluate 'Case 4: grouped view with constant join column (inline view vs view)';
+create or replace view v_tbl_group_const as
+select 1 as cola, count(*) as cnt
+from tbl
+group by 1;
+
+evaluate '4-1. inline view';
+select /*+ recompile use_hash */ count(*)
+from tbl a,
+     (select 1 as cola, count(*) as cnt from tbl group by 1) b
+where a.cola = b.cola(+);
+
+evaluate '4-2. view';
+select /*+ recompile use_hash */ count(*)
+from tbl a,
+     v_tbl_group_const b
+where a.cola = b.cola(+);
+
+evaluate 'Case 5: LEFT OUTER JOIN vs INNER JOIN with the same constant-key view';
+create or replace view v_tbl_const_key as
+select 1 as cola
+from tbl
+where cola between 1 and 10;
+
+evaluate '5-1. LEFT OUTER JOIN using the view';
+select /*+ recompile use_hash */ count(*)
+from tbl a
+     left outer join v_tbl_const_key b
+       on a.cola = b.cola;
+
+evaluate '5-2. INNER JOIN using the view';
+select /*+ recompile use_hash */ count(*)
+from tbl a
+     inner join v_tbl_const_key b
+       on a.cola = b.cola;
+
+drop table if exists tbl;

--- a/sql/_33_elderberry/cbrd_24042/cbrd_26375/cases/cbrd_26375.sql
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_26375/cases/cbrd_26375.sql
@@ -12,12 +12,12 @@ create or replace view v_tbl as
 select 1 cola from tbl;
 
 evaluate '1-1. inline view';
-select /*+ recompile use_hash */ count(*)
+select /*+ recompile */ count(*)
 from tbl a, (select 1 cola from tbl) b
 where a.cola = b.cola(+);
 
 evaluate '1-2. view';
-select /*+ recompile use_hash */ count(*)
+select /*+ recompile */ count(*)
 from tbl a, v_tbl b
 where a.cola = b.cola(+);
 
@@ -27,12 +27,12 @@ acreate or replace view v_tbl as
 select cola from tbl;
 
 evaluate '2-1. inline view';
-select /*+ recompile use_hash */ count(*)
+select /*+ recompile */ count(*)
 from tbl a, (select cola from tbl) b
 where a.cola = b.cola(+);
 
 evaluate '2-2. view';
-select /*+ recompile use_hash */ count(*)
+select /*+ recompile */ count(*)
 from tbl a, v_tbl b
 where a.cola = b.cola(+);
 
@@ -42,14 +42,14 @@ select cola * 0 + 1 as cola_expr
 from tbl;
 
 evaluate '3-1. inline view';
-select /*+ recompile use_hash */ count(*)
+select /*+ recompile */ count(*)
 from tbl a,
      (select cola * 0 + 1 as cola_expr from tbl) b
 where a.cola = b.cola_expr(+)
   and a.cola between 1 and 10;
 
 evaluate '3-2. view';
-select /*+ recompile use_hash */ count(*)
+select /*+ recompile */ count(*)
 from tbl a,
      v_tbl_const_expr b
 where a.cola = b.cola_expr(+)
@@ -62,13 +62,13 @@ from tbl
 group by 1;
 
 evaluate '4-1. inline view';
-select /*+ recompile use_hash */ count(*)
+select /*+ recompile */ count(*)
 from tbl a,
      (select 1 as cola, count(*) as cnt from tbl group by 1) b
 where a.cola = b.cola(+);
 
 evaluate '4-2. view';
-select /*+ recompile use_hash */ count(*)
+select /*+ recompile */ count(*)
 from tbl a,
      v_tbl_group_const b
 where a.cola = b.cola(+);
@@ -80,13 +80,13 @@ from tbl
 where cola between 1 and 10;
 
 evaluate '5-1. LEFT OUTER JOIN using the view';
-select /*+ recompile use_hash */ count(*)
+select /*+ recompile */ count(*)
 from tbl a
      left outer join v_tbl_const_key b
        on a.cola = b.cola;
 
 evaluate '5-2. INNER JOIN using the view';
-select /*+ recompile use_hash */ count(*)
+select /*+ recompile */ count(*)
 from tbl a
      inner join v_tbl_const_key b
        on a.cola = b.cola;


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-26375

위 이슈가 merge될 때 아래 케이스들에 대한 결과도 바뀌었습니다.
인라인 뷰의 조회 결과가 0건인 LEFT OUTER JOIN에서
조인 방식 힌트(USE_HASH, USE_MERGE)가 적용되지 않는 시나리오이며 아래 링크에서 확인하실 수 있습니다.
https://github.com/CUBRID/cubrid-testcases/blob/develop/sql/_13_issues/_25_2h/cases/cbrd_26099.sql

추가 시나리오를 검토하실 때 위 테스트도 함께 봐 주시면,
커버리지가 겹치지 않고 서로 보완적인 케이스로 구성하는 데 도움이 될 것 같습니다.