### PR TITLE
[CBRD-26708] Add SQL testcase for SQL data access information in PL/CSQL SP compilation (11.5)

### DIFF
--- a/sql/_13_issues/_26_1h/answers/cbrd_26708.answer
+++ b/sql/_13_issues/_26_1h/answers/cbrd_26708.answer
@@ -1,0 +1,438 @@
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+3
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+    
+Case 1: NO SQL - procedure with only DBMS_OUTPUT, function with arithmetic     
+
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+    
+Case 2: NO SQL - empty body (no statement at all)     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 3: CONTAINS SQL - SELECT of an expression without table reference     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 4: CONTAINS SQL - SELECT of a function without FROM (no table data)     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 5: CONTAINS SQL - control statement COMMIT     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 6: CONTAINS SQL - control statement ROLLBACK     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 7: CONTAINS SQL - set-derived table TABLE({...}) is not real table data     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 8: CONTAINS SQL - view built on a set-derived (virtual) table     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 9: READS SQL DATA - SELECT INTO from a table     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 10: READS SQL DATA - constant select-list but FROM a real table     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 11: READS SQL DATA - SELECT from dual     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 12: READS SQL DATA - explicit cursor over a table SELECT     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 13: READS SQL DATA - OPEN FOR (ref cursor) over a table SELECT     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 14: READS SQL DATA - FOR ... IN (SELECT) LOOP over a table     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 15: READS SQL DATA - SELECT from a derived table (subquery) over a real table     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 16: READS SQL DATA - SELECT from a view over a base table     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 17: READS SQL DATA - strongest wins, CONTAINS + READS in one body -> READS     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 18: MODIFIES SQL DATA - INSERT     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 19: MODIFIES SQL DATA - UPDATE     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 20: MODIFIES SQL DATA - DELETE     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 21: MODIFIES SQL DATA - MERGE     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 22: MODIFIES SQL DATA - REPLACE     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 23: MODIFIES SQL DATA - TRUNCATE     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 24: MODIFIES SQL DATA - INSERT ... SELECT (read + write)     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 25: MODIFIES SQL DATA - strongest wins, READS + MODIFIES in one body -> MODIFIES     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 26: NO SQL - dynamic SQL string is not statically analyzed     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 27: NO SQL - DDL is only possible via dynamic SQL, so it is not analyzed     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 28: NO SQL - calling another SP is not counted as SQL access     
+
+
+===================================================
+0
+
+===================================================
+    
+Case 29: DBMS_OUTPUT execution path is exercised for the NO SQL procedure     
+
+
+===================================================
+    
+null     
+
+
+no sql here
+===================================================
+    
+Case 30: sql_data_access from db_stored_procedure for all cases above     
+
+
+===================================================
+sp_name    sp_type    sql_data_access    
+f_calc     FUNCTION     NO SQL     
+f_const_realtbl     FUNCTION     READS SQL DATA     
+f_contains     FUNCTION     CONTAINS SQL     
+f_contains_reads     FUNCTION     READS SQL DATA     
+f_cursor     FUNCTION     READS SQL DATA     
+f_dual     FUNCTION     READS SQL DATA     
+f_forloop     FUNCTION     READS SQL DATA     
+f_func_nofrom     FUNCTION     CONTAINS SQL     
+f_openfor     FUNCTION     READS SQL DATA     
+f_reads     FUNCTION     READS SQL DATA     
+f_setderived     FUNCTION     CONTAINS SQL     
+f_subquery     FUNCTION     READS SQL DATA     
+f_view     FUNCTION     READS SQL DATA     
+f_view_set     FUNCTION     CONTAINS SQL     
+p_callmod     PROCEDURE     NO SQL     
+p_commit     PROCEDURE     CONTAINS SQL     
+p_ddl     PROCEDURE     NO SQL     
+p_delete     PROCEDURE     MODIFIES SQL DATA     
+p_dynamic     PROCEDURE     NO SQL     
+p_empty     PROCEDURE     NO SQL     
+p_insert     PROCEDURE     MODIFIES SQL DATA     
+p_insert_select     PROCEDURE     MODIFIES SQL DATA     
+p_merge     PROCEDURE     MODIFIES SQL DATA     
+p_mixed     PROCEDURE     MODIFIES SQL DATA     
+p_nosql     PROCEDURE     NO SQL     
+p_replace     PROCEDURE     MODIFIES SQL DATA     
+p_rollback     PROCEDURE     CONTAINS SQL     
+p_truncate     PROCEDURE     MODIFIES SQL DATA     
+p_update     PROCEDURE     MODIFIES SQL DATA     
+
+
+===================================================
+    
+Case 31: same value is exposed through information_schema.routines for every routine     
+
+
+===================================================
+routine_name    routine_type    sql_data_access    
+f_calc     FUNCTION     NO SQL     
+f_const_realtbl     FUNCTION     READS SQL DATA     
+f_contains     FUNCTION     CONTAINS SQL     
+f_contains_reads     FUNCTION     READS SQL DATA     
+f_cursor     FUNCTION     READS SQL DATA     
+f_dual     FUNCTION     READS SQL DATA     
+f_forloop     FUNCTION     READS SQL DATA     
+f_func_nofrom     FUNCTION     CONTAINS SQL     
+f_openfor     FUNCTION     READS SQL DATA     
+f_reads     FUNCTION     READS SQL DATA     
+f_setderived     FUNCTION     CONTAINS SQL     
+f_subquery     FUNCTION     READS SQL DATA     
+f_view     FUNCTION     READS SQL DATA     
+f_view_set     FUNCTION     CONTAINS SQL     
+p_callmod     PROCEDURE     NO SQL     
+p_commit     PROCEDURE     CONTAINS SQL     
+p_ddl     PROCEDURE     NO SQL     
+p_delete     PROCEDURE     MODIFIES SQL DATA     
+p_dynamic     PROCEDURE     NO SQL     
+p_empty     PROCEDURE     NO SQL     
+p_insert     PROCEDURE     MODIFIES SQL DATA     
+p_insert_select     PROCEDURE     MODIFIES SQL DATA     
+p_merge     PROCEDURE     MODIFIES SQL DATA     
+p_mixed     PROCEDURE     MODIFIES SQL DATA     
+p_nosql     PROCEDURE     NO SQL     
+p_replace     PROCEDURE     MODIFIES SQL DATA     
+p_rollback     PROCEDURE     CONTAINS SQL     
+p_truncate     PROCEDURE     MODIFIES SQL DATA     
+p_update     PROCEDURE     MODIFIES SQL DATA     
+
+
+===================================================
+    
+Case 32: CREATE OR REPLACE re-determines sql_data_access (READS -> MODIFIES)     
+
+
+===================================================
+0
+
+===================================================
+sp_name    sql_data_access    
+f_reads     MODIFIES SQL DATA     
+
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+

