### PR TITLE
[CBRD-25719] (BACKPORT) Fix trigger owner resolution when loading legacy unload files with loaddb --no-user-specified-name

### DIFF
--- a/sql/_01_object/_10_system_table/_022_db_trigger/answers/1037.answer
+++ b/sql/_01_object/_10_system_table/_022_db_trigger/answers/1037.answer
@@ -27,7 +27,7 @@ null
 
 ===================================================
 owner    name    action_definition    
-db_user     test_trigger     insert into [dba.op_record] values ( CURRENT_USER , 'delete a new record from test_class', '2008-05-27 15:50:58')     
+db_user     test_trigger     insert into [dba.op_record] ([operator], [op_action], [op_time]) values ( CURRENT_USER , 'delete a new record from test_class', '2008-05-27 15:50:58')     
 
 ===================================================
 0

--- a/sql/_01_object/_10_system_table/_022_db_trigger/answers/1038.answer
+++ b/sql/_01_object/_10_system_table/_022_db_trigger/answers/1038.answer
@@ -27,7 +27,7 @@ null
 
 ===================================================
 owner    name    action_definition    action_time    
-db_user     test_trigger     insert into [dba.op_record] values ( CURRENT_USER , 'delete a new record from test_class', '2008-05-27 15:50:58')     AFTER     
+db_user     test_trigger     insert into [dba.op_record] ([operator], [op_action], [op_time]) values ( CURRENT_USER , 'delete a new record from test_class', '2008-05-27 15:50:58')     AFTER     
 
 ===================================================
 0

--- a/sql/_13_issues/_17_1h/answers/cbrd_21311.answer
+++ b/sql/_13_issues/_17_1h/answers/cbrd_21311.answer
@@ -67,9 +67,9 @@ attribute
 
 ===================================================
 name    condition    action_type    action_definition    comment    
-delete     null     1     insert into [dba.CLASS] values (3)     null     
-insert     null     1     insert into [dba.CLASS] values (1)     null     
-update     null     1     insert into [dba.CLASS] values (2)     null     
+delete     null     1     insert into [dba.CLASS] ([attribute]) values (3)     null     
+insert     null     1     insert into [dba.CLASS] ([attribute]) values (1)     null     
+update     null     1     insert into [dba.CLASS] ([attribute]) values (2)     null     
 
 ===================================================
 0

--- a/sql/_33_elderberry/cbrd_23844/cbrd_24195/answers/change_owner2.answer
+++ b/sql/_33_elderberry/cbrd_23844/cbrd_24195/answers/change_owner2.answer
@@ -13,7 +13,7 @@ null     dba.t2     t2     DBA
 
 ===================================================
 unique_name    name    owner.name    target_class    action_definition    
-dba.trig1     trig1     DBA     null     insert into [dba.t2] values ([obj].[c1])     
+dba.trig1     trig1     DBA     null     insert into [dba.t2] ([c1]) values ([obj].[c1])     
 
 ===================================================
 0
@@ -26,7 +26,7 @@ null     u1.t2     t2     U1
 
 ===================================================
 unique_name    name    owner.name    target_class    action_definition    
-dba.trig1     trig1     DBA     null     insert into [dba.t2] values ([obj].[c1])     
+dba.trig1     trig1     DBA     null     insert into [dba.t2] ([c1]) values ([obj].[c1])     
 
 ===================================================
 1

--- a/sql/_33_elderberry/cbrd_23844/cbrd_24195/answers/change_owner3.answer
+++ b/sql/_33_elderberry/cbrd_23844/cbrd_24195/answers/change_owner3.answer
@@ -29,7 +29,7 @@ null     u2.t2     t2     U2
 
 ===================================================
 unique_name    name    owner.name    target_class    action_definition    
-dba.trig1     trig1     DBA     null     insert into [dba.t2] values ([obj].[c1])     
+dba.trig1     trig1     DBA     null     insert into [dba.t2] ([c1]) values ([obj].[c1])     
 
 ===================================================
 1
@@ -50,7 +50,7 @@ null     u2.t2     t2     U2
 
 ===================================================
 unique_name    name    owner.name    target_class    action_definition    
-dba.trig1     trig1     DBA     null     insert into [dba.t2] values ([obj].[c1])     
+dba.trig1     trig1     DBA     null     insert into [dba.t2] ([c1]) values ([obj].[c1])     
 
 ===================================================
 1
@@ -72,7 +72,7 @@ null     u2.t2     t2     U2
 
 ===================================================
 unique_name    name    owner.name    target_class    action_definition    
-dba.trig1     trig1     DBA     null     insert into [dba.t2] values ([obj].[c1])     
+dba.trig1     trig1     DBA     null     insert into [dba.t2] ([c1]) values ([obj].[c1])     
 
 ===================================================
 1

--- a/sql/_33_elderberry/cbrd_23844/cbrd_24195/answers/change_owner4.answer
+++ b/sql/_33_elderberry/cbrd_23844/cbrd_24195/answers/change_owner4.answer
@@ -41,15 +41,15 @@ dba.t1_ai_c1     t1_ai_c1     DBA
 Error:-1342
 ===================================================
 unique_name    name    owner.name    target_class    action_definition    
