### PR TITLE
[CBRD-26955] updated one TC and 2 answers

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_04_with_parameters/answers/01_01_04-04_error_sys_refcursor_param_type.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_04_with_parameters/answers/01_01_04-04_error_sys_refcursor_param_type.answer
@@ -1,10 +1,7 @@
 ===================================================
-Error:-494
-Semantic: before ' ) as
-begin
-null;
-end; '
-dba.sys_refcursor is not defined. create or replace procedure [dba.t](a  [dba.sys_refcursor]) ...
+Error:-493
+Syntax: invalid create procedure
+  CREATE [OR REPLACE] PROCEDURE identifier '(' {sp_param_list} ')' {IS|AS} {[LANGUAGE PLCSQL|LANGUAGE JAVA]} {procedure_source|procedure_spec} 
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_02_create_function/_11_common/answers/01_02_11-10_error_sys_refcursor_return_type.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_02_create_function/_11_common/answers/01_02_11-10_error_sys_refcursor_return_type.answer
@@ -1,18 +1,16 @@
 ===================================================
-Error:-494
-Semantic: before '  as
-begin
-return null;
-end; '
-dba.sys_refcursor is not defined. create or replace function [dba.t](i  integer) return [dba.s...
+0
 
 ===================================================
 count(*)    
-0     
+1     
 
 
 ===================================================
 count(*)    
-0     
+1     
 
+
+===================================================
+0
 

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_02_create_function/_11_common/cases/01_02_11-10_error_sys_refcursor_return_type.sql
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_02_create_function/_11_common/cases/01_02_11-10_error_sys_refcursor_return_type.sql
@@ -10,5 +10,6 @@ end;
 select count(*) from db_stored_procedure where sp_name = 't';
 select count(*) from db_stored_procedure_args where sp_name = 't';
 
+drop function t;
 
 --+ server-message off


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26955

SYS_REFCURSOR 가 stored function 의 리턴 타입으로 허용됨으로 인해 TC 한 건과 답지 두 건 변경이 필요합니다. 
기술지원팀의 요청에 따라 11.4에 먼저 적용하였고, develop 에는 이후 port 할 예정입니다. 

- 01_01_04-04_error_sys_refcursor_param_type.answer: 
  - SYS_REFCURSOR 가 키워드로 추가됨에 따라 에러 메시지가 변경되었습니다. 
  - 인자 타입에는 SYS_REFCURSOR를 허용하지 않기에 여전히 에러입니다. 
- 01_02_11-10_error_sys_refcursor_return_type.sql/answer: 
  - SYS_REFCURSOR 가 리턴타입으로 추가됨에 따라 에러 아닌 유효한 stored function 이 되었습니다. 
  - 에러가 나지 않게 되었기에 drop function 문을 TC 끝에 추가하였습니다. 