### PR TITLE
[CBRD-26309] Estimate number of groups

### DIFF
--- a/sql/_33_elderberry/cbrd_24042/cbrd_24182/answers/r_outer_join.answer
+++ b/sql/_33_elderberry/cbrd_24042/cbrd_24182/answers/r_outer_join.answer
@@ -66,26 +66,26 @@ count(*)
 3     
 
 Query plan:
-nl-join (inner join)
-    edge:  term[?]
-    outer: idx-join (left outer join)
-               outer: idx-join (inner join)
+idx-join (inner join)
+    outer: nl-join (inner join)
+               edge:  term[?]
+               outer: idx-join (left outer join)
                           outer: sscan
                                      class: a node[?]
                                      cost:  ? card ?
                           inner: iscan
-                                     class: b node[?]
-                                     index: idx term[?] AND term[?] (covers)
+                                     class: c node[?]
+                                     index: idx term[?] AND term[?]
                                      cost:  ? card ?
                           cost:  ? card ?
-               inner: iscan
-                          class: c node[?]
-                          index: idx term[?] AND term[?]
+               inner: sscan
+                          class: d node[?]
+                          sargs: term[?]
                           cost:  ? card ?
                cost:  ? card ?
-    inner: sscan
-               class: d node[?]
-               sargs: term[?]
+    inner: iscan
+               class: b node[?]
+               index: idx term[?] AND term[?] (covers)
                cost:  ? card ?
     cost:  ? card ?
 Query stmt:

--- a/sql/_35_fig_cake/cbrd_25382/answers/cbrd_25382_1.answer
+++ b/sql/_35_fig_cake/cbrd_25382/answers/cbrd_25382_1.answer
@@ -305,7 +305,7 @@ idx-join (inner join)
     sargs: term[?]
     cost:  ? card ?
 Query stmt:
-select /*+ USE_NL(c) USE_HASH(a, b) NO_PARALLEL_SUBQUERY */ count(*) from ta a, tb b, tc c where a.ca=b.ca and a.cb=b.cb and a.cc=b.cc and a.cd=b.cd and a.ca=c.ca and a.cb=c.cb and a.cc=c.cc and a.cd=c.cd
+select /*+ LEADING(a) USE_NL(c) USE_HASH(a, b) NO_PARALLEL_SUBQUERY */ count(*) from ta a, tb b, tc c where a.ca=b.ca and a.cb=b.cb and a.cc=b.cc and a.cd=b.cd and a.ca=c.ca and a.cb=c.cb and a.cc=c.cc and a.cd=c.cd
 ===================================================
 trace    
 
@@ -316,7 +316,7 @@ Query Plan:
       TABLE SCAN (b)
     INDEX SCAN (c.i_a) (key range: a.ca=c.cakey range: a.cb=c.cbkey range: a.cc=c.cc)
 
-  rewritten query: select /*+ USE_NL(c) USE_HASH(a, b) NO_PARALLEL_SUBQUERY */ count(*) from [dba.ta] a, [dba.tb] b, [dba.tc] c where a.ca=b.ca and a.cb=b.cb and a.cc=b.cc and a.cd=b.cd and a.ca=c.ca and a.cb=c.cb and a.cc=c.cc and a.cd=c.cd
+  rewritten query: select /*+ LEADING(a) USE_NL(c) USE_HASH(a, b) NO_PARALLEL_SUBQUERY */ count(*) from [dba.ta] a, [dba.tb] b, [dba.tc] c where a.ca=b.ca and a.cb=b.cb and a.cc=b.cc and a.cd=b.cd and a.ca=c.ca and a.cb=c.cb and a.cc=c.cc and a.cd=c.cd
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -363,7 +363,7 @@ idx-join (inner join)
     sargs: term[?]
     cost:  ? card ?
 Query stmt:
-select /*+ USE_NL(c) USE_HASH(a, b) NO_PARALLEL_SUBQUERY */ count(*) from ta a, tb b, tc c where a.ca=b.ca and a.cb=b.cb and a.cc=b.cc and a.cd=b.cd and a.ca=c.ca and a.cb=c.cb and a.cc=c.cc and a.cd=c.cd
+select /*+ LEADING(a) USE_NL(c) USE_HASH(a, b) NO_PARALLEL_SUBQUERY */ count(*) from ta a, tb b, tc c where a.ca=b.ca and a.cb=b.cb and a.cc=b.cc and a.cd=b.cd and a.ca=c.ca and a.cb=c.cb and a.cc=c.cc and a.cd=c.cd
 ===================================================
 trace    
 
@@ -374,7 +374,7 @@ Query Plan:
       TABLE SCAN (b)
     INDEX SCAN (c.i_a) (key range: a.ca=c.cakey range: a.cb=c.cbkey range: a.cc=c.cc)
 
