### PR TITLE
[CBRD-26419] 뷰머지시 ordered힌트가 복사되면서 의도하지 않게 전체 테이블 조인 순서 고정됨

### DIFF
--- a/sql/_35_fig_cake/cbrd_24044/cbrd_25089/answers/cbrd_25089.answer
+++ b/sql/_35_fig_cake/cbrd_24044/cbrd_25089/answers/cbrd_25089.answer
@@ -134,8 +134,8 @@ nl-join (inner join)
                sargs: term[?]
                cost:  ? card ?
     cost:  ? card ?
-Query stmt: [Warning: HINT ignored]
-select a.cola, a.colb, b.cola, b.colb, c.cola, c.colb from tbl a, tbl b, tbl c where a.cola=b.cola and b.cola=c.cola
+Query stmt:
+select /*+ LEADING(a, c) */ a.cola, a.colb, b.cola, b.colb, c.cola, c.colb from tbl a, tbl b, tbl c where a.cola=b.cola and b.cola=c.cola
 ===================================================
 'test5'    
 
@@ -154,15 +154,15 @@ nl-join (inner join)
     outer: nl-join (inner join)
                edge:  term[?]
                outer: sscan
-                          class: b node[?]
+                          class: a node[?]
                           cost:  ? card ?
                inner: sscan
-                          class: c node[?]
+                          class: b node[?]
                           sargs: term[?]
                           cost:  ? card ?
                cost:  ? card ?
     inner: sscan
-               class: a node[?]
+               class: c node[?]
                sargs: term[?]
                cost:  ? card ?
     cost:  ? card ?
@@ -752,13 +752,13 @@ temp
                                          outer: temp
                                                     order: cola[?]
                                                     subplan: sscan
-                                                                 class: b node[?]
+                                                                 class: a node[?]
                                                                  cost:  ? card ?
                                                     cost:  ? card ?
                                          inner: temp
                                                     order: cola[?]
                                                     subplan: sscan
-                                                                 class: c node[?]
+                                                                 class: b node[?]
                                                                  cost:  ? card ?
                                                     cost:  ? card ?
                                          cost:  ? card ?
@@ -766,7 +766,7 @@ temp
                  inner: temp
                             order: cola[?]
                             subplan: sscan
-                                         class: a node[?]
+                                         class: c node[?]
                                          cost:  ? card ?
                             cost:  ? card ?
                  cost:  ? card ?


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26419

leading hint prefix방식에서 부분 우선순위 방식으로 변경에 따른 실행계획 변경