### PR TITLE
[CBRD-26457] Revised incorrectly added backport

### DIFF
--- a/sql/_13_issues/_26_1h/answers/cbrd_26457.answer_cci
+++ b/sql/_13_issues/_26_1h/answers/cbrd_26457.answer_cci
@@ -144,8 +144,8 @@ id    date_sub_result    subdate_result    results_equal
 Case 3.7: Type Casting - Boundary Values     
 
 ===================================================
-near_zero    very_large    negative_fraction    
-2020-01-01     2047-05-19     2019-12-31     
+near_zero    very_large    
+2020-01-01     2047-05-19     
 
 ===================================================
     


### PR DESCRIPTION
refer to: http://jira.cubrid.org/browse/CBRD-26457

이 PR(https://github.com/CUBRID/cubrid-testcases/pull/2866) 에서 cci 11.5 답지를 그대로 가져와서 11.4에 반영하였는데, 11.4 이하 https://github.com/CUBRID/cubrid-testcases/blob/develop/sql/_13_issues/_26_1h/cases/cbrd_26457.sql 파일에서는, 11.5와 달리 Case 3.7의 SELECT 구문에 ' adddate(date'2020-01-01', INTERVAL -0.5 DAY) as negative_fraction;' 부분이 생략되어 있습니다 (11.5 에서 해결된 별도의 이슈가 11.4 이하에서는 해결이 안된 점을 고려해서 의도적으로 제외되었음).
 
Greptile 리뷰도 같은 부분을 위 PR에서 지적을 하였는데, 반영이 되지않고 머지가 되어, 현재 11.4에서 fail하고 있습니다. 이를 수정하는 PR입니다.