### PR TITLE
[CBRD-26400] Revised SQL_BY_CCI answers for The correlated subquery cache is being disabled before reaching the max_size

### DIFF
--- a/sql/_36_guava/cbrd_25447/answers/cbrd_25447.answer_cci
+++ b/sql/_36_guava/cbrd_25447/answers/cbrd_25447.answer_cci
@@ -1008,6 +1008,7 @@ Trace Statistics:
     SUBQUERY (correlated)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SUBQUERY_CACHE (hit: ?, miss: ?, size: ?, status: enabled)
      
 
 ===================================================


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26400

CCI revise for: https://github.com/CUBRID/cubrid-testcases/pull/2426/files