--- a/sql/_13_issues/_26_1h/cases/cbrd_26708.sql
+++ b/sql/_13_issues/_26_1h/cases/cbrd_26708.sql
@@ -1,0 +1,311 @@
+/**
+ * This test case verifies CBRD-26708: Provide SQL data access information during PL/CSQL SP compilation
+ *
+ * During compilation of a PL/CSQL stored procedure/function, the SQL data access
+ * characteristic is automatically determined by static analysis of the body and
+ * stored in the catalog. It is exposed via db_stored_procedure.sql_data_access and
+ * information_schema.routines.sql_data_access with one of:
+ *   NO SQL / CONTAINS SQL / READS SQL DATA / MODIFIES SQL DATA
+ *
+ * Coverage:
+ * 1 - NO SQL: no SQL statement at all (pure computation / DBMS_OUTPUT / empty body),
+ *     dynamic SQL (EXECUTE IMMEDIATE, incl. DDL), nested SP call
+ * 2 - CONTAINS SQL: SQL that does not touch table data - expression-only SELECT,
+ *     function SELECT without FROM, control statement (COMMIT / ROLLBACK),
+ *     set-derived table TABLE({...}), and a view built on such a virtual table
+ * 3 - READS SQL DATA: SELECT INTO / cursor / OPEN FOR / FOR-IN-LOOP over a table,
+ *     derived table (subquery) over a real table, view over a base table,
+ *     constant select-list with a real-table FROM, dual, and mixed CONTAINS+READS
+ * 4 - MODIFIES SQL DATA: INSERT / UPDATE / DELETE / MERGE / REPLACE / TRUNCATE /
+ *     INSERT ... SELECT, and mixed READS + MODIFIES
+ * 5 - The determination follows the strongest access level found in the body
+ * 6 - Verify the value is also exposed through information_schema.routines
+ */
+
+--+ server-message on
+
+DROP TABLE IF EXISTS tbl1;
+CREATE TABLE tbl1 (a INT);
+INSERT INTO tbl1 VALUES (1), (2), (3);
+
+CREATE OR REPLACE VIEW v_tbl1 AS SELECT a FROM tbl1;
+CREATE OR REPLACE VIEW v_set AS SELECT * FROM TABLE({1, 2, 3}) t(i);
+
+evaluate 'Case 1: NO SQL - procedure with only DBMS_OUTPUT, function with arithmetic';
+CREATE OR REPLACE PROCEDURE p_nosql AS
+BEGIN
+  DBMS_OUTPUT.put_line('no sql here');
+END;
+
+CREATE OR REPLACE FUNCTION f_calc(x INT) RETURN INT AS
+BEGIN
+  RETURN x * 2;
+END;
+
+evaluate 'Case 2: NO SQL - empty body (no statement at all)';
+CREATE OR REPLACE PROCEDURE p_empty AS
+BEGIN
+  NULL;
+END;
+
+evaluate 'Case 3: CONTAINS SQL - SELECT of an expression without table reference';
+CREATE OR REPLACE FUNCTION f_contains RETURN INT AS
+  n INT;
+BEGIN
+  SELECT 1 + 1 INTO n;
+  RETURN n;
+END;
+
+evaluate 'Case 4: CONTAINS SQL - SELECT of a function without FROM (no table data)';
+CREATE OR REPLACE FUNCTION f_func_nofrom RETURN VARCHAR AS
+  v VARCHAR(256);
+BEGIN
+  SELECT database() INTO v;
+  RETURN v;
+END;
+
+evaluate 'Case 5: CONTAINS SQL - control statement COMMIT';
+CREATE OR REPLACE PROCEDURE p_commit AS
+BEGIN
+  COMMIT;
+END;
+
+evaluate 'Case 6: CONTAINS SQL - control statement ROLLBACK';
+CREATE OR REPLACE PROCEDURE p_rollback AS
+BEGIN
+  ROLLBACK;
+END;
+
+evaluate 'Case 7: CONTAINS SQL - set-derived table TABLE({...}) is not real table data';
+CREATE OR REPLACE FUNCTION f_setderived RETURN INT AS
+  n INT;
+BEGIN
+  SELECT count(*) INTO n FROM TABLE({1, 2, 3}) t(i);
+  RETURN n;
+END;
+
+evaluate 'Case 8: CONTAINS SQL - view built on a set-derived (virtual) table';
+CREATE OR REPLACE FUNCTION f_view_set RETURN INT AS
+  n INT;
+BEGIN
+  SELECT count(*) INTO n FROM v_set;
+  RETURN n;
+END;
+
+evaluate 'Case 9: READS SQL DATA - SELECT INTO from a table';
+CREATE OR REPLACE FUNCTION f_reads RETURN INT AS
+  n INT;
+BEGIN
+  SELECT count(*) INTO n FROM tbl1;
+  RETURN n;
+END;
+
+evaluate 'Case 10: READS SQL DATA - constant select-list but FROM a real table';
+CREATE OR REPLACE FUNCTION f_const_realtbl RETURN INT AS
+  n INT;
+BEGIN
+  SELECT 1 INTO n FROM tbl1 LIMIT 1;
+  RETURN n;
+END;
+
+evaluate 'Case 11: READS SQL DATA - SELECT from dual';
+CREATE OR REPLACE FUNCTION f_dual RETURN INT AS
+  n INT;
+BEGIN
+  SELECT 1 INTO n FROM dual;
+  RETURN n;
+END;
+
+evaluate 'Case 12: READS SQL DATA - explicit cursor over a table SELECT';
+CREATE OR REPLACE FUNCTION f_cursor RETURN INT AS
+  CURSOR c IS SELECT a FROM tbl1;
+  n INT := 0;
+BEGIN
+  OPEN c;
+  CLOSE c;
+  RETURN n;
+END;
+
+evaluate 'Case 13: READS SQL DATA - OPEN FOR (ref cursor) over a table SELECT';
+CREATE OR REPLACE FUNCTION f_openfor RETURN INT AS
+  c SYS_REFCURSOR;
+  n INT := 0;
+BEGIN
+  OPEN c FOR SELECT a FROM tbl1;
+  CLOSE c;
+  RETURN n;
+END;
+
+evaluate 'Case 14: READS SQL DATA - FOR ... IN (SELECT) LOOP over a table';
+CREATE OR REPLACE FUNCTION f_forloop RETURN INT AS
+  n INT := 0;
+BEGIN
+  FOR r IN (SELECT a FROM tbl1) LOOP
+    n := n + 1;
+  END LOOP;
+  RETURN n;
+END;
+
+evaluate 'Case 15: READS SQL DATA - SELECT from a derived table (subquery) over a real table';
+CREATE OR REPLACE FUNCTION f_subquery RETURN INT AS
+  n INT;
+BEGIN
+  SELECT count(*) INTO n FROM (SELECT a FROM tbl1) d;
+  RETURN n;
+END;
+
+evaluate 'Case 16: READS SQL DATA - SELECT from a view over a base table';
+CREATE OR REPLACE FUNCTION f_view RETURN INT AS
+  n INT;
+BEGIN
+  SELECT count(*) INTO n FROM v_tbl1;
+  RETURN n;
+END;
+
+evaluate 'Case 17: READS SQL DATA - strongest wins, CONTAINS + READS in one body -> READS';
+CREATE OR REPLACE FUNCTION f_contains_reads RETURN INT AS
+  a1 INT;
+  a2 INT;
+BEGIN
+  SELECT 1 + 1 INTO a1;
+  SELECT count(*) INTO a2 FROM tbl1;
+  RETURN a1 + a2;
+END;
+
+evaluate 'Case 18: MODIFIES SQL DATA - INSERT';
+CREATE OR REPLACE PROCEDURE p_insert AS
+BEGIN
+  INSERT INTO tbl1 VALUES (99);
+END;
+
+evaluate 'Case 19: MODIFIES SQL DATA - UPDATE';
+CREATE OR REPLACE PROCEDURE p_update AS
+BEGIN
+  UPDATE tbl1 SET a = a + 1;
+END;
+
+evaluate 'Case 20: MODIFIES SQL DATA - DELETE';
+CREATE OR REPLACE PROCEDURE p_delete AS
+BEGIN
+  DELETE FROM tbl1 WHERE a > 100;
+END;
+
+evaluate 'Case 21: MODIFIES SQL DATA - MERGE';
+CREATE OR REPLACE PROCEDURE p_merge AS
+BEGIN
+  MERGE INTO tbl1 USING (SELECT 1 AS x) s ON (tbl1.a = s.x)
+    WHEN NOT MATCHED THEN INSERT VALUES (s.x);
+END;
+
+evaluate 'Case 22: MODIFIES SQL DATA - REPLACE';
+CREATE OR REPLACE PROCEDURE p_replace AS
+BEGIN
+  REPLACE INTO tbl1 VALUES (1);
+END;
+
+evaluate 'Case 23: MODIFIES SQL DATA - TRUNCATE';
+CREATE OR REPLACE PROCEDURE p_truncate AS
+BEGIN
+  TRUNCATE TABLE tbl1;
+END;
+
+evaluate 'Case 24: MODIFIES SQL DATA - INSERT ... SELECT (read + write)';
+CREATE OR REPLACE PROCEDURE p_insert_select AS
+BEGIN
+  INSERT INTO tbl1 SELECT a FROM tbl1 WHERE a < 0;
+END;
+
+evaluate 'Case 25: MODIFIES SQL DATA - strongest wins, READS + MODIFIES in one body -> MODIFIES';
+CREATE OR REPLACE PROCEDURE p_mixed AS
+  n INT;
+BEGIN
+  SELECT count(*) INTO n FROM tbl1;
+  INSERT INTO tbl1 VALUES (n);
+END;
+
+evaluate 'Case 26: NO SQL - dynamic SQL string is not statically analyzed';
+CREATE OR REPLACE PROCEDURE p_dynamic AS
+BEGIN
+  EXECUTE IMMEDIATE 'INSERT INTO tbl1 VALUES (7)';
+END;
+
+evaluate 'Case 27: NO SQL - DDL is only possible via dynamic SQL, so it is not analyzed';
+CREATE OR REPLACE PROCEDURE p_ddl AS
+BEGIN
+  EXECUTE IMMEDIATE 'CREATE TABLE t_new (x INT)';
+END;
+
+evaluate 'Case 28: NO SQL - calling another SP is not counted as SQL access';
+CREATE OR REPLACE PROCEDURE p_callmod AS
+BEGIN
+  p_insert();
+END;
+
+evaluate 'Case 29: DBMS_OUTPUT execution path is exercised for the NO SQL procedure';
+CALL p_nosql();
+
+evaluate 'Case 30: sql_data_access from db_stored_procedure for all cases above';
+SELECT sp_name, sp_type, sql_data_access
+FROM db_stored_procedure
+WHERE sp_name IN ('p_nosql', 'f_calc', 'p_empty', 'f_contains', 'f_func_nofrom',
+                  'p_commit', 'p_rollback', 'f_setderived', 'f_view_set', 'f_reads',
+                  'f_const_realtbl', 'f_dual', 'f_cursor', 'f_openfor', 'f_forloop',
+                  'f_subquery', 'f_view', 'f_contains_reads', 'p_insert', 'p_update',
+                  'p_delete', 'p_merge', 'p_replace', 'p_truncate', 'p_insert_select',
+                  'p_mixed', 'p_dynamic', 'p_ddl', 'p_callmod')
+ORDER BY sp_name;
+
+evaluate 'Case 31: same value is exposed through information_schema.routines for every routine';
+SELECT routine_name, routine_type, sql_data_access
+FROM information_schema.routines
+WHERE routine_name IN ('p_nosql', 'f_calc', 'p_empty', 'f_contains', 'f_func_nofrom',
+                       'p_commit', 'p_rollback', 'f_setderived', 'f_view_set', 'f_reads',
+                       'f_const_realtbl', 'f_dual', 'f_cursor', 'f_openfor', 'f_forloop',
+                       'f_subquery', 'f_view', 'f_contains_reads', 'p_insert', 'p_update',
+                       'p_delete', 'p_merge', 'p_replace', 'p_truncate', 'p_insert_select',
+                       'p_mixed', 'p_dynamic', 'p_ddl', 'p_callmod')
+ORDER BY routine_name;
+
+evaluate 'Case 32: CREATE OR REPLACE re-determines sql_data_access (READS -> MODIFIES)';
+CREATE OR REPLACE FUNCTION f_reads RETURN INT AS
+  n INT;
+BEGIN
+  INSERT INTO tbl1 VALUES (5);
+  SELECT count(*) INTO n FROM tbl1;
+  RETURN n;
+END;
+
+SELECT sp_name, sql_data_access FROM db_stored_procedure WHERE sp_name = 'f_reads';
+
+DROP PROCEDURE p_nosql;
+DROP FUNCTION f_calc;
+DROP PROCEDURE p_empty;
+DROP FUNCTION f_contains;
+DROP FUNCTION f_func_nofrom;
+DROP PROCEDURE p_commit;
+DROP PROCEDURE p_rollback;
+DROP FUNCTION f_setderived;
+DROP FUNCTION f_view_set;
+DROP FUNCTION f_reads;
+DROP FUNCTION f_const_realtbl;
+DROP FUNCTION f_dual;
+DROP FUNCTION f_cursor;
+DROP FUNCTION f_openfor;
+DROP FUNCTION f_forloop;
+DROP FUNCTION f_subquery;
+DROP FUNCTION f_view;
+DROP FUNCTION f_contains_reads;
+DROP PROCEDURE p_insert;
+DROP PROCEDURE p_update;
+DROP PROCEDURE p_delete;
+DROP PROCEDURE p_merge;
+DROP PROCEDURE p_replace;
+DROP PROCEDURE p_truncate;
+DROP PROCEDURE p_insert_select;
+DROP PROCEDURE p_mixed;
+DROP PROCEDURE p_dynamic;
+DROP PROCEDURE p_ddl;
+DROP PROCEDURE p_callmod;
+DROP VIEW v_tbl1;
+DROP VIEW v_set;
+DROP TABLE IF EXISTS tbl1;


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CBRD-26708

