### PR TITLE
[CBRD-26541] Revise isolation test answer for DROP synonym check fix

### DIFF
--- a/isolation/_01_ReadCommitted/issues/_22_1h/cbrd_24336/answer/synonym_in_use.answer
+++ b/isolation/_01_ReadCommitted/issues/_22_1h/cbrd_24336/answer/synonym_in_use.answer
@@ -11,8 +11,7 @@
 |    on statement number: 4
 | ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on X_LOCK lock on instance ?|?|? of class _db_synonym. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
 |    on statement number: 5
-| ERROR RETURNED: Semantic: before ' ;'
-| Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on SCH_M_LOCK lock on class public.t?_?. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. drop [public.t?_?] 
+| ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on SCH_M_LOCK lock on class public.t?_?. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
 |    on statement number: 6
 | 1 row affected
 | ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on X_LOCK lock on instance ?|?|? of class _db_synonym. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
@@ -21,8 +20,7 @@
 |    on statement number: 8
 | ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on X_LOCK lock on instance ?|?|? of class _db_synonym. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
 |    on statement number: 9
-| ERROR RETURNED: Semantic: before ' ;'
-| Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on SCH_M_LOCK lock on class public.t?_?. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. drop [public.t?_?] 
+| ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on SCH_M_LOCK lock on class public.t?_?. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
 |    on statement number: 10
 | =================   Q U E R Y   R E S U L T S   =================
 | 
@@ -36,6 +34,5 @@
 |    on statement number: 12
 | ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on X_LOCK lock on instance ?|?|? of class _db_synonym. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
 |    on statement number: 13
-| ERROR RETURNED: Semantic: before ' ;'
-| Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on SCH_M_LOCK lock on class public.t?_?. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. drop [public.t?_?] 
+| ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on SCH_M_LOCK lock on class public.t?_?. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
 |    on statement number: 14


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-26541

qa home fail 링크: [qa home link](https://qahome.cubrid.org/qaresult/showfile.nhn?treeId=&level=&summaryName=&catPath=&name=&m=showCaseFile&statid=55731&itemid=3322047&tc=isolation&buildId=11.5.0.2161-dba5264&filePath=isolation%2F_01_ReadCommitted%2Fissues%2F_22_1h%2Fcbrd_24336%2Fsynonym_in_use.ctl&isNew=&isSuccessFul=false)