-dba.trig1     trig1     DBA     null     insert into [dba.t2] values ([obj].[c1])     
-u2.trig2     trig2     U2     null     insert into [u2.t2] values ([obj].[c1])     
+dba.trig1     trig1     DBA     null     insert into [dba.t2] ([c1]) values ([obj].[c1])     
+u2.trig2     trig2     U2     null     insert into [u2.t2] ([c1]) values ([obj].[c1])     
 
 ===================================================
 0
 ===================================================
 unique_name    name    owner.name    target_class    action_definition    
-dba.trig2     trig2     DBA     null     insert into [dba.t2] values ([obj].[c1])     
-u2.trig2     trig2     U2     null     insert into [u2.t2] values ([obj].[c1])     
+dba.trig2     trig2     DBA     null     insert into [dba.t2] ([c1]) values ([obj].[c1])     
+u2.trig2     trig2     U2     null     insert into [u2.t2] ([c1]) values ([obj].[c1])     
 
 ===================================================
 1
@@ -63,8 +63,8 @@ null
 
 ===================================================
 unique_name    name    owner.name    target_class    action_definition    
-u1.trig2     trig2     U1     null     insert into [dba.t2] values ([obj].[c1])     
-u2.trig2     trig2     U2     null     insert into [u2.t2] values ([obj].[c1])     
+u1.trig2     trig2     U1     null     insert into [dba.t2] ([c1]) values ([obj].[c1])     
+u2.trig2     trig2     U2     null     insert into [u2.t2] ([c1]) values ([obj].[c1])     
 
 ===================================================
 1
@@ -77,8 +77,8 @@ c1
 Error:-505
 ===================================================
 unique_name    name    owner.name    target_class    action_definition    
-u1.trig2     trig2     U1     null     insert into [dba.t2] values ([obj].[c1])     
-u2.trig2     trig2     U2     null     insert into [u2.t2] values ([obj].[c1])     
+u1.trig2     trig2     U1     null     insert into [dba.t2] ([c1]) values ([obj].[c1])     
+u2.trig2     trig2     U2     null     insert into [u2.t2] ([c1]) values ([obj].[c1])     
 
 ===================================================
 1

--- a/sql/_33_elderberry/cbrd_23844/cbrd_24195/answers/create1.answer
+++ b/sql/_33_elderberry/cbrd_23844/cbrd_24195/answers/create1.answer
@@ -20,7 +20,7 @@ u1.s1     s1     U1
 0
 ===================================================
 unique_name    name    owner.name    target_class    action_definition    
-u1.trig1     trig1     U1     null     insert into [dba.t2] values ([obj].[c1])     
+u1.trig1     trig1     U1     null     insert into [dba.t2] ([c1]) values ([obj].[c1])     
 
 ===================================================
 1

--- a/sql/_33_elderberry/cbrd_23844/cbrd_24195/answers/create2.answer
+++ b/sql/_33_elderberry/cbrd_23844/cbrd_24195/answers/create2.answer
@@ -30,7 +30,7 @@ u1.s1     s1     U1
 0
 ===================================================
 unique_name    name    owner.name    target_class    action_definition    
-u1.trig1     trig1     U1     null     insert into [u2.t2] values ([obj].[c1])     
+u1.trig1     trig1     U1     null     insert into [u2.t2] ([c1]) values ([obj].[c1])     
 
 ===================================================
 1

--- a/sql/_33_elderberry/cbrd_23844/cbrd_24195/answers/rename2.answer
+++ b/sql/_33_elderberry/cbrd_23844/cbrd_24195/answers/rename2.answer
@@ -11,7 +11,7 @@ null     dba.t2     t2     DBA
 
 ===================================================
 unique_name    name    owner.name    target_class    action_definition    
-dba.trig1     trig1     DBA     null     insert into [dba.t2] values ([obj].[c1])     
+dba.trig1     trig1     DBA     null     insert into [dba.t2] ([c1]) values ([obj].[c1])     
 
 ===================================================
 0
@@ -24,7 +24,7 @@ null     dba.t4     t4     DBA
 
 ===================================================
 unique_name    name    owner.name    target_class    action_definition    
-dba.trig1     trig1     DBA     null     insert into [dba.t2] values ([obj].[c1])     
+dba.trig1     trig1     DBA     null     insert into [dba.t2] ([c1]) values ([obj].[c1])     
 
 ===================================================
 1

--- a/sql/_33_elderberry/cbrd_23844/cbrd_24195/answers/rename3.answer
+++ b/sql/_33_elderberry/cbrd_23844/cbrd_24195/answers/rename3.answer
@@ -11,7 +11,7 @@ null     dba.t2     t2     DBA
 
 ===================================================
 unique_name    name    owner.name    target_class    action_definition    
-dba.trig1     trig1     DBA     null     insert into [dba.t2] values ([obj].[c1])     
+dba.trig1     trig1     DBA     null     insert into [dba.t2] ([c1]) values ([obj].[c1])     
 
 ===================================================
 1
