### PR TITLE
[CBRD-26465] Parallel heap scan 시 min page를 0으로 설정할 때 발생하는 오류 수정

### DIFF
--- a/sql/_36_guava/cbrd_25447/answers/cbrd_25447.answer
+++ b/sql/_36_guava/cbrd_25447/answers/cbrd_25447.answer
@@ -621,7 +621,7 @@ Trace Statistics:
 
 ===================================================
     
-15. select list contains set (should work) -> row by row     
+15. select list contains set (should work) -> mergeable list     
 
 ===================================================
 0
@@ -649,7 +649,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (table: dba.set_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
@@ -984,7 +984,7 @@ Trace Statistics:
 0
 ===================================================
     
-24. contains correlated SUBQUERY (should not work)     
+24. contains correlated SUBQUERY (should work) -> count (CBRD-26465)     
 
 ===================================================
 count(id)    
@@ -1006,6 +1006,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: count)
     SUBQUERY (correlated)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
@@ -1140,7 +1141,7 @@ Trace Statistics:
 
 ===================================================
     
-30. UPDATE statement with subquery in WHERE clause. subquery SELECT part (should not work)     
+30. UPDATE statement with subquery in WHERE clause. subquery SELECT part (should work) -> mergeable list     
 
 ===================================================
 0
@@ -1171,13 +1172,14 @@ Trace Statistics:
         SUBQUERY (uncorrelated)
           SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
             SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+                 (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
             ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
                     (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
     
-31. DELETE statement with subquery in WHERE clause. subquery SELECT part (should not work)     
+31. DELETE statement with subquery in WHERE clause. subquery SELECT part (should work) -> mergeable list     
 
 ===================================================
 0
@@ -1208,6 +1210,7 @@ Trace Statistics:
         SUBQUERY (uncorrelated)
           SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
             SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+                 (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
             ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
                     (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      

--- a/sql/_36_guava/cbrd_25447/answers/cbrd_25447.answer_cci
+++ b/sql/_36_guava/cbrd_25447/answers/cbrd_25447.answer_cci
@@ -621,7 +621,7 @@ Trace Statistics:
 
 ===================================================
     
-15. select list contains set (should work) -> row by row     
+15. select list contains set (should work) -> mergeable list     
 
 ===================================================
 0
@@ -649,7 +649,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (table: dba.set_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
@@ -984,7 +984,7 @@ Trace Statistics:
 0
 ===================================================
     
-24. contains correlated SUBQUERY (should not work)     
+24. contains correlated SUBQUERY (should work) -> count (CBRD-26465)     
 
 ===================================================
 count(id)    
@@ -1006,6 +1006,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: count)
     SUBQUERY (correlated)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
@@ -1140,7 +1141,7 @@ Trace Statistics:
 
 ===================================================
     
-30. UPDATE statement with subquery in WHERE clause. subquery SELECT part (should not work)     
+30. UPDATE statement with subquery in WHERE clause. subquery SELECT part (should work) -> mergeable list     
 
 ===================================================
 0
@@ -1171,13 +1172,14 @@ Trace Statistics:
         SUBQUERY (uncorrelated)
           SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
             SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+                 (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
             ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
                     (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
     
-31. DELETE statement with subquery in WHERE clause. subquery SELECT part (should not work)     
+31. DELETE statement with subquery in WHERE clause. subquery SELECT part (should work) -> mergeable list     
 
 ===================================================
 0
@@ -1208,6 +1210,7 @@ Trace Statistics:
         SUBQUERY (uncorrelated)
           SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
             SCAN (table: dba.tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+                 (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
             ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
                     (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      

--- a/sql/_36_guava/cbrd_25447/cases/cbrd_25447.sql
+++ b/sql/_36_guava/cbrd_25447/cases/cbrd_25447.sql
@@ -151,7 +151,7 @@ select /*+ PARALLEL(2) */ cola from tbl order by 1 limit 2 for update;
 show trace;
 
 
-evaluate '15. select list contains set (should work) -> row by row';
+evaluate '15. select list contains set (should work) -> mergeable list';
 drop table if exists set_tbl;
 create table set_tbl (c1 set(int));
 insert into set_tbl select {rownum, rownum+1, rownum+2} from db_class a, db_class b, db_class c, db_class d, db_class e limit 8000;
@@ -218,7 +218,7 @@ show trace;
 drop table if exists tree;
 
 
-evaluate '24. contains correlated SUBQUERY (should not work)';
+evaluate '24. contains correlated SUBQUERY (should work) -> count (CBRD-26465)';
 select /*+ PARALLEL(2) */ count(id) from tbl a where a.cola like '%1' and exists (select /*+ PARALLEL(2) */ 1 from tbl b where b.id=a.id);
 show trace;
 
@@ -257,12 +257,12 @@ select count(*) from tbl where (cola like '0%' AND colb = '00000000000000000000'
 show trace;
 
 
-evaluate '30. UPDATE statement with subquery in WHERE clause. subquery SELECT part (should not work)';
+evaluate '30. UPDATE statement with subquery in WHERE clause. subquery SELECT part (should work) -> mergeable list';
 update new_tbl set cola = 'updated' where id in (select /*+ PARALLEL(2) */ id from tbl where cola like '000%');
 show trace;
 
 
-evaluate '31. DELETE statement with subquery in WHERE clause. subquery SELECT part (should not work)';
+evaluate '31. DELETE statement with subquery in WHERE clause. subquery SELECT part (should work) -> mergeable list';
 delete from new_tbl where id in (select /*+ PARALLEL(2) */ id from tbl where colb like '000%');
 show trace;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26465

`exists, scalar correlated subquery가 포함된 질의`에 대한 parallel heap scan 이 가능해지고, 
`set 자료형을 사용하는 질의`나, 
`update, delete의 부질의`에서의 parallel heap scan이 가능해져서 TC를 수정합니다.