### PR TITLE
[CBRD-26504] Fixed charset encoding issue under evaluate statement

### DIFF
--- a/sql/_13_issues/_26_1h/answers/cbrd_26504.answer
+++ b/sql/_13_issues/_26_1h/answers/cbrd_26504.answer
@@ -60,7 +60,7 @@ c1
 
 ===================================================
     
-Case 6. CONNECT BY with WHERE Clause — WHERE Must Not Affect START WITH     
+Case 6. CONNECT BY with WHERE Clause, WHERE Must Not Affect START WITH     
 
 ===================================================
 c1    

--- a/sql/_13_issues/_26_1h/cases/cbrd_26504.sql
+++ b/sql/_13_issues/_26_1h/cases/cbrd_26504.sql
@@ -53,9 +53,9 @@ SELECT c1 FROM tbl
 START WITH c1 = 'Z'
 CONNECT BY PRIOR c1 = c2
 ORDER BY c1;
--- Expected: (empty — 0 rows)
+-- Expected: (empty, 0 rows)
 
-evaluate 'Case 6. CONNECT BY with WHERE Clause — WHERE Must Not Affect START WITH';
+evaluate 'Case 6. CONNECT BY with WHERE Clause, WHERE Must Not Affect START WITH';
 SELECT c1 FROM tbl
 WHERE c1 <> 'C'
 START WITH c1 = 'A'


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-26504

The test case used an em dash ("—") in `evaluate`, which causes inconsistent results due to charset encoding differences across DB versions. For example, in CUBRID 11.4 it is interpreted as: ```â```

Replaced with a safe ASCII alternative to ensure consistent behavior.