### PR TITLE
[CBRD-26652] (Backport-10.2.18) Expand precision for auto-casting string literals and non-integers

### DIFF
--- a/sql/_14_mysql_compatibility_2/_15_host_variable/_12_common/answers/where_clause.answer
+++ b/sql/_14_mysql_compatibility_2/_15_host_variable/_12_common/answers/where_clause.answer
@@ -27,7 +27,7 @@ iscan
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select t?.i?, t?.i? from t? t? where t?.i?= cast(t?.i? as numeric)+?.? order by ?
+select t?.i?, t?.i? from t? t? where t?.i?= cast(t?.i? as numeric(?,?))+?.? order by ?
 /* ---> skip ORDER BY */
 ===================================================
 0
@@ -45,7 +45,7 @@ sscan
     class: t? node[?]
     cost:  ? card ?
 Query stmt:
-(select max( cast(t?.i? as numeric)+?.?) from t? t?)
+(select max( cast(t?.i? as numeric(?,?))+?.?) from t? t?)
 Query plan:
 temp(order by)
     subplan: nl-join (inner join)
@@ -61,7 +61,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select /*+ ORDERED */ t?.i?, t?.i? from t? t?, (select max( cast(t?.i? as numeric)+?.?) from t? t?) av? (av_?) where t?.i?=av?.av_? order by ?
+select /*+ ORDERED */ t?.i?, t?.i? from t? t?, (select max( cast(t?.i? as numeric(?,?))+?.?) from t? t?) av? (av_?) where t?.i?=av?.av_? order by ?
 ===================================================
 0
 i1    i2    
@@ -79,13 +79,13 @@ sscan
     class: t? node[?]
     cost:  ? card ?
 Query stmt:
-(select max( cast(t?.i? as numeric)+?.?) from t? t?)
+(select max( cast(t?.i? as numeric(?,?))+?.?) from t? t?)
 Query plan:
 sscan
     class: t? node[?]
     cost:  ? card ?
 Query stmt:
-(select min( cast(t?.i? as numeric)+?.?) from t? t?)
+(select min( cast(t?.i? as numeric(?,?))+?.?) from t? t?)
 Query plan:
 iscan
     class: t? node[?]
@@ -93,7 +93,7 @@ iscan
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select t?.i?, t?.i? from t? t? where ((t?.i?=(select max( cast(t?.i? as numeric)+?.?) from t? t?)) or (t?.i?=(select min( cast(t?.i? as numeric)+?.?) from t? t?))) order by ?
+select t?.i?, t?.i? from t? t? where ((t?.i?=(select max( cast(t?.i? as numeric(?,?))+?.?) from t? t?)) or (t?.i?=(select min( cast(t?.i? as numeric(?,?))+?.?) from t? t?))) order by ?
 /* ---> skip ORDER BY */
 ===================================================
 0
@@ -155,7 +155,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select t?.i?, t?.i? from t? t? where t?.i?= cast(t?.i? as numeric)+?.? order by ?
+select t?.i?, t?.i? from t? t? where t?.i?= cast(t?.i? as numeric(?,?))+?.? order by ?
 ===================================================
 0
 i1    i2    
@@ -172,7 +172,7 @@ sscan
     class: t? node[?]
     cost:  ? card ?
 Query stmt:
-(select max( cast(t?.i? as numeric)+?.?) from t? t?)
+(select max( cast(t?.i? as numeric(?,?))+?.?) from t? t?)
 Query plan:
 temp(order by)
     subplan: nl-join (inner join)
@@ -188,7 +188,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select /*+ ORDERED */ t?.i?, t?.i? from t? t?, (select max( cast(t?.i? as numeric)+?.?) from t? t?) av? (av_?) where t?.i?=av?.av_? order by ?
+select /*+ ORDERED */ t?.i?, t?.i? from t? t?, (select max( cast(t?.i? as numeric(?,?))+?.?) from t? t?) av? (av_?) where t?.i?=av?.av_? order by ?
 ===================================================
 0
 i1    i2    
