### PR TITLE
[CBRD-26457] Remove unnecessary answer from 10.2

### DIFF
--- a/sql/_13_issues/_26_1h/answers/cbrd_26457.answer_cci
+++ b/sql/_13_issues/_26_1h/answers/cbrd_26457.answer_cci
@@ -144,8 +144,8 @@ id    date_sub_result    subdate_result    results_equal
 Case 3.7: Type Casting - Boundary Values     
 
 ===================================================
-near_zero    very_large    negative_fraction    
-2020-01-01     2047-05-19     2019-12-31     
+near_zero    very_large    
+2020-01-01     2047-05-19     
 
 ===================================================
     


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-26457

`negative_fraction` answer is only available for version 11.5. The test case was removed in the lower version due to this ticket: http://jira.cubrid.org/browse/CBRD-26561.