@@ -30,7 +30,7 @@ null     dba.t4     t4     DBA
 
 ===================================================
 unique_name    name    owner.name    target_class    action_definition    
-dba.trig1     trig1     DBA     null     insert into [dba.t2] values ([obj].[c1])     
+dba.trig1     trig1     DBA     null     insert into [dba.t2] ([c1]) values ([obj].[c1])     
 
 ===================================================
 1

--- a/sql/_33_elderberry/cbrd_23844/cbrd_24195/answers/rename4.answer
+++ b/sql/_33_elderberry/cbrd_23844/cbrd_24195/answers/rename4.answer
@@ -17,7 +17,7 @@ null     dba.t4     t4     DBA
 
 ===================================================
 unique_name    name    owner.name    target_class    action_definition    
-dba.trig1     trig1     DBA     null     insert into [dba.t2] values ([obj].[c1])     
+dba.trig1     trig1     DBA     null     insert into [dba.t2] ([c1]) values ([obj].[c1])     
 
 ===================================================
 1
@@ -38,7 +38,7 @@ null     dba.t4     t4     DBA
 
 ===================================================
 unique_name    name    owner.name    target_class    action_definition    
-dba.trig1     trig1     DBA     null     insert into [dba.t2] values ([obj].[c1])     
+dba.trig1     trig1     DBA     null     insert into [dba.t2] ([c1]) values ([obj].[c1])     
 
 ===================================================
 1


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25719

### Purpose

#### 11.4v에 반영된 PR 1건(#5729)을 백포트하는 과정에서 답안지 수정이 필요합니다.
- 11.4v에 반영된 PR(#5729)의 목적은 과거 unload 파일을 loaddb --no-user-specified-name 옵션으로 로드하여 Trigger를 생성할 때, 실제 소유자를 정확히 찾아 db_trigger 카탈로그에 저장하도록 하는 것입니다.
- 해당 PR을 백포트하는 과정에서 Trigger 관련 동작이 변경되어, 기존 TC의 기대 결과와 차이가 발생함에 따라 답안지 수정이 필요합니다.

#### Trigger 생성 및 loaddb 실행 시 db_trigger 카탈로그 관련 TC 답안지 수정
- loaddb 유틸리티를 통해 Trigger를 생성하는 로직이 수정되었으며, 이에 따라 db_trigger 카탈로그의 condition 및 action_definition 컬럼에는 Query Rewrite 구문이 저장되도록 변경되었습니다.
  - 그 결과, INSERT 및 Inline View 구문에서 컬럼 리스트가 명시적으로 출력됩니다.
  - 해당 변경 사항은 `loaddb 유틸리티`뿐만 아니라, `CREATE TRIGGER` 구문에도 동일하게 적용됩니다.
- 11.3v 에서는 SP에 [user_schema] 개념이 존재하지 않아, 본 변경 사항의 적용 대상에서 제외됩니다.

SQL 구문
```sql
CREATE TABLE t1(col1 INTEGER, col2 VARCHAR, col3 DATETIME);
CREATE TABLE t2(col1 INTEGER, col2 VARCHAR, col3 DATETIME);

CREATE TRIGGER example_trigger1
  STATUS ACTIVE
  PRIORITY 0.000000
  AFTER INSERT ON [t1]
  EXECUTE insert into [t2] values(1, 'a', sysdatetime);

CREATE TRIGGER example_trigger2
  STATUS ACTIVE
  PRIORITY 0.000000
  AFTER INSERT ON [t1]
  EXECUTE insert into [t2] select a.col1, 'a', sysdatetime from (select col1 from t2);
```

AS-IS
```
select unique_name, owner.name, name, condition, action_definition from db_trigger;

<00001> unique_name      : 'dba.example_trigger1'
        owner.name       : 'DBA'
        name             : 'example_trigger1'
        condition        : NULL
        action_definition: 'insert into [dba.t2] values (1, 'a',  SYS_DATETIME )'
<00002> unique_name      : 'dba.example_trigger2'
        owner.name       : 'DBA'
        name             : 'example_trigger2'
        condition        : NULL
        action_definition: 'insert into [dba.t2] select [a].[col1], 'a',  SYS_DATETIME  from (select [dba.t2].[col1] from [dba.t2] [dba.t2]) [a]'
```

TO-BE
```
select unique_name, owner.name, name, condition, action_definition from db_trigger;

<00001> unique_name      : 'dba.example_trigger1'
        owner.name       : 'DBA'
        name             : 'example_trigger1'
        condition        : NULL
        action_definition: 'insert into [dba.t2] ([col1], [col2], [col3]) values (1, 'a',  SYS_DATETIME )'
<00002> unique_name      : 'dba.example_trigger2'
        owner.name       : 'DBA'
        name             : 'example_trigger2'
        condition        : NULL
        action_definition: 'insert into [dba.t2] ([col1], [col2], [col3]) select [a].[col1], 'a',  SYS_DATETIME  from (select [dba.t2].[col1] from [dba.t2] [dba.t2]) [a] ([col1])'
```

### Implementation

N/A

### Remarks

N/A