@@ -206,13 +206,13 @@ sscan
     class: t? node[?]
     cost:  ? card ?
 Query stmt:
-(select max( cast(t?.i? as numeric)+?.?) from t? t?)
+(select max( cast(t?.i? as numeric(?,?))+?.?) from t? t?)
 Query plan:
 sscan
     class: t? node[?]
     cost:  ? card ?
 Query stmt:
-(select min( cast(t?.i? as numeric)+?.?) from t? t?)
+(select min( cast(t?.i? as numeric(?,?))+?.?) from t? t?)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -222,7 +222,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select t?.i?, t?.i? from t? t? where ((t?.i?=(select max( cast(t?.i? as numeric)+?.?) from t? t?)) or (t?.i?=(select min( cast(t?.i? as numeric)+?.?) from t? t?))) order by ?
+select t?.i?, t?.i? from t? t? where ((t?.i?=(select max( cast(t?.i? as numeric(?,?))+?.?) from t? t?)) or (t?.i?=(select min( cast(t?.i? as numeric(?,?))+?.?) from t? t?))) order by ?
 ===================================================
 0
 i1    i2    

--- a/sql/_14_mysql_compatibility_2/_15_host_variable/_12_common/answers/where_clause.answer_cci
+++ b/sql/_14_mysql_compatibility_2/_15_host_variable/_12_common/answers/where_clause.answer_cci
@@ -27,7 +27,7 @@ iscan
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select t?.i?, t?.i? from t? t? where t?.i?= cast(t?.i? as numeric)+?.? order by ?
+select t?.i?, t?.i? from t? t? where t?.i?= cast(t?.i? as numeric(?,?))+?.? order by ?
 /* ---> skip ORDER BY */
 ===================================================
 0
@@ -55,7 +55,7 @@ sscan
     class: t? node[?]
     cost:  ? card ?
 Query stmt:
-(select max( cast(t?.i? as numeric)+?.?) from t? t?)
+(select max( cast(t?.i? as numeric(?,?))+?.?) from t? t?)
 Query plan:
 temp(order by)
     subplan: nl-join (inner join)
@@ -71,7 +71,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select /*+ ORDERED */ t?.i?, t?.i? from t? t?, (select max( cast(t?.i? as numeric)+?.?) from t? t?) av? (av_?) where t?.i?=av?.av_? order by ?
+select /*+ ORDERED */ t?.i?, t?.i? from t? t?, (select max( cast(t?.i? as numeric(?,?))+?.?) from t? t?) av? (av_?) where t?.i?=av?.av_? order by ?
 ===================================================
 0
 i1    i2    
@@ -105,13 +105,13 @@ sscan
     class: t? node[?]
     cost:  ? card ?
 Query stmt:
-(select max( cast(t?.i? as numeric)+?.?) from t? t?)
+(select max( cast(t?.i? as numeric(?,?))+?.?) from t? t?)
 Query plan:
 sscan
     class: t? node[?]
     cost:  ? card ?
 Query stmt:
-(select min( cast(t?.i? as numeric)+?.?) from t? t?)
+(select min( cast(t?.i? as numeric(?,?))+?.?) from t? t?)
 Query plan:
 iscan
     class: t? node[?]
@@ -119,7 +119,7 @@ iscan
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select t?.i?, t?.i? from t? t? where ((t?.i?=(select max( cast(t?.i? as numeric)+?.?) from t? t?)) or (t?.i?=(select min( cast(t?.i? as numeric)+?.?) from t? t?))) order by ?
+select t?.i?, t?.i? from t? t? where ((t?.i?=(select max( cast(t?.i? as numeric(?,?))+?.?) from t? t?)) or (t?.i?=(select min( cast(t?.i? as numeric(?,?))+?.?) from t? t?))) order by ?
 /* ---> skip ORDER BY */
 ===================================================
 0
