### PR TITLE
[CBRD-26635] Fix timing issue in unstable isolation test cases

### DIFF
--- a/isolation/_01_ReadCommitted/index_column/composite_index/basic_sql/update_delete_09.ctl
+++ b/isolation/_01_ReadCommitted/index_column/composite_index/basic_sql/update_delete_09.ctl
@@ -52,6 +52,7 @@ MC: wait until C1 ready;
 C2: DELETE FROM t1 WHERE id = 7 and sleep(2) = 0;
 /* expect: no transactions need to wait */
 /* expect: C1 select - id = 2,3 are updated */
+MC: sleep 1;
 C1: SELECT * FROM t1 order by 1,2,3;
 C1: commit;
 /* expect: C2 finished execution after C1 committed, 1 rows (id=7)deleted message, C2 select - id = 7 are deleted */

--- a/isolation/_01_ReadCommitted/index_column/composite_index/basic_sql/update_delete_09_1.ctl
+++ b/isolation/_01_ReadCommitted/index_column/composite_index/basic_sql/update_delete_09_1.ctl
@@ -51,6 +51,7 @@ MC: wait until C1 ready;
 C2: DELETE FROM t1 WHERE tag in ('A','D') and 0 = (select sleep(4)); 
 /* expect: no transactions need to wait */
 /* expect: C1 select - id = 2,3,5 are updated */
+MC: sleep 1;
 C1: SELECT * FROM t1 order by 1,2;
 C1: commit;
 /* expect: C2 finished execution after C1 commit, 2 rows (id=1,4)deleted message, C2 select - id = 1,4 are deleted */

--- a/isolation/_01_ReadCommitted/index_column/composite_index/basic_sql/update_delete_09_3.ctl
+++ b/isolation/_01_ReadCommitted/index_column/composite_index/basic_sql/update_delete_09_3.ctl
@@ -52,6 +52,7 @@ MC: wait until C1 ready;
 C2: DELETE FROM t1 WHERE tag = 'B' and sleep(2)=0;
 /* expect: no transactions need to wait */
 /* expect: C1 select - id = 1,4 are updated */
+MC: sleep 1;
 C1: SELECT * FROM t1 order by 1,2;
 C1: commit;
 /* expect: C2 finished execution after C1 commit, 1 row (id=2)deleted message, C2 select - id = 2 is deleted */

--- a/isolation/_04_RepeatableRead_ReadCommitted/index_column/composite_index/basic_sql/update_delete_09.ctl
+++ b/isolation/_04_RepeatableRead_ReadCommitted/index_column/composite_index/basic_sql/update_delete_09.ctl
@@ -52,6 +52,7 @@ MC: wait until C1 ready;
 C2: DELETE FROM t1 WHERE id = 7 and sleep(2) = 0;
 /* expect: no transactions need to wait */
 /* expect: C1 select - id = 2,3 are updated */
+MC: sleep 1;
 C1: SELECT * FROM t1 order by 1,2,3;
 C1: commit;
 /* expect: C2 finished execution after C1 committed, 1 rows (id=7)deleted message, C2 select - id = 7 are deleted */

--- a/isolation/_04_RepeatableRead_ReadCommitted/index_column/composite_index/basic_sql/update_delete_09_1.ctl
+++ b/isolation/_04_RepeatableRead_ReadCommitted/index_column/composite_index/basic_sql/update_delete_09_1.ctl
@@ -51,6 +51,7 @@ MC: wait until C1 ready;
 C2: DELETE FROM t1 WHERE tag in ('A','D') and 0 = (select sleep(4)); 
 /* expect: no transactions need to wait */
 /* expect: C1 select - id = 2,3,5 are updated */
+MC: sleep 1;
 C1: SELECT * FROM t1 order by 1,2;
 C1: commit;
 /* expect: C2 finished execution after C1 commit, 2 rows (id=1,4)deleted message, C2 select - id = 1,4 are deleted */

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/_04_RepeatableRead_ReadCommitted/index_column/composite_index/basic_sql/update_delete_09.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/_04_RepeatableRead_ReadCommitted/index_column/composite_index/basic_sql/update_delete_09.ctl
@@ -52,6 +52,7 @@ MC: wait until C1 ready;
 C2: DELETE FROM t1 WHERE id = 7 and sleep(2) = 0;
 /* expect: no transactions need to wait */
 /* expect: C1 select - id = 2,3 are updated */
+MC: sleep 1;
 C1: SELECT * FROM t1 order by 1,2,3;
 C1: commit;
 /* expect: C2 finished execution after C1 committed, 1 rows (id=7)deleted message, C2 select - id = 7 are deleted */

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/_04_RepeatableRead_ReadCommitted/index_column/composite_index/basic_sql/update_delete_09_1.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/_04_RepeatableRead_ReadCommitted/index_column/composite_index/basic_sql/update_delete_09_1.ctl
@@ -51,6 +51,7 @@ MC: wait until C1 ready;
 C2: DELETE FROM t1 WHERE tag in ('A','D') and 0 = (select sleep(4)); 
 /* expect: no transactions need to wait */
 /* expect: C1 select - id = 2,3,5 are updated */
+MC: sleep 1;
 C1: SELECT * FROM t1 order by 1,2;
 C1: commit;
 /* expect: C2 finished execution after C1 commit, 2 rows (id=1,4)deleted message, C2 select - id = 1,4 are deleted */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26635

connection pool 적용 이후로 꾸준히 unstable 한 case들에 대해 타이밍을 수정합니다. (regression 에서 fail 횟수 빈번)

자세한 내용은 아래를 참고 부탁드립니다.
문의 내용 : [cbrd-26635_코멘트링크](http://jira.cubrid.org/browse/CBRD-26635?focusedCommentId=4774300&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4774300)

개발자 답변 : isolation_debug: connection pool 이후 epoll event-driven 기반의 배치성 처리 구조가 도입되어 작은 단위의 작업에서는 jitter가 생길 수 있습니다. 트랜잭션 격리 수준 테스트 케이스라 앞뒤 타이밍에 민감한데, jitter로 인해 타이밍이 흔들리며 앞선 트랜잭션이 snapshot을 잡기 전에 이후 처리가 수행되는 것으로 보입니다. https://github.com/CUBRID/cubrid-testcases/pull/2506 에서 수정하신 것처럼 타이밍만 지연시켜주시면 충분할 것 같습니다.