### PR TITLE
[CBRD-26889] Modified test_case for i have corrected the answer key and also corrected the C…

### DIFF
--- a/sql/_35_fig_cake/cbrd_25382/answers/cbrd_25382_1.answer
+++ b/sql/_35_fig_cake/cbrd_25382/answers/cbrd_25382_1.answer
@@ -48,7 +48,7 @@ hash-join (inner join)
                outer: hash-join (inner join)
                           edge:  term[?]
                           outer: iscan
-                                     class: a node[?]
+                                     class: b node[?]
                                      index: i_b term[?]
                                      cost:  ? card ?
                           inner: iscan
@@ -57,12 +57,12 @@ hash-join (inner join)
                                      cost:  ? card ?
                           cost:  ? card ?
                inner: iscan
-                          class: b node[?]
+                          class: c node[?]
                           index: i_b term[?]
                           cost:  ? card ?
                cost:  ? card ?
     inner: iscan
-               class: c node[?]
+               class: a node[?]
                index: i_b term[?]
                cost:  ? card ?
     cost:  ? card ?
@@ -75,10 +75,10 @@ Query Plan:
   HASH JOIN (inner join)
     HASH JOIN (inner join)
       HASH JOIN (inner join)
-        INDEX SCAN (a.i_b) (key range: ((a.cb= ?:? ) or (a.cb= ?:? )))
+        INDEX SCAN (b.i_b) (key range: ((b.cb= ?:? ) or (b.cb= ?:? ) or (b.cb= ?:? )))
         INDEX SCAN (d.i_b) (key range: d.cb= ?:? )
-      INDEX SCAN (b.i_b) (key range: ((b.cb= ?:? ) or (b.cb= ?:? ) or (b.cb= ?:? )))
-    INDEX SCAN (c.i_b) (key range: ((c.cb= ?:? ) or (c.cb= ?:? ) or (c.cb= ?:? ) or (c.cb= ?:? )))
+      INDEX SCAN (c.i_b) (key range: ((c.cb= ?:? ) or (c.cb= ?:? ) or (c.cb= ?:? ) or (c.cb= ?:? )))
+    INDEX SCAN (a.i_b) (key range: ((a.cb= ?:? ) or (a.cb= ?:? )))
 
   rewritten query: select /*+ USE_HASH NO_PARALLEL_SUBQUERY */ count(*) from [dba.ta] a, [dba.tb] b, [dba.tc] c, [dba.td] d where a.cd=b.cd and b.cd=c.cd and c.cd=d.cd and ((a.cb= ?:? ) or (a.cb= ?:? )) and ((b.cb= ?:? ) or (b.cb= ?:? ) or (b.cb= ?:? )) and ((c.cb= ?:? ) or (c.cb= ?:? ) or (c.cb= ?:? ) or (c.cb= ?:? )) and d.cb= ?:? 
 
