### PR TITLE
[CUBRIDQA-1136] Backport from develop to 11.4 - Modify Test case for DATETIME Year Defaulting Behavior

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_04_type_convert_function/answers/04_04_03_04_bfn_type_cast4.answer
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_04_type_convert_function/answers/04_04_03_04_bfn_type_cast4.answer
@@ -31,8 +31,12 @@ null
 12:00:00.000 AM 01/01/1999
 10:00:00.000 AM 01/01/1999
 10:00:00.000 PM 01/01/1999
-12:00:00.998 AM 01/01/2025
-12:00:00.998 AM 01/01/2025
+-- year defaulting rule (omitted year = current system year)
+1
+1
+-- normalized output (omit year to keep answer stable)
+12:00:00.998 AM 01/01
+12:00:00.998 AM 01/01
 12:00:00.998 AM 01/01/1999
 12:00:00.998 AM 01/01/1999
 10:00:00.998 AM 01/01/1999

--- a/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_04_type_convert_function/cases/04_04_03_04_bfn_type_cast4.sql
+++ b/sql/_05_plcsql/_01_testspec/_04_expression/_04_function_call/_03_builtin_function/_04_type_convert_function/cases/04_04_03_04_bfn_type_cast4.sql
@@ -23,8 +23,23 @@ begin
     dbms_output.put_line(CAST('00:00 01/01/1999' AS DATETIME));
     dbms_output.put_line(CAST('10:00 am 01/01/1999' AS DATETIME));
     dbms_output.put_line(CAST('10:00 pm 01/01/1999' AS DATETIME));
-    dbms_output.put_line(CAST('00:00:00.998 1/1' AS DATETIME));
-    dbms_output.put_line(CAST('00:00:00.998 01/01' AS DATETIME));
+    dbms_output.put_line('-- year defaulting rule (omitted year = current system year)');
+    dbms_output.put_line(
+      CASE
+        WHEN YEAR(CAST('00:00:00.998 1/1' AS DATETIME)) = YEAR(SYS_DATETIME)
+        THEN 1 ELSE 0
+      END
+    );
+    dbms_output.put_line(
+      CASE
+        WHEN YEAR(CAST('00:00:00.998 01/01' AS DATETIME)) = YEAR(SYS_DATETIME)
+        THEN 1 ELSE 0
+      END
+    );
+
+    dbms_output.put_line('-- normalized output (omit year to keep answer stable)');
+    dbms_output.put_line(TO_CHAR(CAST('00:00:00.998 1/1' AS DATETIME), 'HH:MI:SS.FF AM MM/DD'));
+    dbms_output.put_line(TO_CHAR(CAST('00:00:00.998 01/01' AS DATETIME), 'HH:MI:SS.FF AM MM/DD'));
     dbms_output.put_line(CAST('00:00:00.998 01/01/99' AS DATETIME));
     dbms_output.put_line(CAST('00:00:00.998 01/01/1999' AS DATETIME));
     dbms_output.put_line(CAST('10:00:00.998 am 01/01/1999' AS DATETIME));


### PR DESCRIPTION
Backport #2443

develop 브랜치에서 리뷰를 이미 받았고, 긴급패치로 인해 바로 merge합니다.