### PR TITLE
[CBRD-26006] Revise isolation test cases to reflect Floating-Point NUMERIC support 

### DIFF
--- a/isolation/_01_ReadCommitted/function/numeric_function/answer/delete_delete_03.answer
+++ b/isolation/_01_ReadCommitted/function/numeric_function/answer/delete_delete_03.answer
@@ -3,24 +3,24 @@
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
-|    1    'book1'    30  
-|    4    'book4'    32  
-|    5    'book5'    30  
-|    6    'book6'    32  
-|    7    'book7'    32  
+|    1    'book1'    29.16  
+|    4    'book4'    31.66  
+|    5    'book5'    29.87  
+|    6    'book6'    31.89  
+|    7    'book7'    32.04  
 | 5 rows selected
 | 2 rows affected
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
-|    4    'book4'    32  
-|    6    'book6'    32  
-|    7    'book7'    32  
+|    4    'book4'    31.66  
+|    6    'book6'    31.89  
+|    7    'book7'    32.04  
 | 3 rows selected
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
-|    4    'book4'    32  
-|    6    'book6'    32  
-|    7    'book7'    32  
+|    4    'book4'    31.66  
+|    6    'book6'    31.89  
+|    7    'book7'    32.04  
 | 3 rows selected

--- a/isolation/_01_ReadCommitted/function/numeric_function/answer/delete_delete_04.answer
+++ b/isolation/_01_ReadCommitted/function/numeric_function/answer/delete_delete_04.answer
@@ -3,26 +3,26 @@
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
-|    -3    'book6'    32  
-|    1    'book1'    30  
-|    2    'book4'    32  
-|    3    'book5'    30  
-|    4    'book7'    32  
+|    -3    'book6'    31.89  
+|    1    'book1'    31.16  
+|    2    'book4'    31.66  
+|    3    'book5'    29.87  
+|    4    'book7'    32.04  
 | 5 rows selected
 | 1 row affected
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
-|    -3    'book6'    32  
-|    2    'book4'    32  
-|    3    'book5'    30  
-|    4    'book7'    32  
+|    -3    'book6'    31.89  
+|    2    'book4'    31.66  
+|    3    'book5'    29.87  
+|    4    'book7'    32.04  
 | 4 rows selected
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
-|    -3    'book6'    32  
-|    2    'book4'    32  
-|    3    'book5'    30  
-|    4    'book7'    32  
+|    -3    'book6'    31.89  
+|    2    'book4'    31.66  
+|    3    'book5'    29.87  
+|    4    'book7'    32.04  
 | 4 rows selected

--- a/isolation/_01_ReadCommitted/function/numeric_function/answer/select_select_02_1.answer
+++ b/isolation/_01_ReadCommitted/function/numeric_function/answer/select_select_02_1.answer
@@ -2,14 +2,14 @@
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
-|    4    'book6'    38  
-|    -4    'book7'    35  
+|    4    'book6'    38.12  
+|    -4    'book7'    34.99  
 | 2 rows selected
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
-|    -1    'book1'    35  
-|    1    'book2'    35  
-|    -2    'book4'    35  
-|    -4    'book7'    35  
+|    -1    'book1'    34.999  
+|    1    'book2'    34.996  
+|    -2    'book4'    34.993  
+|    -4    'book7'    34.99  
 | 4 rows selected