@@ -99,13 +99,13 @@ Trace Statistics:
                             SCAN (index: dba.td.i_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
                         PROBE (time: ?, fetch: ?, ioread: ?, readrows: ?, readkeys: ?, rows: ?)
                           SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-                            SCAN (index: dba.ta.i_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+                            SCAN (index: dba.tb.i_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
                 PROBE (time: ?, fetch: ?, ioread: ?, readrows: ?, readkeys: ?, rows: ?)
                   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-                    SCAN (index: dba.tb.i_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+                    SCAN (index: dba.tc.i_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
         PROBE (time: ?, fetch: ?, ioread: ?, readrows: ?, readkeys: ?, rows: ?)
           SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-            SCAN (index: dba.tc.i_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+            SCAN (index: dba.ta.i_b), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
 
 ===================================================

--- a/sql/_36_guava/cbrd_26258/answers/join_orderby_skip.answer_cci
+++ b/sql/_36_guava/cbrd_26258/answers/join_orderby_skip.answer_cci
@@ -18,7 +18,7 @@
 0
 ===================================================
     
-Q101. When a covering index scan cannot be used, it is less cost-effective; therefore, skip ORDER BY cannot be applied.     
+Q101. When a covering index scan cannot be used, skip ORDER BY is applied via a non-covering index scan since the lowered ISCAN_OID_ACCESS_OVERHEAD makes its cost competitive (CBRD-26889).     
 
 ===================================================
 'Q101'    cola    colb    colc    cold    cole    colf    
@@ -34,37 +34,35 @@ Q101     9     9     9     9     9     9
 Q101     10     10     10     10     10     10     
 
 Query plan:
-temp(order by)
-    subplan: idx-join (inner join)
-                 outer: sscan
-                            class: a node[?]
-                            cost:  ? card ?
-                 inner: iscan
-                            class: b node[?]
-                            index: pk_tbl_b_cold term[?]
-                            cost:  ? card ?
-                 cost:  ? card ?
+idx-join (inner join)
+    outer: iscan
+               class: a node[?]
+               index: idx_cola 
+               cost:  ? card ?
+    inner: iscan
+               class: b node[?]
+               index: pk_tbl_b_cold term[?]
+               cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
 select /*+ ORDERED */ 'Q?', a.cola, a.colb, a.colc, b.cold, b.cole, b.colf from tbl_a a, tbl_b b where a.cola=b.cold order by ? for orderby_num()<= ?:? 
+/* ---> skip ORDER BY */
 ===================================================
 trace    
 
 Query Plan:
-  SORT (order by)
-    NESTED LOOPS (inner join)
-      TABLE SCAN (a)
-      INDEX SCAN (b.pk_tbl_b_cold) (key range: a.cola=b.cold)
+  NESTED LOOPS (inner join)
+    INDEX SCAN (a.idx_cola) ()
+    INDEX SCAN (b.pk_tbl_b_cold) (key range: a.cola=b.cold)
+  skip order by: true
 
   rewritten query: select /*+ ORDERED */ 'Q?', a.cola, a.colb, a.colc, b.cold, b.cole, b.colf from [dba.tbl_a] a, [dba.tbl_b] b where a.cola=b.cold order by ? for orderby_num()<= ?:? 
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
+    SCAN (index: dba.tbl_a.idx_cola), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
       SCAN (index: dba.tbl_b.pk_tbl_b_cold), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ORDERBY (time: ?, topnsort: true)
      
 
 Query plan:
@@ -1356,7 +1354,7 @@ Query stmt:
 select  trace_stats() from dual dual
 ===================================================
     
-Q121. When an additional condition is included on FK-PK columns apart from the join condition, SORT LIMIT optimization cannot be applied.     
+Q121. When an additional condition is included on FK-PK columns apart from the join condition, SORT LIMIT optimization is not applied, but skip ORDER BY is applied via an order-providing index scan under the lowered ISCAN_OID_ACCESS_OVERHEAD cost model (CBRD-26889).     
 
 ===================================================
 'Q121'    cola    colb    colc    cold    cole    colf    
@@ -1372,38 +1370,36 @@ Q121     209     209     209     209     209     209
 Q121     210     210     210     210     210     210     
 
 Query plan:
-temp(order by)
-    subplan: idx-join (inner join)
-                 outer: sscan
-                            class: a node[?]
-                            cost:  ? card ?
-                 inner: iscan
-                            class: b node[?]
-                            index: pk_tbl_b_cold term[?]
-                            filtr: term[?]
-                            cost:  ? card ?
-                 cost:  ? card ?
+idx-join (inner join)
+    outer: iscan
+               class: a node[?]
+               index: idx_cola_colb 
+               cost:  ? card ?
+    inner: iscan
+               class: b node[?]
+               index: pk_tbl_b_cold term[?]
+               filtr: term[?]
+               cost:  ? card ?
     sort:  ? asc, ? asc
     cost:  ? card ?
 Query stmt:
 select /*+ ORDERED */ 'Q?', a.cola, a.colb, a.colc, b.cold, b.cole, b.colf from tbl_a a, tbl_b b where a.cola=b.cold and b.cold<>-? order by ?, ? for orderby_num()> ?:?  and orderby_num()<= ?:? 
+/* ---> skip ORDER BY */
 ===================================================
 trace    
 
 Query Plan:
-  SORT (order by)
-    NESTED LOOPS (inner join)
-      TABLE SCAN (a)
-      INDEX SCAN (b.pk_tbl_b_cold) (key range: a.cola=b.cold, key filter: b.cold<>-?)
+  NESTED LOOPS (inner join)
+    INDEX SCAN (a.idx_cola_colb) ()
+    INDEX SCAN (b.pk_tbl_b_cold) (key range: a.cola=b.cold, key filter: b.cold<>-?)
+  skip order by: true
 
   rewritten query: select /*+ ORDERED */ 'Q?', a.cola, a.colb, a.colc, b.cold, b.cole, b.colf from [dba.tbl_a] a, [dba.tbl_b] b where a.cola=b.cold and b.cold<>-? order by ?, ? for orderby_num()> ?:?  and orderby_num()<= ?:? 
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
+    SCAN (index: dba.tbl_a.idx_cola_colb), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
       SCAN (index: dba.tbl_b.pk_tbl_b_cold), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ORDERBY (time: ?, topnsort: true)
      
 
 Query plan:
@@ -1460,7 +1456,7 @@ Query stmt:
 select  trace_stats() from dual dual
 ===================================================
     
-Q123. When the LIMIT value exceeds the sort_limit_max_count parameter, SORT LIMIT optimization is not applied; therefore, skip ORDER BY cannot be applied.     
+Q123. When the LIMIT value exceeds the sort_limit_max_count parameter, SORT LIMIT optimization is not applied, but skip ORDER BY is applied via an order-providing index scan under the lowered ISCAN_OID_ACCESS_OVERHEAD cost model (CBRD-26889).     
 
 ===================================================
 0
@@ -1478,37 +1474,35 @@ Q123     1009     1009     1009     1009     1009     1009
 Q123     1010     1010     1010     1010     1010     1010     
 
 Query plan:
-temp(order by)
-    subplan: idx-join (inner join)
-                 outer: sscan
-                            class: a node[?]
-                            cost:  ? card ?
-                 inner: iscan
-                            class: b node[?]
-                            index: pk_tbl_b_cold term[?]
-                            cost:  ? card ?
-                 cost:  ? card ?
+idx-join (inner join)
+    outer: iscan
+               class: a node[?]
+               index: idx_cola_colb 
+               cost:  ? card ?
+    inner: iscan
+               class: b node[?]
+               index: pk_tbl_b_cold term[?]
+               cost:  ? card ?
     sort:  ? asc, ? asc
     cost:  ? card ?
 Query stmt:
 select /*+ ORDERED */ 'Q?', a.cola, a.colb, a.colc, b.cold, b.cole, b.colf from tbl_a a, tbl_b b where a.cola=b.cold order by ?, ? for orderby_num()> ?:?  and orderby_num()<= ?:? 
+/* ---> skip ORDER BY */
 ===================================================
 trace    
 
 Query Plan:
-  SORT (order by)
-    NESTED LOOPS (inner join)
-      TABLE SCAN (a)
-      INDEX SCAN (b.pk_tbl_b_cold) (key range: a.cola=b.cold)
+  NESTED LOOPS (inner join)
+    INDEX SCAN (a.idx_cola_colb) ()
+    INDEX SCAN (b.pk_tbl_b_cold) (key range: a.cola=b.cold)
+  skip order by: true
 
   rewritten query: select /*+ ORDERED */ 'Q?', a.cola, a.colb, a.colc, b.cold, b.cole, b.colf from [dba.tbl_a] a, [dba.tbl_b] b where a.cola=b.cold order by ?, ? for orderby_num()> ?:?  and orderby_num()<= ?:? 
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
+    SCAN (index: dba.tbl_a.idx_cola_colb), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
       SCAN (index: dba.tbl_b.pk_tbl_b_cold), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ORDERBY (time: ?, topnsort: true)
      
 
 Query plan:


### PR DESCRIPTION
to refer : http://jira.cubrid.org/browse/CBRD-26889

- 통계 부정확(낮은 NDV) 시 비커버링 인덱스 스캔이 풀스캔으로 퇴행
- 페널티 상수 ISCAN_OID_ACCESS_OVERHEAD 를 20 → 5 로 낮춰 인덱스 스캔 선호를 회복한다. 
   (커버링 스캔은 heap_access = 0 이라 영향 없음)

1. cbrd_25382_1.answer 를 수정해야하는데 빠져서 답지 수정. ( plan 정보 변경 )
  - 참조 : https://github.com/CUBRID/cubrid-testcases/pull/2871
2. join_orderby_skip.answer_cci 답지 변경 ( plan 정보 변경 )
  - 참조 : https://github.com/CUBRID/cubrid-testcases/pull/2871