@@ -216,7 +216,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select t?.i?, t?.i? from t? t? where t?.i?= cast(t?.i? as numeric)+?.? order by ?
+select t?.i?, t?.i? from t? t? where t?.i?= cast(t?.i? as numeric(?,?))+?.? order by ?
 ===================================================
 0
 i1    i2    
@@ -243,7 +243,7 @@ sscan
     class: t? node[?]
     cost:  ? card ?
 Query stmt:
-(select max( cast(t?.i? as numeric)+?.?) from t? t?)
+(select max( cast(t?.i? as numeric(?,?))+?.?) from t? t?)
 Query plan:
 temp(order by)
     subplan: nl-join (inner join)
@@ -259,7 +259,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select /*+ ORDERED */ t?.i?, t?.i? from t? t?, (select max( cast(t?.i? as numeric)+?.?) from t? t?) av? (av_?) where t?.i?=av?.av_? order by ?
+select /*+ ORDERED */ t?.i?, t?.i? from t? t?, (select max( cast(t?.i? as numeric(?,?))+?.?) from t? t?) av? (av_?) where t?.i?=av?.av_? order by ?
 ===================================================
 0
 i1    i2    
@@ -293,13 +293,13 @@ sscan
     class: t? node[?]
     cost:  ? card ?
 Query stmt:
-(select max( cast(t?.i? as numeric)+?.?) from t? t?)
+(select max( cast(t?.i? as numeric(?,?))+?.?) from t? t?)
 Query plan:
 sscan
     class: t? node[?]
     cost:  ? card ?
 Query stmt:
-(select min( cast(t?.i? as numeric)+?.?) from t? t?)
+(select min( cast(t?.i? as numeric(?,?))+?.?) from t? t?)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -309,7 +309,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select t?.i?, t?.i? from t? t? where ((t?.i?=(select max( cast(t?.i? as numeric)+?.?) from t? t?)) or (t?.i?=(select min( cast(t?.i? as numeric)+?.?) from t? t?))) order by ?
+select t?.i?, t?.i? from t? t? where ((t?.i?=(select max( cast(t?.i? as numeric(?,?))+?.?) from t? t?)) or (t?.i?=(select min( cast(t?.i? as numeric(?,?))+?.?) from t? t?))) order by ?
 ===================================================
 0
 i1    i2    

--- a/sql/_23_apricot_qa/_02_performance/_02_function_based_index/answers/function_based_index_function_LEAST.answer
+++ b/sql/_23_apricot_qa/_02_performance/_02_function_based_index/answers/function_based_index_function_LEAST.answer
@@ -53,7 +53,7 @@ iscan
     index: i_t?_a?h term[?]
     cost:  ? card ?
 Query stmt:
-select t?.a, t?.b, t?.c, t?.d, t?.e, t?.f, t?.g, t?.h, t?.i, t?.j, t?.k, t?.l, t?.m, t?.n, t?.o, t?.p, t?.q from t? t? where least(t?.j,  cast(? as numeric))>?
+select t?.a, t?.b, t?.c, t?.d, t?.e, t?.f, t?.g, t?.h, t?.i, t?.j, t?.k, t?.l, t?.m, t?.n, t?.o, t?.p, t?.q from t? t? where least(t?.j,  cast(? as numeric(?,?)))>?
 ===================================================
 0
 ===================================================

--- a/sql/_23_apricot_qa/_02_performance/_02_function_based_index/answers/function_based_index_function_LEAST.answer_cci
+++ b/sql/_23_apricot_qa/_02_performance/_02_function_based_index/answers/function_based_index_function_LEAST.answer_cci
@@ -53,7 +53,7 @@ iscan
     index: i_t?_a?h term[?]
     cost:  ? card ?
 Query stmt:
-select t?.a, t?.b, t?.c, t?.d, t?.e, t?.f, t?.g, t?.h, t?.i, t?.j, t?.k, t?.l, t?.m, t?.n, t?.o, t?.p, t?.q from t? t? where least(t?.j,  cast(? as numeric))>?
+select t?.a, t?.b, t?.c, t?.d, t?.e, t?.f, t?.g, t?.h, t?.i, t?.j, t?.k, t?.l, t?.m, t?.n, t?.o, t?.p, t?.q from t? t? where least(t?.j,  cast(? as numeric(?,?)))>?
 ===================================================
 0
 ===================================================

