### PR TITLE
[CUBRIDQA-1136] Stabilize Test Case by Adding 'wait until C2 ready' (11.4)

### DIFF
--- a/isolation/_05_ReadCommitted_RepeatableRead/index_column/composite_index/basic_sql/insert_select_01_complex.ctl
+++ b/isolation/_05_ReadCommitted_RepeatableRead/index_column/composite_index/basic_sql/insert_select_01_complex.ctl
@@ -119,6 +119,7 @@ MC: wait until C2 ready;
 C1: select count(*) from t;
 C1: commit;
 C2: insert into t values(1,1);
+C2: wait until C2 ready;
 
 /* expected 100 */
 C6: select count(*) from t where col=1;

--- a/isolation/_05_ReadCommitted_RepeatableRead/index_column/composite_index/basic_sql/insert_select_01_complex.ctl
+++ b/isolation/_05_ReadCommitted_RepeatableRead/index_column/composite_index/basic_sql/insert_select_01_complex.ctl
@@ -119,7 +119,7 @@ MC: wait until C2 ready;
 C1: select count(*) from t;
 C1: commit;
 C2: insert into t values(1,1);
-C2: wait until C2 ready;
+MC: wait until C2 ready;
 
 /* expected 100 */
 C6: select count(*) from t where col=1;


### PR DESCRIPTION
isolation에서 unstable case 를 수정했던 것을, 11.4에도 백포트합니다.
Backport #2299 #2330