--- a/isolation/_01_ReadCommitted/function/numeric_function/answer/update_delete_04.answer
+++ b/isolation/_01_ReadCommitted/function/numeric_function/answer/update_delete_04.answer
@@ -3,28 +3,28 @@
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
-|    1    'book1'    30  
-|    2    'unknown_bo'    31  
-|    3    'unknown_bo'    31  
-|    4    'book4'    32  
-|    5    'book5'    30  
-|    6    'book6'    29  
-|    7    'book7'    32  
+|    1    'book1'    30.16  
+|    2    'unknown_bo'    31.23  
+|    3    'unknown_bo'    31.99  
+|    4    'book4'    32.66  
+|    5    'book5'    30.87  
+|    6    'book6'    29.01  
+|    7    'book7'    32.04  
 | 7 rows selected
 | 3 rows affected
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
-|    2    'unknown_bo'    31  
-|    4    'book4'    32  
-|    6    'book6'    29  
-|    7    'book7'    32  
+|    2    'unknown_bo'    31.23  
+|    4    'book4'    32.66  
+|    6    'book6'    29.01  
+|    7    'book7'    32.04  
 | 4 rows selected
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
-|    2    'unknown_bo'    31  
-|    4    'book4'    32  
-|    6    'book6'    29  
-|    7    'book7'    32  
+|    2    'unknown_bo'    31.23  
+|    4    'book4'    32.66  
+|    6    'book6'    29.01  
+|    7    'book7'    32.04  
 | 4 rows selected

--- a/isolation/_01_ReadCommitted/function/numeric_function/answer/update_delete_05.answer
+++ b/isolation/_01_ReadCommitted/function/numeric_function/answer/update_delete_05.answer
@@ -3,28 +3,28 @@
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
-|    1    'book1'    30  
-|    2    'book2'    31  
-|    3    'book3'    31  
-|    4    'book4'    30  
-|    5    'book5'    30  
-|    6    'book6'    29  
-|    7    'book7'    30  
+|    1    'book1'    30.16  
+|    2    'book2'    31.23  
+|    3    'book3'    31.19  
+|    4    'book4'    30.22  
+|    5    'book5'    30.87  
+|    6    'book6'    29.01  
+|    7    'book7'    30.22  
 | 7 rows selected
 | 3 rows affected
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
-|    2    'book2'    31  
-|    3    'book3'    31  
-|    6    'book6'    29  
-|    7    'book7'    30  
+|    2    'book2'    31.23  
+|    3    'book3'    31.19  
+|    6    'book6'    29.01  
+|    7    'book7'    30.22  
 | 4 rows selected
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
-|    2    'book2'    31  
-|    3    'book3'    31  
-|    6    'book6'    29  
-|    7    'book7'    30  
+|    2    'book2'    31.23  
+|    3    'book3'    31.19  
+|    6    'book6'    29.01  
+|    7    'book7'    30.22  
 | 4 rows selected

--- a/isolation/_01_ReadCommitted/function/numeric_function/delete_delete_03.ctl
+++ b/isolation/_01_ReadCommitted/function/numeric_function/delete_delete_03.ctl
@@ -40,7 +40,7 @@ C3: set transaction isolation level read committed;
 /* preparation */
 C1: DROP TABLE IF EXISTS t1;
 C1: CREATE TABLE t1(id INT, title VARCHAR(10), price DECIMAL);
-C1: INSERT INTO t1 VALUES(1,'book1',30.16),(2,'book2',31.23),(3,'book3',30.99),(4,'book4',31.66),(5,'book5',29.87),(6,'book6',31.89),(7,'book7',32.04);
+C1: INSERT INTO t1 VALUES(1,'book1',29.16),(2,'book2',30.23),(3,'book3',30.99),(4,'book4',31.66),(5,'book5',29.87),(6,'book6',31.89),(7,'book7',32.04);
 C1: COMMIT WORK;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/function/numeric_function/delete_delete_04.ctl
+++ b/isolation/_01_ReadCommitted/function/numeric_function/delete_delete_04.ctl
@@ -40,7 +40,7 @@ C3: set transaction isolation level read committed;
 /* preparation */
 C1: DROP TABLE IF EXISTS t1;
 C1: CREATE TABLE t1(id INT UNIQUE, title VARCHAR(10), price DECIMAL);
-C1: INSERT INTO t1 VALUES(1,'book1',30.16),(-1,'book2',31.23),(-2,'book3',30.99),(2,'book4',31.66),(3,'book5',29.87),(-3,'book6',31.89),(4,'book7',32.04);
+C1: INSERT INTO t1 VALUES(1,'book1',31.16),(-1,'book2',30.23),(-2,'book3',30.99),(2,'book4',31.66),(3,'book5',29.87),(-3,'book6',31.89),(4,'book7',32.04);
 C1: COMMIT WORK;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/function/numeric_function/select_select_02_1.ctl