--- a/sql/_23_apricot_qa/_02_performance/_02_function_based_index/answers/function_based_index_function_MOD.answer
+++ b/sql/_23_apricot_qa/_02_performance/_02_function_based_index/answers/function_based_index_function_MOD.answer
@@ -66,7 +66,7 @@ iscan
     index: i_t?_a?h term[?]
     cost:  ? card ?
 Query stmt:
-select t?.a, t?.b, t?.c, t?.d, t?.e, t?.f, t?.g, t?.h, t?.i, t?.j, t?.k, t?.l, t?.m, t?.n, t?.o, t?.p, t?.q from t? t? where  mod(t?.j,  cast(? as numeric))=?
+select t?.a, t?.b, t?.c, t?.d, t?.e, t?.f, t?.g, t?.h, t?.i, t?.j, t?.k, t?.l, t?.m, t?.n, t?.o, t?.p, t?.q from t? t? where  mod(t?.j,  cast(? as numeric(?,?)))=?
 ===================================================
 0
 ===================================================

--- a/sql/_23_apricot_qa/_02_performance/_02_function_based_index/answers/function_based_index_function_NULLIF.answer
+++ b/sql/_23_apricot_qa/_02_performance/_02_function_based_index/answers/function_based_index_function_NULLIF.answer
@@ -96,7 +96,7 @@ iscan
     index: i_t?_a?h term[?]
     cost:  ? card ?
 Query stmt:
-select t?.a, t?.b, t?.c, t?.d, t?.e, t?.f, t?.g, t?.h, t?.i, t?.j, t?.k, t?.l, t?.m, t?.n, t?.o, t?.p, t?.q from t? t? where nullif(t?.j,  cast(? as numeric))=?
+select t?.a, t?.b, t?.c, t?.d, t?.e, t?.f, t?.g, t?.h, t?.i, t?.j, t?.k, t?.l, t?.m, t?.n, t?.o, t?.p, t?.q from t? t? where nullif(t?.j,  cast(? as numeric(?,?)))=?
 ===================================================
 0
 ===================================================

--- a/sql/_24_aprium_qa/_03_other/issue_6091_orderbynum/answers/_07_mro_limit_orderbynum.answer
+++ b/sql/_24_aprium_qa/_03_other/issue_6091_orderbynum/answers/_07_mro_limit_orderbynum.answer
@@ -56,7 +56,7 @@ temp(order by)
     sort:  ? desc, ? asc
     cost:  ? card ?
 Query stmt:
-select t.i?, t.i?, u.i, t.i?+t.i?+ cast(t.i? as numeric) from t t, u u where ((t.i?= ?:? ) or (t.i?= ?:? ) or (t.i?= ?:? )) and t.i?=u.i order by ? desc , ? for orderby_num()<= ?:? 
+select t.i?, t.i?, u.i, t.i?+t.i?+ cast(t.i? as numeric(?,?)) from t t, u u where ((t.i?= ?:? ) or (t.i?= ?:? ) or (t.i?= ?:? )) and t.i?=u.i order by ? desc , ? for orderby_num()<= ?:? 
 ===================================================
 i2    i3    i    
 3.0     13.0     3     
@@ -81,7 +81,7 @@ temp(order by)
     sort:  ? asc, ? asc
     cost:  ? card ?
 Query stmt:
-select t.i?, t.i?, u.i, t.i?+t.i?+ cast(t.i? as numeric) from t t, u u where ((t.i?= ?:? ) or (t.i?= ?:? )) and t.i?=u.i order by ?, ? for orderby_num()<= ?:? 
+select t.i?, t.i?, u.i, t.i?+t.i?+ cast(t.i? as numeric(?,?)) from t t, u u where ((t.i?= ?:? ) or (t.i?= ?:? )) and t.i?=u.i order by ?, ? for orderby_num()<= ?:? 
 ===================================================
 i2    i3    i    
 3.0     13.0     3     

