### PR TITLE
[CBRD-26541] Revise isolation test answer for DROP synonym check fix (11.4)

### DIFF
--- a/isolation/_01_ReadCommitted/issues/_22_1h/cbrd_24336/answer/synonym_in_use.answer
+++ b/isolation/_01_ReadCommitted/issues/_22_1h/cbrd_24336/answer/synonym_in_use.answer
@@ -11,8 +11,7 @@
 |    on statement number: 4
 | ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on      X_LOCK lock on instance ?|?|? of class _db_synonym. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
 |    on statement number: 5
-| ERROR RETURNED: Semantic: before ' ;'
-| Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on  SCH_M_LOCK lock on class public.t?_?. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. drop [public.t?_?] 
+| ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on  SCH_M_LOCK lock on class public.t?_?. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
 |    on statement number: 6
 | 1 row affected
 | ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on      X_LOCK lock on instance ?|?|? of class _db_synonym. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
@@ -21,8 +20,7 @@
 |    on statement number: 8
 | ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on      X_LOCK lock on instance ?|?|? of class _db_synonym. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
 |    on statement number: 9
-| ERROR RETURNED: Semantic: before ' ;'
-| Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on  SCH_M_LOCK lock on class public.t?_?. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. drop [public.t?_?] 
+| ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on  SCH_M_LOCK lock on class public.t?_?. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
 |    on statement number: 10
 | =================   Q U E R Y   R E S U L T S   =================
 | 
@@ -36,6 +34,5 @@
 |    on statement number: 12
 | ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on      X_LOCK lock on instance ?|?|? of class _db_synonym. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
 |    on statement number: 13
-| ERROR RETURNED: Semantic: before ' ;'
-| Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on  SCH_M_LOCK lock on class public.t?_?. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. drop [public.t?_?] 
+| ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on  SCH_M_LOCK lock on class public.t?_?. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
 |    on statement number: 14


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-26541
backport #2604