### PR TITLE
[CUBRIDQA-1136] Fix timing issue in unstable isolation test cases

### DIFF
--- a/isolation/_04_RepeatableRead_ReadCommitted/index_column/multi_index/basic_sql/update_delete_09_1.ctl
+++ b/isolation/_04_RepeatableRead_ReadCommitted/index_column/multi_index/basic_sql/update_delete_09_1.ctl
@@ -52,6 +52,7 @@ C2: DELETE FROM t1 WHERE tag IN ('A','B') and 0 = (select sleep(4));
 MC: wait until C2 ready;
 /* expect: no transactions need to wait */
 /* expect: C1 select - id = 3,6 are updated */
+MC: sleep 1;
 C1: SELECT * FROM t1 order by 1,2;
 C1: commit;
 /* expect: C2 finished execution after C1 commit, 2 rows (id=1,2)deleted message, C2 select - id = 1,2 are deleted */

--- a/isolation/_04_RepeatableRead_ReadCommitted/index_column/multi_index/basic_sql/update_delete_09_3.ctl
+++ b/isolation/_04_RepeatableRead_ReadCommitted/index_column/multi_index/basic_sql/update_delete_09_3.ctl
@@ -51,6 +51,7 @@ MC: wait until C1 ready;
 C2: DELETE FROM t1 WHERE (description IS NULL or col = 'abcd') and 0 = (select sleep(4));
 /* expect: no transactions need to wait */
 /* expect: C1 select - id = 2,3,7 are updated */
+MC: sleep 1;
 C1: SELECT * FROM t1 order by 1,2;
 C1: commit;
 /* expect: C2 finished execution after C1 commit, 2 rows (id=5,6)deleted message, C2 select - id = 5,6 are deleted */


### PR DESCRIPTION
[테스트 케이스 수정 사유]

발생 현상: READ COMMITTED 격리 수준에서 4초동안 실행되는 긴 쿼리(C2)가, 초기 데이터 스냅샷이 아닌 다른 트랜잭션(C1)의 커밋이 반영된 후의 최신 데이터를 읽어 테스트가 간헐적으로 실패함.
```
/* test case */
C1: UPDATE t1 SET tag = 'A' WHERE id IN (2,3,5,6) and col != 'pqr' ;
MC: wait until C1 ready;
C2: DELETE FROM t1 WHERE tag in ('A','D') and 0 = (select sleep(4)) 
--> C2가 수행되는 사이 (약 4초간), 
C1: SELECT * FROM t1 order by 1,2;
C1: commit; 
/* expect: C2 finished execution after C1 commit, 2 rows (id=1,4)deleted message, C2 select - id = 1,4 are deleted */
--> C1이 수행되어야하는데, debug모드에서 타이밍 문제로 인해 C1이 C2보다 먼저 수행될 경우가 있음.
```
해결 방안 (MC: sleep 1; 추가): C2 쿼리 전송과 C1 커밋 사이에 1초의 대기 시간을 명시적으로 추가함. 이를 통해 C2가 초기 스냅샷을 먼저 안전하게 확보하는 것을 보장한 뒤 C1이 커밋하도록 유도함. 이로써 동시성 테스트의 본래 의도(쿼리 실행 도중 다른 커밋이 발생해도, 쿼리 시작 시점에 획득한 스냅샷을 올바르게 유지하는가)를 정확히 검증하도록 수정함.

release, debug모드에서 모두 안정적으로 pass하는 것을 확인했습니다.