--- a/sql/_24_aprium_qa/_03_other/issue_6091_orderbynum/answers/_07_mro_limit_orderbynum.answer_cci
+++ b/sql/_24_aprium_qa/_03_other/issue_6091_orderbynum/answers/_07_mro_limit_orderbynum.answer_cci
@@ -56,7 +56,7 @@ temp(order by)
     sort:  ? desc, ? asc
     cost:  ? card ?
 Query stmt:
-select t.i?, t.i?, u.i, t.i?+t.i?+ cast(t.i? as numeric) from t t, u u where ((t.i?= ?:? ) or (t.i?= ?:? ) or (t.i?= ?:? )) and t.i?=u.i order by ? desc , ? for orderby_num()<= ?:? 
+select t.i?, t.i?, u.i, t.i?+t.i?+ cast(t.i? as numeric(?,?)) from t t, u u where ((t.i?= ?:? ) or (t.i?= ?:? ) or (t.i?= ?:? )) and t.i?=u.i order by ? desc , ? for orderby_num()<= ?:? 
 ===================================================
 i2    i3    i    
 3.0     13.0     3     
@@ -81,7 +81,7 @@ temp(order by)
     sort:  ? asc, ? asc
     cost:  ? card ?
 Query stmt:
-select t.i?, t.i?, u.i, t.i?+t.i?+ cast(t.i? as numeric) from t t, u u where ((t.i?= ?:? ) or (t.i?= ?:? )) and t.i?=u.i order by ?, ? for orderby_num()<= ?:? 
+select t.i?, t.i?, u.i, t.i?+t.i?+ cast(t.i? as numeric(?,?)) from t t, u u where ((t.i?= ?:? ) or (t.i?= ?:? )) and t.i?=u.i order by ?, ? for orderby_num()<= ?:? 
 ===================================================
 i2    i3    i    
 3.0     13.0     3     

--- a/sql/_24_aprium_qa/_03_other/issue_7441_MRO/answers/_07_mro_limit.answer
+++ b/sql/_24_aprium_qa/_03_other/issue_7441_MRO/answers/_07_mro_limit.answer
@@ -59,7 +59,7 @@ temp(order by)
     sort:  ? desc, ? asc
     cost:  ? card ?
 Query stmt:
-select t.i?, t.i?, u.i, t.i?+t.i?+ cast(t.i? as numeric) from t t, u u where ((t.i?= ?:? ) or (t.i?= ?:? ) or (t.i?= ?:? )) and t.i?=u.i order by ? desc , ? for orderby_num()<= ?:? 
+select t.i?, t.i?, u.i, t.i?+t.i?+ cast(t.i? as numeric(?,?)) from t t, u u where ((t.i?= ?:? ) or (t.i?= ?:? ) or (t.i?= ?:? )) and t.i?=u.i order by ? desc , ? for orderby_num()<= ?:? 
 ===================================================
 i2    i3    i    
 3.0     13.0     3     
@@ -84,7 +84,7 @@ temp(order by)
     sort:  ? asc, ? asc
     cost:  ? card ?
 Query stmt:
-select t.i?, t.i?, u.i, t.i?+t.i?+ cast(t.i? as numeric) from t t, u u where ((t.i?= ?:? ) or (t.i?= ?:? )) and t.i?=u.i order by ?, ? for orderby_num()<= ?:? 
+select t.i?, t.i?, u.i, t.i?+t.i?+ cast(t.i? as numeric(?,?)) from t t, u u where ((t.i?= ?:? ) or (t.i?= ?:? )) and t.i?=u.i order by ?, ? for orderby_num()<= ?:? 
 ===================================================
 i2    i3    i    
 3.0     13.0     3     