-  rewritten query: select /*+ USE_NL(c) USE_HASH(a, b) NO_PARALLEL_SUBQUERY */ count(*) from [dba.ta] a, [dba.tb] b, [dba.tc] c where a.ca=b.ca and a.cb=b.cb and a.cc=b.cc and a.cd=b.cd and a.ca=c.ca and a.cb=c.cb and a.cc=c.cc and a.cd=c.cd
+  rewritten query: select /*+ LEADING(a) USE_NL(c) USE_HASH(a, b) NO_PARALLEL_SUBQUERY */ count(*) from [dba.ta] a, [dba.tb] b, [dba.tc] c where a.ca=b.ca and a.cb=b.cb and a.cc=b.cc and a.cd=b.cd and a.ca=c.ca and a.cb=c.cb and a.cc=c.cc and a.cd=c.cd
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -474,7 +474,7 @@ idx-join (inner join)
     sargs: term[?]
     cost:  ? card ?
 Query stmt:
-select /*+ USE_NL(c) USE_HASH(a, b) NO_PARALLEL_SUBQUERY */ count(*) from ta a, tb b, tc c where a.ca=b.ca and a.cb=b.cb and a.cc=b.cc and a.cd=b.cd and a.ca=c.ca and a.cb=c.cb and a.cc=c.cc and a.cd=c.cd
+select /*+ LEADING(a) USE_NL(c) USE_HASH(a, b) NO_PARALLEL_SUBQUERY */ count(*) from ta a, tb b, tc c where a.ca=b.ca and a.cb=b.cb and a.cc=b.cc and a.cd=b.cd and a.ca=c.ca and a.cb=c.cb and a.cc=c.cc and a.cd=c.cd
 ===================================================
 trace    
 
@@ -485,7 +485,7 @@ Query Plan:
       TABLE SCAN (b)
     INDEX SCAN (c.i_a) (key range: a.ca=c.cakey range: a.cb=c.cbkey range: a.cc=c.cc)
 
-  rewritten query: select /*+ USE_NL(c) USE_HASH(a, b) NO_PARALLEL_SUBQUERY */ count(*) from [dba.ta] a, [dba.tb] b, [dba.tc] c where a.ca=b.ca and a.cb=b.cb and a.cc=b.cc and a.cd=b.cd and a.ca=c.ca and a.cb=c.cb and a.cc=c.cc and a.cd=c.cd
+  rewritten query: select /*+ LEADING(a) USE_NL(c) USE_HASH(a, b) NO_PARALLEL_SUBQUERY */ count(*) from [dba.ta] a, [dba.tb] b, [dba.tc] c where a.ca=b.ca and a.cb=b.cb and a.cc=b.cc and a.cd=b.cd and a.ca=c.ca and a.cb=c.cb and a.cc=c.cc and a.cd=c.cd
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)

--- a/sql/_35_fig_cake/cbrd_25382/cases/cbrd_25382_1.sql
+++ b/sql/_35_fig_cake/cbrd_25382/cases/cbrd_25382_1.sql
@@ -101,7 +101,7 @@ evaluate concat ('####', lpad (@i, 3), '. cost: in_memory, hybrid < file, build_
 set system parameters 'max_hash_list_scan_size=512k';
 
 --@queryplan
-select /*+  recompile use_hash(a,b) use_nl(c) no_parallel_subquery */
+select /*+  recompile leading(a) use_hash(a,b) use_nl(c) no_parallel_subquery */
   count (*)
 from ta a, tb b, tc c
 where a.ca = b.ca and a.cb = b.cb and a.cc = b.cc and a.cd = b.cd
@@ -116,7 +116,7 @@ evaluate concat ('####', lpad (@i, 3), '. cost: in_memory, hybrid < file, build_
 set system parameters 'max_hash_list_scan_size=128k';
 
 --@queryplan
-select /*+  recompile use_hash(a,b) use_nl(c) no_parallel_subquery */
+select /*+  recompile leading(a) use_hash(a,b) use_nl(c) no_parallel_subquery */
   count (*)
 from ta a, tb b, tc c
 where a.ca = b.ca and a.cb = b.cb and a.cc = b.cc and a.cd = b.cd
@@ -141,7 +141,7 @@ show trace;
 --select trace_stats ();
 
 --@queryplan
-select /*+  recompile use_hash(a,b) use_nl(c) no_parallel_subquery */
+select /*+  recompile leading(a) use_hash(a,b) use_nl(c) no_parallel_subquery */
   count (*)
 from ta a, tb b, tc c
 where a.ca = b.ca and a.cb = b.cb and a.cc = b.cc and a.cd = b.cd


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26309

sql/_35_fig_cake/cbrd_25382/cases/cbrd_25382_1.sql
--조인시 선택도 최대값이 과도하게 설정되어 card 과소예측되어 nl조인이 유리하다고 판단함.
<== leading 힌트 삽입

sql/_33_elderberry/cbrd_24042/cbrd_24182/cases/r_outer_join.sql
--조인시 선택도 최대값이 과도하게 설정되어 조인 조건이 많은 관계를 우선하는 것이 유리하다고 판단함.
<== plan 변경