+++ b/isolation/_01_ReadCommitted/function/numeric_function/select_select_02_1.ctl
@@ -37,7 +37,7 @@ C1: DROP TABLE IF EXISTS t1;
 C1: CREATE TABLE t1(id INT, col VARCHAR(10), price DECIMAL);
 C1: CREATE INDEX idx_id on t1(ABS(id));
 C1: CREATE INDEX idx_price on t1(TRUNC(price,2));
-C1: INSERT INTO t1 VALUES(-1,'book1',34.599),(1,'book2',34.60),(2,'book3',35.88),(-2,'book4',34.593),(3,'book5',37.10),(4,'book6',38.12),(-4,'book7',34.99);
+C1: INSERT INTO t1 VALUES(-1,'book1',34.999),(1,'book2',34.996),(2,'book3',35.88),(-2,'book4',34.993),(3,'book5',37.10),(4,'book6',38.12),(-4,'book7',34.99);
 C1: COMMIT WORK;
 MC: wait until C1 ready;
 
@@ -45,7 +45,7 @@ MC: wait until C1 ready;
 C1: SELECT * FROM t1 WHERE ABS(id) = 4; 
 MC: wait until C1 ready;
 
-C2: SELECT * FROM t1 WHERE TRUNC(price,2) = 35; 
+C2: SELECT * FROM t1 WHERE TRUNC(price,2) = 34.99; 
 /* expect: no transactions need to wait, assume C1 finished before C2 */
 MC: wait until C2 ready;
 /* expect: C1 select - id = 4,-4, are selected */

--- a/isolation/_01_ReadCommitted/function/numeric_function/update_delete_04.ctl
+++ b/isolation/_01_ReadCommitted/function/numeric_function/update_delete_04.ctl
@@ -42,7 +42,7 @@ C3: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS t1;
 C1: CREATE TABLE t1(id INT, title VARCHAR(10), price DECIMAL);
 C1: CREATE INDEX idx_price on t1(price);
-C1: INSERT INTO t1 VALUES(1,'book1',30.16),(2,'book2',31.23),(3,'book3',30.99),(4,'book4',31.66),(5,'book5',29.87),(6,'book6',29.01),(7,'book7',32.04);
+C1: INSERT INTO t1 VALUES(1,'book1',30.16),(2,'book2',31.23),(3,'book3',31.99),(4,'book4',32.66),(5,'book5',30.87),(6,'book6',29.01),(7,'book7',32.04);
 C1: COMMIT WORK;
 MC: wait until C1 ready;
 

--- a/isolation/_01_ReadCommitted/function/numeric_function/update_delete_05.ctl
+++ b/isolation/_01_ReadCommitted/function/numeric_function/update_delete_05.ctl
@@ -43,7 +43,7 @@ C3: set transaction isolation level read committed;
 C1: DROP TABLE IF EXISTS t1;
 C1: CREATE TABLE t1(id INT, title VARCHAR(10), price DECIMAL);
 C1: CREATE INDEX idx_price on t1(price);
-C1: INSERT INTO t1 VALUES(1,'book1',30.16),(2,'book2',31.23),(3,'book3',31.19),(4,'book4',31.66),(5,'book5',29.87),(6,'book6',29.01),(7,'book7',32.04);
+C1: INSERT INTO t1 VALUES(1,'book1',30.16),(2,'book2',31.23),(3,'book3',31.19),(4,'book4',32.66),(5,'book5',30.87),(6,'book6',29.01),(7,'book7',32.04);
 C1: COMMIT WORK;
 MC: wait until C1 ready;
 


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-26006


1) 기존 TC의도를 해치지 않게 TC내의 테스트 데이터를 수정하였습니다.
2) `SELECT * FROM t1 order by 1,2; ` 의 결과값이 정확한 값이 나오도록 변경되었습니다. 