--- a/sql/_24_aprium_qa/_03_other/issue_7441_MRO/answers/_07_mro_limit.answer_cci
+++ b/sql/_24_aprium_qa/_03_other/issue_7441_MRO/answers/_07_mro_limit.answer_cci
@@ -59,7 +59,7 @@ temp(order by)
     sort:  ? desc, ? asc
     cost:  ? card ?
 Query stmt:
-select t.i?, t.i?, u.i, t.i?+t.i?+ cast(t.i? as numeric) from t t, u u where ((t.i?= ?:? ) or (t.i?= ?:? ) or (t.i?= ?:? )) and t.i?=u.i order by ? desc , ? for orderby_num()<= ?:? 
+select t.i?, t.i?, u.i, t.i?+t.i?+ cast(t.i? as numeric(?,?)) from t t, u u where ((t.i?= ?:? ) or (t.i?= ?:? ) or (t.i?= ?:? )) and t.i?=u.i order by ? desc , ? for orderby_num()<= ?:? 
 ===================================================
 i2    i3    i    
 3.0     13.0     3     
@@ -84,7 +84,7 @@ temp(order by)
     sort:  ? asc, ? asc
     cost:  ? card ?
 Query stmt:
-select t.i?, t.i?, u.i, t.i?+t.i?+ cast(t.i? as numeric) from t t, u u where ((t.i?= ?:? ) or (t.i?= ?:? )) and t.i?=u.i order by ?, ? for orderby_num()<= ?:? 
+select t.i?, t.i?, u.i, t.i?+t.i?+ cast(t.i? as numeric(?,?)) from t t, u u where ((t.i?= ?:? ) or (t.i?= ?:? )) and t.i?=u.i order by ?, ? for orderby_num()<= ?:? 
 ===================================================
 i2    i3    i    
 3.0     13.0     3     


### PR DESCRIPTION
 http://jira.cubrid.org/browse/CBRD-26652

### Purpose
- 문자 리터럴의 Numeric 자동 형변환 정밀도(Precision) 확장
  - semantic_check 단계에서 문자 리터럴을 NUMERIC으로 자동 형변환할 때 적용되는 기본 Precision을 15에서 38로 확장하여, Scale 보정 과정에서 발생하는 정밀도 초과 에러를 해결합니다.

### Implementation
- 변경 사항
  - 기존에 문자 리터럴 등 '기타 타입'에 일괄 적용되던 NUMERIC(15, 9) 도메인을 NUMERIC(38, 9)로 변경.
- 유지 사항
  - smallint, integer, bigint 등 정수 계열 타입에 대한 고정 도메인 결정 로직은 기존과 동일하게 유지하여 하위 호환성 확보.
- 예제
- 수정 전 (문자열 -> NUMERIC(15, 9))
```sql
create table test(num_col NUMERIC(10,0));
insert into test values('1111111'); -- 7자리

-- 조회 시 에러 발생
select * from test where num_col='1111111';
In line 5, column 33,
ERROR: before ' ; '
Cannot coerce '1111111' to type numeric.

-- Update 시 에러 발생
update test set num_col = 123 where num_col='1111111';
In line 5, column 35,
ERROR: before ' ; '
Cannot coerce '1111111' to type numeric.
```
- 수정 후 (문자열 -> NUMERIC(38, 9))
 ```sql
create table test(num_col NUMERIC(10,0));
insert into test values('1111111'); -- 7자리

-- 조회 성공
select * from test where num_col='1111111';
  num_col             
======================
  1111111             

-- Update 성공
update test set num_col = 123 where num_col='1111111';
1 row affected. (0.000000 sec) Committed.

select * from test;
  num_col             
======================
  123   
```

### Remarks
- 본 PR은 의존성이 있는 [PR #4375](https://github.com/CUBRID/cubrid/pull/4375) (CBRD-24815)의 변경 사항을 포함하고 있습니다.
  - CBRD-24815의 TC 수정 pr :  https://github.com/CUBRID/cubrid-testcases/pull/1479
- 최종적으로 [PR #6961](https://github.com/CUBRID/cubrid/pull/6961)의 로직을 백포트합니다.