### PR TITLE
[CBRD-26848] Revise testcase for modify cci answers

### DIFF
--- a/sql/_28_features_930/issue_13133_hash_query_profile/answers/hash_agg_query_profile.answer_cci
+++ b/sql/_28_features_930/issue_13133_hash_query_profile/answers/hash_agg_query_profile.answer_cci
@@ -305,12 +305,15 @@ trace
           "time": "?..?",
           "readrows": "?..?",
           "rows": "?..?",
-          "gather": "row by row"
+          "gather": "mergeable list",
+          "topnsort": true
         }
       },
       "ORDERBY": {
         "time": ?,
-        "topnsort": true
+        "sort": true,
+        "page": ?,
+        "ioread": ?
       }
     }
   }

--- a/sql/_36_guava/cbrd_26258/answers/join_orderby_skip.answer_cci
+++ b/sql/_36_guava/cbrd_26258/answers/join_orderby_skip.answer_cci
@@ -241,7 +241,8 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    ORDERBY (time: ?, topnsort: true)
+         (parallel workers: ?, temp time: ?..?, readrows: ?..?, rows: ?..?, topnsort: true, gather: mergeable list)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       MERGELIST (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (index: dba.tbl_a.idx_cola_colb_colc), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
@@ -316,7 +317,8 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    ORDERBY (time: ?, topnsort: true)
+         (parallel workers: ?, temp time: ?..?, readrows: ?..?, rows: ?..?, topnsort: true, gather: mergeable list)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       MERGELIST (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (index: dba.tbl_a.idx_cola_colb_colc), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
@@ -379,7 +381,8 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    ORDERBY (time: ?, topnsort: true)
+         (parallel workers: ?, temp time: ?..?, readrows: ?..?, rows: ?..?, topnsort: true, gather: mergeable list)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       HASHJOIN (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         BUILD (time: ?, fetch: ?, ioread: ?, rows: ?, method: memory)
         PROBE (time: ?, fetch: ?, ioread: ?, readrows: ?, readkeys: ?, rows: ?)
@@ -443,7 +446,8 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    ORDERBY (time: ?, topnsort: true)
+         (parallel workers: ?, temp time: ?..?, readrows: ?..?, rows: ?..?, topnsort: true, gather: mergeable list)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       HASHJOIN (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         BUILD (time: ?, fetch: ?, ioread: ?, rows: ?, method: memory)
         PROBE (time: ?, fetch: ?, ioread: ?, readrows: ?, readkeys: ?, rows: ?)
@@ -636,8 +640,8 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-             (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
-        ORDERBY (time: ?, topnsort: true)
+             (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, topnsort: true, gather: mergeable list)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
 Query plan:


### PR DESCRIPTION
to refer : http://jira.cubrid.org/browse/CBRD-26848

- Enable topn_sort optimization for parallel scan
  -> ORDER BY col LIMIT N 형태 질의에 적용되는 topn_sort 최적화 (binary heap 으로 상위 N tuple 만 유지) 가 parallel scan 경로에서도 동작하도록 확장합니다. 기존에는 px_scan 의 runtime 게이트가 xasl->topn_items 가 set 된 질의에서 MERGEABLE_LIST flag 를 해제하여 row-by-row 모드만 가능하게 했습니다.

수정 내역
- join_orderby_skip.answer_cci
AS-IS : ORDERBY (time: ?, topnsort: true)
TO-BE : (parallel workers: ?, temp time: ?..?, readrows: ?..?, rows: ?..?, topnsort: true, gather: mergeable list)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)

- hash_agg_query_profile.answer_cci
AS-IS : "gather": "row by row"           
TO-BE : "gather": "mergeable list",

AS-IS : "topnsort": true
TO-BE : "topnsort": true
          "sort": true,
         "page": ?,
         "ioread": ?

참조 : https://github.com/CUBRID/cubrid-testcases/pull/2826