As-is
- PL/CSQL SP를 컴파일할 때 SQL data access 특성을 판정하거나 제공하지 않았습니다.
- 카탈로그에 sql_data_access 컬럼은 존재했지만, PL/CSQL SP에 대해 의미 있는 값이 채워지지 않았습니다.

To-be
- PL/CSQL SP 컴파일 시 본문을 정적 분석하여 SQL data access 특성을 자동으로 판정합니다.
- 본문에 직접 포함된 SQL 문을 분석해 NO SQL / CONTAINS SQL / READS SQL DATA / MODIFIES SQL DATA 중 하나로 분류합니다.
- 판정된 값이 db_stored_procedure 및 information_schema.routines 뷰를 통해 노출됩니다.
- 판정 규칙(검증으로 확인된 동작):
  - SQL 문이 전혀 없음(산술 연산, DBMS_OUTPUT, 빈 본문) → NO SQL
  - 테이블 데이터를 건드리지 않는 SQL(표현식 SELECT, FROM 없는 함수 SELECT, COMMIT/ROLLBACK 제어문, set-derived table `TABLE({...})` 및 이를 기반으로 한 뷰) → CONTAINS SQL
  - 실테이블 데이터를 읽는 SELECT/커서/OPEN FOR/FOR-IN-LOOP, 실테이블 기반 파생 테이블·뷰, 상수 select-list + 실테이블 FROM, dual → READS SQL DATA
  - INSERT / UPDATE / DELETE / MERGE / REPLACE / TRUNCATE / INSERT ... SELECT → MODIFIES SQL DATA
  - 여러 수준이 섞이면 가장 강한 접근 수준이 승리(MODIFIES > READS > CONTAINS > NO SQL)
  - 동적 SQL(EXECUTE IMMEDIATE) — 정적 분석 불가 → NO SQL (DDL은 동적 SQL로만 가능하므로 동일)
  - 다른 SP 호출 — 호출 대상으로 전파 안 함 → NO SQL

