### PR TITLE
[CBRD-26722] Expand parallel heap scan to parallel scan (index, heap, list)

### DIFF
--- a/sql/_13_issues/_22_1h/cases/cbrd_24148.sql
+++ b/sql/_13_issues/_22_1h/cases/cbrd_24148.sql
@@ -1,6 +1,6 @@
 DROP TABLE IF EXISTS tbl_hls ;
 CREATE TABLE tbl_hls (a INTEGER, b INTEGER, c INTEGER);
-insert into tbl_hls select r,r,r from (select rand(1)%5000 as r from db_class a, db_class b, db_class c, db_class d limit 410000);
+insert into tbl_hls select /*+ NO_PARALLEL_SCAN */ r,r,r from (select rand(1)%5000 as r from db_class a, db_class b, db_class c, db_class d limit 410000);
 
 set trace on;
 select /*+ recompile ordered */ count(*) from (select /*+ NO_PARALLEL_SCAN */ * from tbl_hls limit 0,10000) a, (select /*+ NO_PARALLEL_SCAN */ * from tbl_hls limit 0,410000) b where a.a = b.a and a.b = b.b and a.c = b.c;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26722

이슈의 comment로 보고된 건에 대한 pr입니다.
parallel list scan이 개발되어 insert된 결과의 순서가 달라지는 현상을 해결합니다.