### PR TITLE
[CUBRIDQA-1136] Fixed Isolation Test Sync Point After C2 SELECT

### DIFF
--- a/isolation/_01_ReadCommitted/partition_table/range/without_index/update_delete_07.ctl
+++ b/isolation/_01_ReadCommitted/partition_table/range/without_index/update_delete_07.ctl
@@ -44,7 +44,7 @@ MC: wait until C1 ready;
 
 /* expect (1,'abc'),(12,'abc') */
 C2: SELECT * FROM t order by 1,2;
-MC: wait until C1 ready;
+MC: wait until C2 ready;
 
 C1: commit;
 MC: wait until C1 ready;


### PR DESCRIPTION
isolation_debug 에서 자주 발생하는 unstable test case를 수정합니다.

원인:
C2가 SELECT를 아직 실행 중이거나 실행하기 직전인데
MC가 wait until C1 ready를 즉시 통과
이어서 C1 commit이 진행됨
C2 SELECT는 commit 이후 (11,'abc'),(12,'abc')를 보게 되는 케이스가 섞임 -> unstable