### PR TITLE
[CBRD-26419] 뷰머지시 ordered힌트가 복사되면서 의도하지 않게 전체 테이블 조인 순서 고정됨

### DIFF
--- a/sql/_33_elderberry/cbrd_24042/cbrd_24182/answers/complex_predicate.answer
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_24182/answers/complex_predicate.answer
@@ -24,12 +24,19 @@ count(*)
 1     
 
 Query plan:
-sscan
-    class: a node[?]
-    sargs: term[?]
+nl-join (left outer join)
+    edge:  term[?] AND term[?]
+    outer: sscan
+               class: a node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               sargs: term[?] AND term[?]
+               cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select count(*) from t a where a.c_c= ?:? 
+select count(*) from t a left outer join t b on a.c_b=b.c_b and a.c_a+a.c_b=nvl(b.c_a, ?) where a.c_c= ?:? 
 ===================================================
 count(*)    
 1     

--- a/sql/_33_elderberry/cbrd_24042/cbrd_26263/answers/cbrd_26263.answer
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_26263/answers/cbrd_26263.answer
@@ -363,11 +363,19 @@ count(*)
 6     
 
 Query plan:
-sscan
-    class: a node[?]
+nl-join (left outer join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: iscan
+               class: b node[?]
+               index: pk term[?] (covers)
+               filtr: term[?]
+               cost:  ? card ?
     cost:  ? card ?
 Query stmt:
-select count(*) from tbl a
+select count(*) from tbl a left outer join tbl b on b.cola= ?:?  and  cast(a.colb as varchar(?))= cast(b.colb as varchar(?))
 ===================================================
     
 Case 19: HAVING uses right-side column (aggregate) -> elimination not allowed     

--- a/sql/_35_fig_cake/cbrd_24044/cbrd_25089/answers/cbrd_25089.answer
+++ b/sql/_35_fig_cake/cbrd_24044/cbrd_25089/answers/cbrd_25089.answer
@@ -134,8 +134,8 @@ nl-join (inner join)
                sargs: term[?]
                cost:  ? card ?
     cost:  ? card ?
-Query stmt: [Warning: HINT ignored]
-select a.cola, a.colb, b.cola, b.colb, c.cola, c.colb from tbl a, tbl b, tbl c where a.cola=b.cola and b.cola=c.cola
+Query stmt:
+select /*+ LEADING(a, c) */ a.cola, a.colb, b.cola, b.colb, c.cola, c.colb from tbl a, tbl b, tbl c where a.cola=b.cola and b.cola=c.cola
 ===================================================
 'test5'    
 
@@ -154,15 +154,15 @@ nl-join (inner join)
     outer: nl-join (inner join)
                edge:  term[?]
                outer: sscan
-                          class: b node[?]
+                          class: a node[?]
                           cost:  ? card ?
                inner: sscan
-                          class: c node[?]
+                          class: b node[?]
                           sargs: term[?]
                           cost:  ? card ?
                cost:  ? card ?
     inner: sscan
-               class: a node[?]
+               class: c node[?]
                sargs: term[?]
                cost:  ? card ?
     cost:  ? card ?
@@ -752,13 +752,13 @@ temp
                                          outer: temp
                                                     order: cola[?]
                                                     subplan: sscan
-                                                                 class: b node[?]
+                                                                 class: a node[?]
                                                                  cost:  ? card ?
                                                     cost:  ? card ?
                                          inner: temp
                                                     order: cola[?]
                                                     subplan: sscan
-                                                                 class: c node[?]
+                                                                 class: b node[?]
                                                                  cost:  ? card ?
                                                     cost:  ? card ?
                                          cost:  ? card ?
@@ -766,7 +766,7 @@ temp
                  inner: temp
                             order: cola[?]
                             subplan: sscan
-                                         class: a node[?]
+                                         class: c node[?]
                                          cost:  ? card ?
                             cost:  ? card ?
                  cost:  ? card ?


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26419

leading 힌트가 prefix에서 부분 우선순위로 변경되면서 실행계획 변경됨