### PR TITLE
[CBRD-26457] Fixed charset encoding issue under evaluate statement

### DIFF
--- a/sql/_13_issues/_26_1h/answers/cbrd_26457.answer
+++ b/sql/_13_issues/_26_1h/answers/cbrd_26457.answer
@@ -173,7 +173,7 @@ sec_milli_17    sec_milli_100    sec_milli_1000    sec_milli_1500
 
 ===================================================
     
-Case 4.3: Millisecond Padding Rules (≤3 digits: pad right)     
+Case 4.3: Millisecond Padding Rules (<=3 digits: pad right)     
 
 ===================================================
 input_value    pad_result    input_value_2    pad_result_2    input_value_3    pad_result_3    

--- a/sql/_13_issues/_26_1h/cases/cbrd_26457.sql
+++ b/sql/_13_issues/_26_1h/cases/cbrd_26457.sql
@@ -6,7 +6,7 @@
  * - Correct leap year and year-end date calculations
  * - Support for all castable types (not just CHAR/VARCHAR/SHORT/INT/BIGINT/NUMERIC)
  * - MILLISECOND interpretation (single unit & composite unit)
- * - Millisecond padding rules: ≤3 digits pad right, >3 digits trim left zeros
+ * - Millisecond padding rules: <=3 digits pad right, >3 digits trim left zeros
  * - Correct delimiter parsing in composite intervals
  */
 
@@ -220,7 +220,7 @@ SELECT
     date_add('2020-01-01 00:00:00.000', INTERVAL '1000' SECOND_MILLISECOND) as sec_milli_1000,
     date_add('2020-01-01 00:00:00.000', INTERVAL '1500' SECOND_MILLISECOND) as sec_milli_1500;
 
-evaluate 'Case 4.3: Millisecond Padding Rules (≤3 digits: pad right)';
+evaluate 'Case 4.3: Millisecond Padding Rules (<=3 digits: pad right)';
 SELECT 
     '12' as input_value,
     date_add('2020-01-01 00:00:00.000', INTERVAL '12' SECOND_MILLISECOND) as pad_result,


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-26457

The test case used a less-than-or-equal-to symbol ("≤") in `evaluate`, which causes inconsistent results due to charset encoding differences across DB versions. For example, in CUBRID 11.4 it is interpreted as: `â¤`.

Replaced it with a safe ASCII alternative to ensure consistent behavior.