### PR TITLE
[CBRD-26490] Add function to set referential_index for self-referencing FK

### DIFF
--- a/sql/_01_object/_08_primary_foreign_key/_001_create/answers/1060.answer
+++ b/sql/_01_object/_08_primary_foreign_key/_001_create/answers/1060.answer
@@ -7,7 +7,7 @@ b     NO
 
 ===================================================
 index_name    is_unique    is_reverse    class_name    owner_name    key_count    is_primary_key    is_foreign_key    filter_expression    have_function    status    referential_index_class_owner_name    referential_index_class_name    referential_index_name    delete_rule    update_rule    referential_match_option    index_type    deduplicate_key_level    comment    
-fk_p2_a     NO     NO     p2     DBA     1     NO     YES     null     NO     NORMAL INDEX     null     null     null     RESTRICT     RESTRICT     NONE     BTREE     0     null     
+fk_p2_a     NO     NO     p2     DBA     1     NO     YES     null     NO     NORMAL INDEX     DBA     p2     pk_p2_b     RESTRICT     RESTRICT     NONE     BTREE     0     null     
 pk_p2_b     YES     NO     p2     DBA     1     YES     NO     null     NO     NORMAL INDEX     null     null     null     null     null     null     BTREE     0     null     
 
 ===================================================


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26490

기존에는 self-referencing 인덱스의 경우 referencial index 정보를 제공하지 못 했는데, 이를 개선(https://github.com/CUBRID/cubrid/pull/6825) 하여 테스트 결과를 수정합니다.