### 리뷰 반영 이력
- 리뷰 피드백(kwonhoil, ssihil, greptile)을 반영하여 커버리지를 13 → 32 케이스로 확대했습니다.
- ssihil 코멘트의 JIRA 시나리오(파생 테이블/상수 select-list+실테이블/함수·제어 SQL/set-derived table/뷰 해석/dual/빈 본문/우선순위 등)를 로컬 빌드(CUBRID 11.5.0.2300)로 실제 판정 probe 후 반영했습니다.
- information_schema.routines 검증을 전체 루틴(db_stored_procedure와 동일 셋)으로 확대, DBMS_OUTPUT 실행 경로(`--+ server-message on` + `CALL`) 검증 추가.
- CUBRID 11.5.0.2300 로컬 빌드에서 CTP `sql`로 실행, 답지 재생성 후 PASS 확인.

| Case | SP 이름 | 시나리오 | 기대 결과 |
|------|---------|----------|-----------|
| 1  | p_nosql / f_calc | DBMS_OUTPUT / 산술 연산 | NO SQL |
| 2  | p_empty | 빈 본문 (`BEGIN NULL; END;`) | NO SQL |
| 3  | f_contains | 테이블 참조 없는 표현식 SELECT (`SELECT 1+1 INTO`) | CONTAINS SQL |
| 4  | f_func_nofrom | FROM 없는 함수 SELECT (`SELECT database() INTO`) | CONTAINS SQL |
| 5  | p_commit | 제어문 COMMIT | CONTAINS SQL |
| 6  | p_rollback | 제어문 ROLLBACK | CONTAINS SQL |
| 7  | f_setderived | set-derived table `TABLE({1,2,3})` (실테이블 아님) | CONTAINS SQL |
| 8  | f_view_set | set-derived table 기반 (가상) 뷰 | CONTAINS SQL |
| 9  | f_reads | 실테이블에서 SELECT INTO | READS SQL DATA |
| 10 | f_const_realtbl | 상수 select-list + 실테이블 FROM (`SELECT 1 INTO FROM tbl1`) | READS SQL DATA |
| 11 | f_dual | dual에서 읽기 | READS SQL DATA |
| 12 | f_cursor | 명시적 CURSOR OPEN/CLOSE | READS SQL DATA |
| 13 | f_openfor | OPEN ... FOR SELECT (ref cursor) | READS SQL DATA |
| 14 | f_forloop | `FOR r IN (SELECT ...) LOOP` | READS SQL DATA |
| 15 | f_subquery | 실테이블 기반 파생 테이블(서브쿼리) | READS SQL DATA |
| 16 | f_view | 실테이블 기반 뷰 | READS SQL DATA |
| 17 | f_contains_reads | 우선순위: CONTAINS + READS 혼재 → READS | READS SQL DATA |
| 18 | p_insert | INSERT | MODIFIES SQL DATA |
| 19 | p_update | UPDATE | MODIFIES SQL DATA |
| 20 | p_delete | DELETE | MODIFIES SQL DATA |
| 21 | p_merge | MERGE | MODIFIES SQL DATA |
| 22 | p_replace | REPLACE | MODIFIES SQL DATA |
| 23 | p_truncate | TRUNCATE | MODIFIES SQL DATA |
| 24 | p_insert_select | INSERT ... SELECT (읽기+쓰기) | MODIFIES SQL DATA |
| 25 | p_mixed | 우선순위: READS + MODIFIES 혼재 → MODIFIES | MODIFIES SQL DATA |
| 26 | p_dynamic | 동적 SQL `EXECUTE IMMEDIATE` (정적 분석 대상 아님) | NO SQL |
| 27 | p_ddl | DDL은 동적 SQL로만 가능 (`EXECUTE IMMEDIATE 'CREATE TABLE ...'`) | NO SQL |
| 28 | p_callmod | 다른 SP 호출 (SQL 접근으로 전파 안 함) | NO SQL |
| 29 | p_nosql (call) | DBMS_OUTPUT 실행 경로 수행 (`CALL`, server-message on) | put_line 출력 확인 |
| 30 | (전체 조회) | `db_stored_procedure`에서 전체 SP의 sql_data_access 조회 | 각 SP가 위 기대값대로 노출됨 |
| 31 | (전체 조회) | `information_schema.routines`에서 전체 루틴의 sql_data_access 조회 | Case 30과 동일한 값으로 노출됨 |
| 32 | f_reads (재정의) | `CREATE OR REPLACE`로 INSERT 추가 후 재조회 | READS → MODIFIES로 재판정됨 |
