### PR TITLE
[CBRD-26624] Backport from develop to 11.4 - Add sql testcase for LEADING hint after single-view / derived merge

### DIFF
--- a/sql/_13_issues/_26_1h/answers/cbrd_26624.answer
+++ b/sql/_13_issues/_26_1h/answers/cbrd_26624.answer
@@ -1,0 +1,188 @@
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+    
+Case 1: inline derived table merged into outer SELECT     
+
+===================================================
+seq    
+
+Query plan:
+nl-join (inner join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ LEADING(a) */ a.seq from a_test a, a_test b where (a.seq=b.seq)
+===================================================
+    
+Case 2: Single view merge: CREATE VIEW with LEADING, then SELECT * FROM view     
+
+===================================================
+0
+===================================================
+seq    
+
+Query plan:
+nl-join (inner join)
+    edge:  term[?]
+    outer: sscan
+               class: v_leading_a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ LEADING(a) */ v_leading_a.seq from a_test v_leading_a, a_test b where (v_leading_a.seq=b.seq)
+===================================================
+    
+Case 3: LEADING on the inner alias (b)     
+
+===================================================
+seq    
+
+Query plan:
+nl-join (inner join)
+    edge:  term[?]
+    outer: sscan
+               class: b node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: t node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ LEADING(b) */ b.seq from a_test t, a_test b where (t.seq=b.seq)
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+    
+Case 4: Two base tables: LEADING(a_test) on distinct a_test / b_test     
+
+===================================================
+id    
+
+Query plan:
+nl-join (inner join)
+    edge:  term[?]
+    outer: sscan
+               class: q node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b_test node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ LEADING(a_test) */ q.id from a_test q, b_test b_test where (q.id=b_test.id)
+===================================================
+    
+Case 5: NO_MERGE keeps LEADING(a) in inner query     
+
+===================================================
+seq    
+
+Query plan:
+nl-join (inner join)
+    edge:  term[?]
+    outer: sscan
+               class: a node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+(select /*+ LEADING(a) NO_MERGE */ a.seq from a_test a, a_test b where a.seq=b.seq)
+Query plan:
+sscan
+    class: x node[?]
+    cost:  ? card ?
+Query stmt:
+select x.seq from (select /*+ LEADING(a) NO_MERGE */ a.seq from a_test a, a_test b where a.seq=b.seq) x (seq)
+===================================================
+    
+Case 6: Multiple hints preserve LEADING(a) after derived merge     
+
+===================================================
+seq    
+
+Query plan:
+nl-join (inner join)
+    edge:  term[?]
+    outer: sscan
+               class: x node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ LEADING(a) USE_NL(b) */ x.seq from a_test x, a_test b where (x.seq=b.seq)
+===================================================
+    
+Case 7: Schema-qualified LEADING(dba.a_test) is preserved after merge     
+
+===================================================
+id    
+
+Query plan:
+nl-join (inner join)
+    edge:  term[?]
+    outer: sscan
+               class: q node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b_test node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ LEADING(a_test) */ q.id from a_test q, b_test b_test where (q.id=b_test.id)
+===================================================
+    
+Case 8: Alias-based LEADING(a) on distinct base tables is preserved after merge     
+
+===================================================
+id    
+
+Query plan:
+nl-join (inner join)
+    edge:  term[?]
+    outer: sscan
+               class: q node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: b node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Query stmt:
+select /*+ LEADING(a) */ q.id from a_test q, b_test b where (q.id=b.id)
+===================================================
+0
+===================================================
+0

--- a/sql/_13_issues/_26_1h/cases/cbrd_26624.sql
+++ b/sql/_13_issues/_26_1h/cases/cbrd_26624.sql
@@ -1,0 +1,81 @@
+-- CBRD-26624 – LEADING hint after single-view / derived merge (merged cases)
+
+DROP VIEW IF EXISTS v_leading_a;
+DROP TABLE IF EXISTS b_test;
+DROP TABLE IF EXISTS a_test;
+
+CREATE TABLE a_test (seq NUMERIC, title VARCHAR(100));
+
+evaluate 'Case 1: inline derived table merged into outer SELECT';
+SELECT /*+ recompile */ *
+FROM (
+  SELECT /*+ LEADING(a) */ a.seq
+  FROM a_test a, a_test b
+  WHERE a.seq = b.seq
+) a;
+
+evaluate 'Case 2: Single view merge: CREATE VIEW with LEADING, then SELECT * FROM view';
+CREATE VIEW v_leading_a AS
+SELECT /*+ LEADING(a) */ a.seq
+FROM a_test a, a_test b
+WHERE a.seq = b.seq;
+
+SELECT /*+ recompile */ * FROM v_leading_a;
+
+evaluate 'Case 3: LEADING on the inner alias (b)';
+SELECT /*+ recompile */ *
+FROM (
+  SELECT /*+ LEADING(b) */ b.seq
+  FROM a_test a, a_test b
+  WHERE a.seq = b.seq
+) t;
+
+DROP VIEW IF EXISTS v_leading_a;
+DROP TABLE IF EXISTS a_test;
+
+CREATE TABLE a_test (id INT, seq NUMERIC, title VARCHAR(100));
+CREATE TABLE b_test (id INT, seq NUMERIC, title VARCHAR(100));
+
+evaluate 'Case 4: Two base tables: LEADING(a_test) on distinct a_test / b_test';
+SELECT /*+ recompile */ *
+FROM (
+  SELECT /*+ LEADING(a_test) */ a_test.id
+  FROM a_test, b_test
+  WHERE a_test.id = b_test.id
+) q;
+
+evaluate 'Case 5: NO_MERGE keeps LEADING(a) in inner query';
+
+SELECT /*+ recompile */ *
+FROM (
+  SELECT /*+ NO_MERGE LEADING(a) */ a.seq
+  FROM a_test a, a_test b
+  WHERE a.seq = b.seq
+) x;
+
+evaluate 'Case 6: Multiple hints preserve LEADING(a) after derived merge';
+SELECT /*+ recompile */ *
+FROM (
+  SELECT /*+ LEADING(a) USE_NL(b) */ a.seq
+  FROM a_test a, a_test b
+  WHERE a.seq = b.seq
+) x;
+
+evaluate 'Case 7: Schema-qualified LEADING(dba.a_test) is preserved after merge';
+SELECT /*+ recompile */ *
+FROM (
+  SELECT /*+ LEADING(dba.a_test) */ a_test.id
+  FROM dba.a_test, dba.b_test
+  WHERE a_test.id = b_test.id
+) q;
+
+evaluate 'Case 8: Alias-based LEADING(a) on distinct base tables is preserved after merge';
+SELECT /*+ recompile */ *
+FROM (
+  SELECT /*+ LEADING(a) */ a.id
+  FROM a_test a, b_test b
+  WHERE a.id = b.id
+) q;
+
+DROP TABLE IF EXISTS b_test;
+DROP TABLE IF EXISTS a_test;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26624, #2655