### PR TITLE
[CBRD-26345] Add a test case - Implement memoize

### DIFF
--- a/sql/_36_guava/cbrd_26345/answers/cbrd_26345.answer
+++ b/sql/_36_guava/cbrd_26345/answers/cbrd_26345.answer
@@ -21,6 +21,10 @@ memoize enabled (memoize_memory_limit=64M)
 ===================================================
 0
 ===================================================
+    
+uniq_int (INT, NDV=100000, unique) - expect: no memoize     
+
+===================================================
 count(*)    
 10     
 
@@ -39,6 +43,10 @@ Trace Statistics:
     SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
+
+===================================================
+    
+low_ndv_int (INT, NDV=10) - expect: memoize enabled     
 
 ===================================================
 count(*)    
@@ -62,6 +70,10 @@ Trace Statistics:
      
 
 ===================================================
+    
+mid_ndv_int (INT, NDV=100) - expect: memoize enabled     
+
+===================================================
 count(*)    
 10000     
 
@@ -81,6 +93,10 @@ Trace Statistics:
       SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       MEMOIZE (time: ?, hit: ?, miss: ?, size: ?KB, enabled: true)
      
+
+===================================================
+    
+mid_ndv_varchar (VARCHAR, NDV=1000) - expect: memoize enabled     
 
 ===================================================
 count(*)    
@@ -104,6 +120,10 @@ Trace Statistics:
      
 
 ===================================================
+    
+high_ndv_numeric (NUMERIC, NDV=10000) - expect: no memoize     
+
+===================================================
 count(*)    
 100     
 
@@ -122,6 +142,10 @@ Trace Statistics:
     SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
+
+===================================================
+    
+uniq_varchar (VARCHAR, NDV=100000, unique) - expect: no memoize     
 
 ===================================================
 count(*)    
@@ -144,6 +168,10 @@ Trace Statistics:
      
 
 ===================================================
+    
+half_ndv_varchar (VARCHAR, NDV=49999) - expect: no memoize     
+
+===================================================
 count(*)    
 22     
 
@@ -162,6 +190,10 @@ Trace Statistics:
     SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
+
+===================================================
+    
+third_ndv_varchar (VARCHAR, NDV=33333) - expect: no memoize     
 
 ===================================================
 count(*)    
@@ -190,6 +222,10 @@ memoize disabled (memoize_memory_limit=0)
 ===================================================
 0
 ===================================================
+    
+uniq_int (INT, NDV=100000, unique) - expect: no memoize (disabled)     
+
+===================================================
 count(*)    
 10     
 
@@ -208,6 +244,10 @@ Trace Statistics:
     SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
+
+===================================================
+    
+low_ndv_int (INT, NDV=10) - expect: no memoize (disabled)     
 
 ===================================================
 count(*)    
@@ -230,6 +270,10 @@ Trace Statistics:
      
 
 ===================================================
+    
+mid_ndv_int (INT, NDV=100) - expect: no memoize (disabled)     
+
+===================================================
 count(*)    
 10000     
 
@@ -248,6 +292,10 @@ Trace Statistics:
     SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
+
+===================================================
+    
+mid_ndv_varchar (VARCHAR, NDV=1000) - expect: no memoize (disabled)     
 
 ===================================================
 count(*)    
@@ -270,6 +318,10 @@ Trace Statistics:
      
 
 ===================================================
+    
+high_ndv_numeric (NUMERIC, NDV=10000) - expect: no memoize (disabled)     
+
+===================================================
 count(*)    
 100     
 
@@ -288,6 +340,10 @@ Trace Statistics:
     SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
+
+===================================================
+    
+uniq_varchar (VARCHAR, NDV=100000, unique) - expect: no memoize (disabled)     
 
 ===================================================
 count(*)    
@@ -310,6 +366,10 @@ Trace Statistics:
      
 
 ===================================================
+    
+half_ndv_varchar (VARCHAR, NDV=49999) - expect: no memoize (disabled)     
+
+===================================================
 count(*)    
 22     
 
@@ -328,6 +388,10 @@ Trace Statistics:
     SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
+
+===================================================
+    
+third_ndv_varchar (VARCHAR, NDV=33333) - expect: no memoize (disabled)     
 
 ===================================================
 count(*)    

--- a/sql/_36_guava/cbrd_26345/answers/cbrd_26345.answer
+++ b/sql/_36_guava/cbrd_26345/answers/cbrd_26345.answer
@@ -1,0 +1,359 @@
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+100000
+===================================================
+0
+===================================================
+10
+===================================================
+0
+===================================================
+    
+memoize enabled (memoize_memory_limit=64M)     
+
+===================================================
+0
+===================================================
+0
+===================================================
+count(*)    
+10     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.m?)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?=[dba.m?].col?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+90000     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.m?)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?=[dba.m?].col?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      MEMOIZE (time: ?, hit: ?, miss: ?, size: ?KB, enabled: true)
+     
+
+===================================================
+count(*)    
+10000     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.m?)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?=[dba.m?].col?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      MEMOIZE (time: ?, hit: ?, miss: ?, size: ?KB, enabled: true)
+     
+
+===================================================
+count(*)    
+1000     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.m?)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?= cast([dba.m?].col? as double)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      MEMOIZE (time: ?, hit: ?, miss: ?, size: ?KB, enabled: true)
+     
+
+===================================================
+count(*)    
+100     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.m?)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?=[dba.m?].col?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+10     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.m?)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?= cast([dba.m?].col? as double)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+22     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.m?)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?= cast([dba.m?].col? as double)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+31     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.m?)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?= cast([dba.m?].col? as double)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+memoize disabled (memoize_memory_limit=0)     
+
+===================================================
+0
+===================================================
+count(*)    
+10     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.m?)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?=[dba.m?].col?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+90000     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.m?)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?=[dba.m?].col?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+10000     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.m?)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?=[dba.m?].col?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+1000     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.m?)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?= cast([dba.m?].col? as double)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+100     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.m?)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?=[dba.m?].col?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+10     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.m?)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?= cast([dba.m?].col? as double)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+22     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.m?)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?= cast([dba.m?].col? as double)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+31     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.m?)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?= cast([dba.m?].col? as double)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0

--- a/sql/_36_guava/cbrd_26345/answers/cbrd_26345.answer
+++ b/sql/_36_guava/cbrd_26345/answers/cbrd_26345.answer
@@ -169,7 +169,7 @@ Trace Statistics:
 
 ===================================================
     
-half_ndv_varchar (VARCHAR, NDV=49999) - expect: no memoize     
+half_ndv_varchar (VARCHAR, NDV=49999) - expect: no memoize (NDV exceeds the 1000-probe free-iteration limit; the 0.50001 duplicate ratio is irrelevant to the current runtime check)     
 
 ===================================================
 count(*)    
@@ -193,7 +193,7 @@ Trace Statistics:
 
 ===================================================
     
-third_ndv_varchar (VARCHAR, NDV=33333) - expect: no memoize     
+third_ndv_varchar (VARCHAR, NDV=33333) - expect: no memoize (NDV exceeds the 1000-probe free-iteration limit; the 0.667 duplicate ratio is irrelevant to the current runtime check)     
 
 ===================================================
 count(*)    
@@ -430,6 +430,8 @@ Trace Statistics:
 ===================================================
 0
 ===================================================
+0
+===================================================
 100
 ===================================================
 0
@@ -448,12 +450,18 @@ Trace Statistics:
 ===================================================
 0
 ===================================================
+14
+===================================================
+0
+===================================================
+0
+===================================================
 0
 ===================================================
 0
 ===================================================
     
-3-way join -> runtime memoize activation on both joins     
+3-way join - expect: memoize enabled on both joins     
 
 ===================================================
 count(*)    
@@ -482,7 +490,7 @@ Trace Statistics:
 
 ===================================================
     
-view-to-table join -> runtime memoize activation (view exposes no NDV stats)     
+view-to-table join (view exposes no NDV stats) - expect: memoize enabled     
 
 ===================================================
 count(*)    
@@ -508,7 +516,7 @@ Trace Statistics:
 
 ===================================================
     
-constraint#4: cartesian product (no join condition) - expect: no memoize     
+cartesian product (no join condition) - expect: no memoize     
 
 ===================================================
 count(*)    
@@ -532,7 +540,7 @@ Trace Statistics:
 
 ===================================================
     
-constraint#2: TARGET_SET-derived TABLE() inner - expect: no memoize     
+TARGET_SET-derived TABLE() inner - expect: no memoize     
 
 ===================================================
 count(*)    
@@ -556,7 +564,7 @@ Trace Statistics:
 
 ===================================================
     
-constraint#3: SET column real projection - expect: no memoize     
+SET column real projection - expect: no memoize     
 
 ===================================================
 low_ndv_int    s    
@@ -584,7 +592,7 @@ Trace Statistics:
 
 ===================================================
     
-constraint#3: MULTISET column real projection - expect: no memoize     
+MULTISET column real projection - expect: no memoize     
 
 ===================================================
 low_ndv_int    ms    
@@ -612,7 +620,7 @@ Trace Statistics:
 
 ===================================================
     
-constraint#3: SEQUENCE column real projection - expect: no memoize     
+SEQUENCE column real projection - expect: no memoize     
 
 ===================================================
 low_ndv_int    sq    
@@ -640,7 +648,7 @@ Trace Statistics:
 
 ===================================================
     
-memoize with index scan on inner table     
+memoize with index scan on inner table - expect: memoize enabled     
 
 ===================================================
 0
@@ -666,6 +674,74 @@ Trace Statistics:
       SCAN (index: dba.inner_tbl.idx_inner_tbl_key), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true, count_only: true)
       MEMOIZE (time: ?, hit: ?, miss: ?, size: ?KB, enabled: true)
      
+
+===================================================
+0
+===================================================
+    
+multi-row-per-key cache path: row-level output, memoize enabled (memoize_memory_limit=64M)     
+
+===================================================
+low_ndv_int    payload    count(*)    
+1     a     10000     
+2     a     10000     
+3     a     10000     
+3     b     10000     
+3     c     10000     
+4     a     10000     
+5     a     10000     
+6     a     10000     
+7     a     10000     
+7     b     10000     
+8     a     10000     
+9     a     10000     
+
+===================================================
+low_ndv_int    count(inner_dup.payload)    
+0     0     
+1     10000     
+2     10000     
+3     20000     
+4     10000     
+5     10000     
+6     10000     
+7     10000     
+8     10000     
+9     10000     
+
+===================================================
+0
+===================================================
+    
+multi-row-per-key cache path: same queries, memoize disabled (memoize_memory_limit=0) - row-level output must match the enabled run above exactly     
+
+===================================================
+low_ndv_int    payload    count(*)    
+1     a     10000     
+2     a     10000     
+3     a     10000     
+3     b     10000     
+3     c     10000     
+4     a     10000     
+5     a     10000     
+6     a     10000     
+7     a     10000     
+7     b     10000     
+8     a     10000     
+9     a     10000     
+
+===================================================
+low_ndv_int    count(inner_dup.payload)    
+0     0     
+1     10000     
+2     10000     
+3     20000     
+4     10000     
+5     10000     
+6     10000     
+7     10000     
+8     10000     
+9     10000     
 
 ===================================================
 0

--- a/sql/_36_guava/cbrd_26345/answers/cbrd_26345.answer
+++ b/sql/_36_guava/cbrd_26345/answers/cbrd_26345.answer
@@ -29,15 +29,15 @@ trace
 
 Query Plan:
   NESTED LOOPS (inner join)
-    TABLE SCAN (dba.m?)
-    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?=[dba.m?].col?
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.outer_tbl].uniq_int=[dba.inner_tbl].join_key
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -49,15 +49,15 @@ trace
 
 Query Plan:
   NESTED LOOPS (inner join)
-    TABLE SCAN (dba.m?)
-    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?=[dba.m?].col?
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.outer_tbl].low_ndv_int=[dba.inner_tbl].join_key
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       MEMOIZE (time: ?, hit: ?, miss: ?, size: ?KB, enabled: true)
      
 
@@ -70,15 +70,15 @@ trace
 
 Query Plan:
   NESTED LOOPS (inner join)
-    TABLE SCAN (dba.m?)
-    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?=[dba.m?].col?
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.outer_tbl].mid_ndv_int=[dba.inner_tbl].join_key
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       MEMOIZE (time: ?, hit: ?, miss: ?, size: ?KB, enabled: true)
      
 
@@ -91,15 +91,15 @@ trace
 
 Query Plan:
   NESTED LOOPS (inner join)
-    TABLE SCAN (dba.m?)
-    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?= cast([dba.m?].col? as double)
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.inner_tbl].join_key= cast([dba.outer_tbl].mid_ndv_varchar as double)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       MEMOIZE (time: ?, hit: ?, miss: ?, size: ?KB, enabled: true)
      
 
@@ -112,15 +112,15 @@ trace
 
 Query Plan:
   NESTED LOOPS (inner join)
-    TABLE SCAN (dba.m?)
-    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?=[dba.m?].col?
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.outer_tbl].high_ndv_numeric=[dba.inner_tbl].join_key
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -132,15 +132,15 @@ trace
 
 Query Plan:
   NESTED LOOPS (inner join)
-    TABLE SCAN (dba.m?)
-    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?= cast([dba.m?].col? as double)
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.inner_tbl].join_key= cast([dba.outer_tbl].uniq_varchar as double)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -152,15 +152,15 @@ trace
 
 Query Plan:
   NESTED LOOPS (inner join)
-    TABLE SCAN (dba.m?)
-    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?= cast([dba.m?].col? as double)
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.inner_tbl].join_key= cast([dba.outer_tbl].half_ndv_varchar as double)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -172,15 +172,15 @@ trace
 
 Query Plan:
   NESTED LOOPS (inner join)
-    TABLE SCAN (dba.m?)
-    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?= cast([dba.m?].col? as double)
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.inner_tbl].join_key= cast([dba.outer_tbl].third_ndv_varchar as double)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -198,15 +198,15 @@ trace
 
 Query Plan:
   NESTED LOOPS (inner join)
-    TABLE SCAN (dba.m?)
-    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?=[dba.m?].col?
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.outer_tbl].uniq_int=[dba.inner_tbl].join_key
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -218,15 +218,15 @@ trace
 
 Query Plan:
   NESTED LOOPS (inner join)
-    TABLE SCAN (dba.m?)
-    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?=[dba.m?].col?
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.outer_tbl].low_ndv_int=[dba.inner_tbl].join_key
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -238,15 +238,15 @@ trace
 
 Query Plan:
   NESTED LOOPS (inner join)
-    TABLE SCAN (dba.m?)
-    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?=[dba.m?].col?
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.outer_tbl].mid_ndv_int=[dba.inner_tbl].join_key
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -258,15 +258,15 @@ trace
 
 Query Plan:
   NESTED LOOPS (inner join)
-    TABLE SCAN (dba.m?)
-    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?= cast([dba.m?].col? as double)
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.inner_tbl].join_key= cast([dba.outer_tbl].mid_ndv_varchar as double)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -278,15 +278,15 @@ trace
 
 Query Plan:
   NESTED LOOPS (inner join)
-    TABLE SCAN (dba.m?)
-    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?=[dba.m?].col?
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.outer_tbl].high_ndv_numeric=[dba.inner_tbl].join_key
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -298,15 +298,15 @@ trace
 
 Query Plan:
   NESTED LOOPS (inner join)
-    TABLE SCAN (dba.m?)
-    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?= cast([dba.m?].col? as double)
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.inner_tbl].join_key= cast([dba.outer_tbl].uniq_varchar as double)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -318,15 +318,15 @@ trace
 
 Query Plan:
   NESTED LOOPS (inner join)
-    TABLE SCAN (dba.m?)
-    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?= cast([dba.m?].col? as double)
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.inner_tbl].join_key= cast([dba.outer_tbl].half_ndv_varchar as double)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -338,15 +338,15 @@ trace
 
 Query Plan:
   NESTED LOOPS (inner join)
-    TABLE SCAN (dba.m?)
-    TABLE SCAN (dba.m?)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.m?] [dba.m?], [dba.m?] [dba.m?] where [dba.m?].col?= cast([dba.m?].col? as double)
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.inner_tbl].join_key= cast([dba.outer_tbl].third_ndv_varchar as double)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (table: dba.m?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================

--- a/sql/_36_guava/cbrd_26345/answers/cbrd_26345.answer
+++ b/sql/_36_guava/cbrd_26345/answers/cbrd_26345.answer
@@ -36,7 +36,7 @@ Query Plan:
     TABLE SCAN (dba.outer_tbl)
     TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.outer_tbl].uniq_int=[dba.inner_tbl].join_key
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.outer_tbl].uniq_int=[dba.inner_tbl].join_key
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -60,7 +60,7 @@ Query Plan:
     TABLE SCAN (dba.outer_tbl)
     TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.outer_tbl].low_ndv_int=[dba.inner_tbl].join_key
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.outer_tbl].low_ndv_int=[dba.inner_tbl].join_key
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -85,7 +85,7 @@ Query Plan:
     TABLE SCAN (dba.outer_tbl)
     TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.outer_tbl].mid_ndv_int=[dba.inner_tbl].join_key
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.outer_tbl].mid_ndv_int=[dba.inner_tbl].join_key
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -96,11 +96,11 @@ Trace Statistics:
 
 ===================================================
     
-mid_ndv_varchar (VARCHAR, NDV=1000) - expect: memoize enabled     
+mid_ndv_varchar (VARCHAR, NDV=300) - expect: memoize enabled     
 
 ===================================================
 count(*)    
-1000     
+3340     
 
 ===================================================
 trace    
@@ -110,7 +110,7 @@ Query Plan:
     TABLE SCAN (dba.outer_tbl)
     TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.inner_tbl].join_key= cast([dba.outer_tbl].mid_ndv_varchar as double)
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.inner_tbl].join_key= cast([dba.outer_tbl].mid_ndv_varchar as double)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -135,7 +135,7 @@ Query Plan:
     TABLE SCAN (dba.outer_tbl)
     TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.outer_tbl].high_ndv_numeric=[dba.inner_tbl].join_key
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.outer_tbl].high_ndv_numeric=[dba.inner_tbl].join_key
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -159,7 +159,7 @@ Query Plan:
     TABLE SCAN (dba.outer_tbl)
     TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.inner_tbl].join_key= cast([dba.outer_tbl].uniq_varchar as double)
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.inner_tbl].join_key= cast([dba.outer_tbl].uniq_varchar as double)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -183,7 +183,7 @@ Query Plan:
     TABLE SCAN (dba.outer_tbl)
     TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.inner_tbl].join_key= cast([dba.outer_tbl].half_ndv_varchar as double)
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.inner_tbl].join_key= cast([dba.outer_tbl].half_ndv_varchar as double)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -207,7 +207,7 @@ Query Plan:
     TABLE SCAN (dba.outer_tbl)
     TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.inner_tbl].join_key= cast([dba.outer_tbl].third_ndv_varchar as double)
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.inner_tbl].join_key= cast([dba.outer_tbl].third_ndv_varchar as double)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -237,7 +237,7 @@ Query Plan:
     TABLE SCAN (dba.outer_tbl)
     TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.outer_tbl].uniq_int=[dba.inner_tbl].join_key
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.outer_tbl].uniq_int=[dba.inner_tbl].join_key
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -261,7 +261,7 @@ Query Plan:
     TABLE SCAN (dba.outer_tbl)
     TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.outer_tbl].low_ndv_int=[dba.inner_tbl].join_key
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.outer_tbl].low_ndv_int=[dba.inner_tbl].join_key
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -285,7 +285,7 @@ Query Plan:
     TABLE SCAN (dba.outer_tbl)
     TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.outer_tbl].mid_ndv_int=[dba.inner_tbl].join_key
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.outer_tbl].mid_ndv_int=[dba.inner_tbl].join_key
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -295,11 +295,11 @@ Trace Statistics:
 
 ===================================================
     
-mid_ndv_varchar (VARCHAR, NDV=1000) - expect: no memoize (disabled)     
+mid_ndv_varchar (VARCHAR, NDV=300) - expect: no memoize (disabled)     
 
 ===================================================
 count(*)    
-1000     
+3340     
 
 ===================================================
 trace    
@@ -309,7 +309,7 @@ Query Plan:
     TABLE SCAN (dba.outer_tbl)
     TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.inner_tbl].join_key= cast([dba.outer_tbl].mid_ndv_varchar as double)
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.inner_tbl].join_key= cast([dba.outer_tbl].mid_ndv_varchar as double)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -333,7 +333,7 @@ Query Plan:
     TABLE SCAN (dba.outer_tbl)
     TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.outer_tbl].high_ndv_numeric=[dba.inner_tbl].join_key
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.outer_tbl].high_ndv_numeric=[dba.inner_tbl].join_key
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -357,7 +357,7 @@ Query Plan:
     TABLE SCAN (dba.outer_tbl)
     TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.inner_tbl].join_key= cast([dba.outer_tbl].uniq_varchar as double)
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.inner_tbl].join_key= cast([dba.outer_tbl].uniq_varchar as double)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -381,7 +381,7 @@ Query Plan:
     TABLE SCAN (dba.outer_tbl)
     TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.inner_tbl].join_key= cast([dba.outer_tbl].half_ndv_varchar as double)
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.inner_tbl].join_key= cast([dba.outer_tbl].half_ndv_varchar as double)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -405,7 +405,7 @@ Query Plan:
     TABLE SCAN (dba.outer_tbl)
     TABLE SCAN (dba.inner_tbl)
 
-  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl] where [dba.inner_tbl].join_key= cast([dba.outer_tbl].third_ndv_varchar as double)
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.inner_tbl].join_key= cast([dba.outer_tbl].third_ndv_varchar as double)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -413,6 +413,272 @@ Trace Statistics:
       SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
 
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+100
+===================================================
+0
+===================================================
+0
+===================================================
+5
+===================================================
+0
+===================================================
+5
+===================================================
+0
+===================================================
+5
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+    
+3-way join -> runtime memoize activation on both joins     
+
+===================================================
+count(*)    
+90000     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (dba.outer_tbl)
+      TABLE SCAN (dba.inner_tbl)
+    TABLE SCAN (dba.extra_join_tbl)
+
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl, extra_join_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.outer_tbl].low_ndv_int=[dba.inner_tbl].join_key inner join [dba.extra_join_tbl] [dba.extra_join_tbl] on [dba.outer_tbl].mid_ndv_int=[dba.extra_join_tbl].dup_key
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      MEMOIZE (time: ?, hit: ?, miss: ?, size: ?KB, enabled: true)
+        SCAN (table: dba.extra_join_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        MEMOIZE (time: ?, hit: ?, miss: ?, size: ?KB, enabled: true)
+     
+
+===================================================
+    
+view-to-table join -> runtime memoize activation (view exposes no NDV stats)     
+
+===================================================
+count(*)    
+90000     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.low_ndv_view)
+    TABLE SCAN (dba.inner_tbl)
+
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.low_ndv_view] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.low_ndv_view].low_ndv_int=[dba.inner_tbl].join_key
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      MEMOIZE (time: ?, hit: ?, miss: ?, size: ?KB, enabled: true)
+     
+
+===================================================
+    
+constraint#4: cartesian product (no join condition) - expect: no memoize     
+
+===================================================
+count(*)    
+1000000     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (cross join)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.inner_tbl)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl], [dba.inner_tbl] [dba.inner_tbl]
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.inner_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+constraint#2: TARGET_SET-derived TABLE() inner - expect: no memoize     
+
+===================================================
+count(*)    
+90000     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (t)
+
+  rewritten query: select /*+ ORDERED USE_NL(t) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join table({?, ?, ?, ?, ?, ?, ?, ?, ?, ?}) t (x) on [dba.outer_tbl].low_ndv_int=t.x
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (set time: ?, fetch: ?, ioread: ?)
+     
+
+===================================================
+    
+constraint#3: SET column real projection - expect: no memoize     
+
+===================================================
+low_ndv_int    s    
+1     1,2,     
+2     3,4,     
+3     5,6,     
+4     7,8,     
+5     9,10,     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.set_col_tbl)
+
+  rewritten query: select /*+ ORDERED USE_NL(set_col_tbl) PARALLEL(?) */ [dba.outer_tbl].low_ndv_int, [dba.set_col_tbl].s from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.set_col_tbl] [dba.set_col_tbl] on [dba.outer_tbl].low_ndv_int=[dba.set_col_tbl].id where (inst_num()<= ?:? )
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.set_col_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+constraint#3: MULTISET column real projection - expect: no memoize     
+
+===================================================
+low_ndv_int    ms    
+1     1,1,2,     
+2     3,3,4,     
+3     5,5,6,     
+4     7,7,8,     
+5     9,9,10,     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.multiset_col_tbl)
+
+  rewritten query: select /*+ ORDERED USE_NL(multiset_col_tbl) PARALLEL(?) */ [dba.outer_tbl].low_ndv_int, [dba.multiset_col_tbl].ms from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.multiset_col_tbl] [dba.multiset_col_tbl] on [dba.outer_tbl].low_ndv_int=[dba.multiset_col_tbl].id where (inst_num()<= ?:? )
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.multiset_col_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+constraint#3: SEQUENCE column real projection - expect: no memoize     
+
+===================================================
+low_ndv_int    sq    
+1     1,2,     
+2     3,4,     
+3     5,6,     
+4     7,8,     
+5     9,10,     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.outer_tbl)
+    TABLE SCAN (dba.sequence_col_tbl)
+
+  rewritten query: select /*+ ORDERED USE_NL(sequence_col_tbl) PARALLEL(?) */ [dba.outer_tbl].low_ndv_int, [dba.sequence_col_tbl].sq from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.sequence_col_tbl] [dba.sequence_col_tbl] on [dba.outer_tbl].low_ndv_int=[dba.sequence_col_tbl].id where (inst_num()<= ?:? )
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.sequence_col_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+memoize with index scan on inner table     
+
+===================================================
+0
+===================================================
+0
+===================================================
+count(*)    
+90000     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (inner join)
+    TABLE SCAN (dba.outer_tbl)
+    INDEX SCAN (dba.inner_tbl.idx_inner_tbl_key) (key range: [dba.outer_tbl].low_ndv_int=[dba.inner_tbl].join_key, covered: true)
+
+  rewritten query: select /*+ ORDERED USE_NL(inner_tbl) PARALLEL(?) */ count(*) from [dba.outer_tbl] [dba.outer_tbl] inner join [dba.inner_tbl] [dba.inner_tbl] on [dba.outer_tbl].low_ndv_int=[dba.inner_tbl].join_key
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.outer_tbl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.inner_tbl.idx_inner_tbl_key), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true, count_only: true)
+      MEMOIZE (time: ?, hit: ?, miss: ?, size: ?KB, enabled: true)
+     
+
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
 ===================================================
 0
 ===================================================

--- a/sql/_36_guava/cbrd_26345/cases/cbrd_26345.sql
+++ b/sql/_36_guava/cbrd_26345/cases/cbrd_26345.sql
@@ -1,0 +1,77 @@
+-- CBRD-26345: Implement memoize
+--
+-- For NLJ with repeated join keys on the inner table,
+-- caches inner scan results keyed by join column value.
+-- Verify memoize activation behavior with various column types
+-- (different NDV ratios) under enabled/disabled memory limit settings.
+
+-- cleanup
+drop table if exists m1;
+drop table if exists m2;
+
+create table m1 (col1 int, col2 int, col3 int, col4 varchar(20), col5 numeric(20,10), col6 varchar(20), col7 varchar(20), col8 varchar(20));
+insert into m1 select
+  rownum,
+  rownum % 10,
+  rownum % 100,
+  lpad(to_char(rownum % 1000), 20, '0'),
+  rownum % 10000,
+  lpad(to_char(rownum), 20, '0'),
+  lpad(to_char(rownum % 49999), 20, '0'),
+  lpad(to_char(rownum % 33333), 20, '0')
+from db_class a, db_class b, db_class c, db_class d, db_class e, db_class f, db_class g
+limit 100000;
+
+create table m2 (col1 int);
+insert into m2 select rownum from db_class a, db_class b, db_class c, db_class d, db_class e, db_class f, db_class g limit 10;
+update statistics on m1, m2 with fullscan;
+
+evaluate 'memoize enabled (memoize_memory_limit=64M)';
+
+set trace on;
+set system parameters 'memoize_memory_limit=64M';
+
+select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col1 = m2.col1;
+show trace;
+select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col2 = m2.col1;
+show trace;
+select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col3 = m2.col1;
+show trace;
+select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col4 = m2.col1;
+show trace;
+select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col5 = m2.col1;
+show trace;
+select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col6 = m2.col1;
+show trace;
+select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col7 = m2.col1;
+show trace;
+select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col8 = m2.col1;
+show trace;
+
+evaluate 'memoize disabled (memoize_memory_limit=0)';
+
+set system parameters 'memoize_memory_limit=0';
+
+select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col1 = m2.col1;
+show trace;
+select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col2 = m2.col1;
+show trace;
+select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col3 = m2.col1;
+show trace;
+select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col4 = m2.col1;
+show trace;
+select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col5 = m2.col1;
+show trace;
+select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col6 = m2.col1;
+show trace;
+select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col7 = m2.col1;
+show trace;
+select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col8 = m2.col1;
+show trace;
+
+set trace off;
+set system parameters 'memoize_memory_limit=default';
+
+-- cleanup
+drop table if exists m1;
+drop table if exists m2;

--- a/sql/_36_guava/cbrd_26345/cases/cbrd_26345.sql
+++ b/sql/_36_guava/cbrd_26345/cases/cbrd_26345.sql
@@ -31,20 +31,28 @@ evaluate 'memoize enabled (memoize_memory_limit=64M)';
 set trace on;
 set system parameters 'memoize_memory_limit=64M';
 
+evaluate 'uniq_int (INT, NDV=100000, unique) - expect: no memoize';
 select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.uniq_int = inner_tbl.join_key;
 show trace;
+evaluate 'low_ndv_int (INT, NDV=10) - expect: memoize enabled';
 select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.low_ndv_int = inner_tbl.join_key;
 show trace;
+evaluate 'mid_ndv_int (INT, NDV=100) - expect: memoize enabled';
 select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.mid_ndv_int = inner_tbl.join_key;
 show trace;
+evaluate 'mid_ndv_varchar (VARCHAR, NDV=1000) - expect: memoize enabled';
 select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.mid_ndv_varchar = inner_tbl.join_key;
 show trace;
+evaluate 'high_ndv_numeric (NUMERIC, NDV=10000) - expect: no memoize';
 select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.high_ndv_numeric = inner_tbl.join_key;
 show trace;
+evaluate 'uniq_varchar (VARCHAR, NDV=100000, unique) - expect: no memoize';
 select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.uniq_varchar = inner_tbl.join_key;
 show trace;
+evaluate 'half_ndv_varchar (VARCHAR, NDV=49999) - expect: no memoize';
 select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.half_ndv_varchar = inner_tbl.join_key;
 show trace;
+evaluate 'third_ndv_varchar (VARCHAR, NDV=33333) - expect: no memoize';
 select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.third_ndv_varchar = inner_tbl.join_key;
 show trace;
 
@@ -52,20 +60,28 @@ evaluate 'memoize disabled (memoize_memory_limit=0)';
 
 set system parameters 'memoize_memory_limit=0';
 
+evaluate 'uniq_int (INT, NDV=100000, unique) - expect: no memoize (disabled)';
 select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.uniq_int = inner_tbl.join_key;
 show trace;
+evaluate 'low_ndv_int (INT, NDV=10) - expect: no memoize (disabled)';
 select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.low_ndv_int = inner_tbl.join_key;
 show trace;
+evaluate 'mid_ndv_int (INT, NDV=100) - expect: no memoize (disabled)';
 select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.mid_ndv_int = inner_tbl.join_key;
 show trace;
+evaluate 'mid_ndv_varchar (VARCHAR, NDV=1000) - expect: no memoize (disabled)';
 select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.mid_ndv_varchar = inner_tbl.join_key;
 show trace;
+evaluate 'high_ndv_numeric (NUMERIC, NDV=10000) - expect: no memoize (disabled)';
 select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.high_ndv_numeric = inner_tbl.join_key;
 show trace;
+evaluate 'uniq_varchar (VARCHAR, NDV=100000, unique) - expect: no memoize (disabled)';
 select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.uniq_varchar = inner_tbl.join_key;
 show trace;
+evaluate 'half_ndv_varchar (VARCHAR, NDV=49999) - expect: no memoize (disabled)';
 select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.half_ndv_varchar = inner_tbl.join_key;
 show trace;
+evaluate 'third_ndv_varchar (VARCHAR, NDV=33333) - expect: no memoize (disabled)';
 select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.third_ndv_varchar = inner_tbl.join_key;
 show trace;
 

--- a/sql/_36_guava/cbrd_26345/cases/cbrd_26345.sql
+++ b/sql/_36_guava/cbrd_26345/cases/cbrd_26345.sql
@@ -14,7 +14,7 @@ insert into outer_tbl select
   rownum,
   rownum % 10,
   rownum % 100,
-  lpad(to_char(rownum % 1000), 20, '0'),
+  lpad(to_char(rownum % 300), 20, '0'),
   rownum % 10000,
   lpad(to_char(rownum), 20, '0'),
   lpad(to_char(rownum % 49999), 20, '0'),
@@ -32,28 +32,28 @@ set trace on;
 set system parameters 'memoize_memory_limit=64M';
 
 evaluate 'uniq_int (INT, NDV=100000, unique) - expect: no memoize';
-select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.uniq_int = inner_tbl.join_key;
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.uniq_int = inner_tbl.join_key;
 show trace;
 evaluate 'low_ndv_int (INT, NDV=10) - expect: memoize enabled';
-select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.low_ndv_int = inner_tbl.join_key;
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.low_ndv_int = inner_tbl.join_key;
 show trace;
 evaluate 'mid_ndv_int (INT, NDV=100) - expect: memoize enabled';
-select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.mid_ndv_int = inner_tbl.join_key;
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.mid_ndv_int = inner_tbl.join_key;
 show trace;
-evaluate 'mid_ndv_varchar (VARCHAR, NDV=1000) - expect: memoize enabled';
-select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.mid_ndv_varchar = inner_tbl.join_key;
+evaluate 'mid_ndv_varchar (VARCHAR, NDV=300) - expect: memoize enabled';
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.mid_ndv_varchar = inner_tbl.join_key;
 show trace;
 evaluate 'high_ndv_numeric (NUMERIC, NDV=10000) - expect: no memoize';
-select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.high_ndv_numeric = inner_tbl.join_key;
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.high_ndv_numeric = inner_tbl.join_key;
 show trace;
 evaluate 'uniq_varchar (VARCHAR, NDV=100000, unique) - expect: no memoize';
-select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.uniq_varchar = inner_tbl.join_key;
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.uniq_varchar = inner_tbl.join_key;
 show trace;
 evaluate 'half_ndv_varchar (VARCHAR, NDV=49999) - expect: no memoize';
-select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.half_ndv_varchar = inner_tbl.join_key;
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.half_ndv_varchar = inner_tbl.join_key;
 show trace;
 evaluate 'third_ndv_varchar (VARCHAR, NDV=33333) - expect: no memoize';
-select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.third_ndv_varchar = inner_tbl.join_key;
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.third_ndv_varchar = inner_tbl.join_key;
 show trace;
 
 evaluate 'memoize disabled (memoize_memory_limit=0)';
@@ -61,33 +61,107 @@ evaluate 'memoize disabled (memoize_memory_limit=0)';
 set system parameters 'memoize_memory_limit=0';
 
 evaluate 'uniq_int (INT, NDV=100000, unique) - expect: no memoize (disabled)';
-select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.uniq_int = inner_tbl.join_key;
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.uniq_int = inner_tbl.join_key;
 show trace;
 evaluate 'low_ndv_int (INT, NDV=10) - expect: no memoize (disabled)';
-select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.low_ndv_int = inner_tbl.join_key;
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.low_ndv_int = inner_tbl.join_key;
 show trace;
 evaluate 'mid_ndv_int (INT, NDV=100) - expect: no memoize (disabled)';
-select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.mid_ndv_int = inner_tbl.join_key;
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.mid_ndv_int = inner_tbl.join_key;
 show trace;
-evaluate 'mid_ndv_varchar (VARCHAR, NDV=1000) - expect: no memoize (disabled)';
-select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.mid_ndv_varchar = inner_tbl.join_key;
+evaluate 'mid_ndv_varchar (VARCHAR, NDV=300) - expect: no memoize (disabled)';
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.mid_ndv_varchar = inner_tbl.join_key;
 show trace;
 evaluate 'high_ndv_numeric (NUMERIC, NDV=10000) - expect: no memoize (disabled)';
-select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.high_ndv_numeric = inner_tbl.join_key;
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.high_ndv_numeric = inner_tbl.join_key;
 show trace;
 evaluate 'uniq_varchar (VARCHAR, NDV=100000, unique) - expect: no memoize (disabled)';
-select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.uniq_varchar = inner_tbl.join_key;
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.uniq_varchar = inner_tbl.join_key;
 show trace;
 evaluate 'half_ndv_varchar (VARCHAR, NDV=49999) - expect: no memoize (disabled)';
-select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.half_ndv_varchar = inner_tbl.join_key;
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.half_ndv_varchar = inner_tbl.join_key;
 show trace;
 evaluate 'third_ndv_varchar (VARCHAR, NDV=33333) - expect: no memoize (disabled)';
-select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.third_ndv_varchar = inner_tbl.join_key;
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.third_ndv_varchar = inner_tbl.join_key;
 show trace;
 
 set trace off;
 set system parameters 'memoize_memory_limit=default';
 
+-- additional scenarios covering the runtime-activation cases and constraints
+-- listed in the JIRA description.
+-- cache-full -> enabled:false is intentionally excluded: only observable on
+-- CUBRID builds between #6652(2025-12-01) and #6877(2026-03-09); unreproducible
+-- on any current/future build.
+drop table if exists extra_join_tbl;
+drop table if exists set_col_tbl;
+drop table if exists multiset_col_tbl;
+drop table if exists sequence_col_tbl;
+drop view if exists low_ndv_view;
+
+create table extra_join_tbl (dup_key int, seq int);
+insert into extra_join_tbl select rownum % 100, rownum from db_class a, db_class b, db_class c, db_class d, db_class e, db_class f, db_class g limit 100;
+update statistics on extra_join_tbl with fullscan;
+
+create table set_col_tbl (id int, s set(int));
+insert into set_col_tbl values (1, {1,2}), (2, {3,4}), (3, {5,6}), (4, {7,8}), (5, {9,10});
+
+create table multiset_col_tbl (id int, ms multiset(int));
+insert into multiset_col_tbl values (1, multiset{1,1,2}), (2, multiset{3,3,4}), (3, multiset{5,5,6}), (4, multiset{7,7,8}), (5, multiset{9,9,10});
+
+create table sequence_col_tbl (id int, sq sequence(int));
+insert into sequence_col_tbl values (1, sequence{1,2}), (2, sequence{3,4}), (3, sequence{5,6}), (4, sequence{7,8}), (5, sequence{9,10});
+
+create view low_ndv_view as select low_ndv_int, uniq_int from outer_tbl;
+
+set trace on;
+set system parameters 'memoize_memory_limit=64M';
+
+evaluate '3-way join -> runtime memoize activation on both joins';
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl, extra_join_tbl) */ count(*)
+from outer_tbl inner join inner_tbl on outer_tbl.low_ndv_int = inner_tbl.join_key
+              inner join extra_join_tbl on outer_tbl.mid_ndv_int = extra_join_tbl.dup_key;
+show trace;
+
+evaluate 'view-to-table join -> runtime memoize activation (view exposes no NDV stats)';
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from low_ndv_view inner join inner_tbl on low_ndv_view.low_ndv_int = inner_tbl.join_key;
+show trace;
+
+evaluate 'constraint#4: cartesian product (no join condition) - expect: no memoize';
+select /*+ recompile parallel(0) */ count(*) from outer_tbl, inner_tbl;
+show trace;
+
+evaluate 'constraint#2: TARGET_SET-derived TABLE() inner - expect: no memoize';
+select /*+ recompile parallel(0) ordered use_nl(t) */ count(*) from outer_tbl inner join TABLE({1,2,3,4,5,6,7,8,9,10}) t(x) on outer_tbl.low_ndv_int = t.x;
+show trace;
+
+evaluate 'constraint#3: SET column real projection - expect: no memoize';
+select /*+ recompile parallel(0) ordered use_nl(set_col_tbl) */ outer_tbl.low_ndv_int, set_col_tbl.s from outer_tbl inner join set_col_tbl on outer_tbl.low_ndv_int = set_col_tbl.id limit 5;
+show trace;
+
+evaluate 'constraint#3: MULTISET column real projection - expect: no memoize';
+select /*+ recompile parallel(0) ordered use_nl(multiset_col_tbl) */ outer_tbl.low_ndv_int, multiset_col_tbl.ms from outer_tbl inner join multiset_col_tbl on outer_tbl.low_ndv_int = multiset_col_tbl.id limit 5;
+show trace;
+
+evaluate 'constraint#3: SEQUENCE column real projection - expect: no memoize';
+select /*+ recompile parallel(0) ordered use_nl(sequence_col_tbl) */ outer_tbl.low_ndv_int, sequence_col_tbl.sq from outer_tbl inner join sequence_col_tbl on outer_tbl.low_ndv_int = sequence_col_tbl.id limit 5;
+show trace;
+
+evaluate 'memoize with index scan on inner table';
+create index idx_inner_tbl_key on inner_tbl (join_key);
+update statistics on inner_tbl with fullscan;
+select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.low_ndv_int = inner_tbl.join_key;
+show trace;
+drop index idx_inner_tbl_key on inner_tbl;
+
+set trace off;
+set system parameters 'memoize_memory_limit=default';
+
 -- cleanup
+drop view if exists low_ndv_view;
+drop table if exists sequence_col_tbl;
+drop table if exists multiset_col_tbl;
+drop table if exists set_col_tbl;
+drop table if exists extra_join_tbl;
 drop table if exists outer_tbl;
 drop table if exists inner_tbl;

--- a/sql/_36_guava/cbrd_26345/cases/cbrd_26345.sql
+++ b/sql/_36_guava/cbrd_26345/cases/cbrd_26345.sql
@@ -6,11 +6,11 @@
 -- (different NDV ratios) under enabled/disabled memory limit settings.
 
 -- cleanup
-drop table if exists m1;
-drop table if exists m2;
+drop table if exists outer_tbl;
+drop table if exists inner_tbl;
 
-create table m1 (col1 int, col2 int, col3 int, col4 varchar(20), col5 numeric(20,10), col6 varchar(20), col7 varchar(20), col8 varchar(20));
-insert into m1 select
+create table outer_tbl (uniq_int int, low_ndv_int int, mid_ndv_int int, mid_ndv_varchar varchar(20), high_ndv_numeric numeric(20,10), uniq_varchar varchar(20), half_ndv_varchar varchar(20), third_ndv_varchar varchar(20));
+insert into outer_tbl select
   rownum,
   rownum % 10,
   rownum % 100,
@@ -22,56 +22,56 @@ insert into m1 select
 from db_class a, db_class b, db_class c, db_class d, db_class e, db_class f, db_class g
 limit 100000;
 
-create table m2 (col1 int);
-insert into m2 select rownum from db_class a, db_class b, db_class c, db_class d, db_class e, db_class f, db_class g limit 10;
-update statistics on m1, m2 with fullscan;
+create table inner_tbl (join_key int);
+insert into inner_tbl select rownum from db_class a, db_class b, db_class c, db_class d, db_class e, db_class f, db_class g limit 10;
+update statistics on outer_tbl, inner_tbl with fullscan;
 
 evaluate 'memoize enabled (memoize_memory_limit=64M)';
 
 set trace on;
 set system parameters 'memoize_memory_limit=64M';
 
-select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col1 = m2.col1;
+select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.uniq_int = inner_tbl.join_key;
 show trace;
-select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col2 = m2.col1;
+select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.low_ndv_int = inner_tbl.join_key;
 show trace;
-select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col3 = m2.col1;
+select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.mid_ndv_int = inner_tbl.join_key;
 show trace;
-select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col4 = m2.col1;
+select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.mid_ndv_varchar = inner_tbl.join_key;
 show trace;
-select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col5 = m2.col1;
+select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.high_ndv_numeric = inner_tbl.join_key;
 show trace;
-select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col6 = m2.col1;
+select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.uniq_varchar = inner_tbl.join_key;
 show trace;
-select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col7 = m2.col1;
+select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.half_ndv_varchar = inner_tbl.join_key;
 show trace;
-select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col8 = m2.col1;
+select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.third_ndv_varchar = inner_tbl.join_key;
 show trace;
 
 evaluate 'memoize disabled (memoize_memory_limit=0)';
 
 set system parameters 'memoize_memory_limit=0';
 
-select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col1 = m2.col1;
+select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.uniq_int = inner_tbl.join_key;
 show trace;
-select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col2 = m2.col1;
+select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.low_ndv_int = inner_tbl.join_key;
 show trace;
-select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col3 = m2.col1;
+select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.mid_ndv_int = inner_tbl.join_key;
 show trace;
-select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col4 = m2.col1;
+select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.mid_ndv_varchar = inner_tbl.join_key;
 show trace;
-select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col5 = m2.col1;
+select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.high_ndv_numeric = inner_tbl.join_key;
 show trace;
-select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col6 = m2.col1;
+select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.uniq_varchar = inner_tbl.join_key;
 show trace;
-select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col7 = m2.col1;
+select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.half_ndv_varchar = inner_tbl.join_key;
 show trace;
-select /*+ recompile parallel(0) */ count(*) from m1 inner join m2 on m1.col8 = m2.col1;
+select /*+ recompile parallel(0) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.third_ndv_varchar = inner_tbl.join_key;
 show trace;
 
 set trace off;
 set system parameters 'memoize_memory_limit=default';
 
 -- cleanup
-drop table if exists m1;
-drop table if exists m2;
+drop table if exists outer_tbl;
+drop table if exists inner_tbl;

--- a/sql/_36_guava/cbrd_26345/cases/cbrd_26345.sql
+++ b/sql/_36_guava/cbrd_26345/cases/cbrd_26345.sql
@@ -2,13 +2,27 @@
 --
 -- For NLJ with repeated join keys on the inner table,
 -- caches inner scan results keyed by join column value.
--- Verify memoize activation behavior with various column types
--- (different NDV ratios) under enabled/disabled memory limit settings.
+--
+-- Covers:
+--   - activation behavior with various column types (different NDV
+--     ratios) under enabled/disabled memory limit settings
+--   - activation across join shapes (3-way join, view-to-table join,
+--     indexed inner scan)
+--   - cases where memoize must not activate (cartesian product,
+--     TABLE()-derived inner, SET/MULTISET/SEQUENCE column projection)
+--   - multi-row-per-key cache correctness (row-level output compared
+--     between memoize enabled and disabled)
 
 -- cleanup
 drop table if exists outer_tbl;
 drop table if exists inner_tbl;
 
+-- mid_ndv_varchar uses NDV=300, chosen relative to
+-- MEMOIZE_FREE_ITERATION_LIMIT=1000 (memoize.hpp): with only 300 distinct
+-- values, the runtime hit-ratio check is guaranteed a minimum hit ratio of
+-- (limit-NDV)/limit = 70% within the first `limit` probes, regardless of
+-- physical heap scan order. If this constant changes in the future, NDV
+-- must be re-evaluated to keep (limit-NDV)/limit > 0.5.
 create table outer_tbl (uniq_int int, low_ndv_int int, mid_ndv_int int, mid_ndv_varchar varchar(20), high_ndv_numeric numeric(20,10), uniq_varchar varchar(20), half_ndv_varchar varchar(20), third_ndv_varchar varchar(20));
 insert into outer_tbl select
   rownum,
@@ -49,10 +63,10 @@ show trace;
 evaluate 'uniq_varchar (VARCHAR, NDV=100000, unique) - expect: no memoize';
 select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.uniq_varchar = inner_tbl.join_key;
 show trace;
-evaluate 'half_ndv_varchar (VARCHAR, NDV=49999) - expect: no memoize';
+evaluate 'half_ndv_varchar (VARCHAR, NDV=49999) - expect: no memoize (NDV exceeds the 1000-probe free-iteration limit; the 0.50001 duplicate ratio is irrelevant to the current runtime check)';
 select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.half_ndv_varchar = inner_tbl.join_key;
 show trace;
-evaluate 'third_ndv_varchar (VARCHAR, NDV=33333) - expect: no memoize';
+evaluate 'third_ndv_varchar (VARCHAR, NDV=33333) - expect: no memoize (NDV exceeds the 1000-probe free-iteration limit; the 0.667 duplicate ratio is irrelevant to the current runtime check)';
 select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.third_ndv_varchar = inner_tbl.join_key;
 show trace;
 
@@ -92,11 +106,24 @@ set system parameters 'memoize_memory_limit=default';
 -- listed in the JIRA description.
 -- cache-full -> enabled:false is intentionally excluded: only observable on
 -- CUBRID builds between #6652(2025-12-01) and #6877(2026-03-09); unreproducible
--- on any current/future build.
+-- on any current/future build, because clear_memoize_storage() (memoize.cpp,
+-- called from storage::put()/put_nullptr() on disable) frees the storage and
+-- resets the pointer to null the instant it would go disabled, and the trace
+-- printer (query_dump.c) only emits the MEMOIZE line when the pointer is
+-- non-null and hit > 0 - so a disabled cache produces no trace output at all
+-- on these builds, identical to a cache that was simply never created.
+--
+-- Note on the "expect: no memoize" scenarios in general: they cannot
+-- distinguish "memoize was never created for this scan" from "it was created
+-- and then disabled at runtime" from "it was created and enabled but never
+-- got a hit" - all three produce the same observable output (no MEMOIZE line).
+-- Regression coverage against memoize being disabled globally comes from the
+-- "expect: memoize enabled" scenarios above, not from these negative ones.
 drop table if exists extra_join_tbl;
 drop table if exists set_col_tbl;
 drop table if exists multiset_col_tbl;
 drop table if exists sequence_col_tbl;
+drop table if exists inner_dup;
 drop view if exists low_ndv_view;
 
 create table extra_join_tbl (dup_key int, seq int);
@@ -112,53 +139,73 @@ insert into multiset_col_tbl values (1, multiset{1,1,2}), (2, multiset{3,3,4}), 
 create table sequence_col_tbl (id int, sq sequence(int));
 insert into sequence_col_tbl values (1, sequence{1,2}), (2, sequence{3,4}), (3, sequence{5,6}), (4, sequence{7,8}), (5, sequence{9,10});
 
+-- inner_dup has duplicate join keys (unlike inner_tbl, whose join_key is
+-- unique 1..10), so a cache hit for a given key must return more than one
+-- row. count(*)/limit-only assertions elsewhere in this file never exercise
+-- that path; here the actual row-level output is compared between
+-- memoize_memory_limit=64M (on) and =0 (off) so a bug in the multi-row cache
+-- path would show up as a result mismatch, not just a missing trace line.
+create table inner_dup (join_key int, payload varchar(10));
+insert into inner_dup values (1,'a'),(2,'a'),(3,'a'),(3,'b'),(3,'c'),(4,'a'),(5,'a'),(6,'a'),(7,'a'),(7,'b'),(8,'a'),(9,'a'),(10,'a'),(null,'z');
+update statistics on inner_dup with fullscan;
+
 create view low_ndv_view as select low_ndv_int, uniq_int from outer_tbl;
 
 set trace on;
 set system parameters 'memoize_memory_limit=64M';
 
-evaluate '3-way join -> runtime memoize activation on both joins';
+evaluate '3-way join - expect: memoize enabled on both joins';
 select /*+ recompile parallel(0) ordered use_nl(inner_tbl, extra_join_tbl) */ count(*)
 from outer_tbl inner join inner_tbl on outer_tbl.low_ndv_int = inner_tbl.join_key
               inner join extra_join_tbl on outer_tbl.mid_ndv_int = extra_join_tbl.dup_key;
 show trace;
 
-evaluate 'view-to-table join -> runtime memoize activation (view exposes no NDV stats)';
+evaluate 'view-to-table join (view exposes no NDV stats) - expect: memoize enabled';
 select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from low_ndv_view inner join inner_tbl on low_ndv_view.low_ndv_int = inner_tbl.join_key;
 show trace;
 
-evaluate 'constraint#4: cartesian product (no join condition) - expect: no memoize';
+evaluate 'cartesian product (no join condition) - expect: no memoize';
 select /*+ recompile parallel(0) */ count(*) from outer_tbl, inner_tbl;
 show trace;
 
-evaluate 'constraint#2: TARGET_SET-derived TABLE() inner - expect: no memoize';
+evaluate 'TARGET_SET-derived TABLE() inner - expect: no memoize';
 select /*+ recompile parallel(0) ordered use_nl(t) */ count(*) from outer_tbl inner join TABLE({1,2,3,4,5,6,7,8,9,10}) t(x) on outer_tbl.low_ndv_int = t.x;
 show trace;
 
-evaluate 'constraint#3: SET column real projection - expect: no memoize';
+evaluate 'SET column real projection - expect: no memoize';
 select /*+ recompile parallel(0) ordered use_nl(set_col_tbl) */ outer_tbl.low_ndv_int, set_col_tbl.s from outer_tbl inner join set_col_tbl on outer_tbl.low_ndv_int = set_col_tbl.id limit 5;
 show trace;
 
-evaluate 'constraint#3: MULTISET column real projection - expect: no memoize';
+evaluate 'MULTISET column real projection - expect: no memoize';
 select /*+ recompile parallel(0) ordered use_nl(multiset_col_tbl) */ outer_tbl.low_ndv_int, multiset_col_tbl.ms from outer_tbl inner join multiset_col_tbl on outer_tbl.low_ndv_int = multiset_col_tbl.id limit 5;
 show trace;
 
-evaluate 'constraint#3: SEQUENCE column real projection - expect: no memoize';
+evaluate 'SEQUENCE column real projection - expect: no memoize';
 select /*+ recompile parallel(0) ordered use_nl(sequence_col_tbl) */ outer_tbl.low_ndv_int, sequence_col_tbl.sq from outer_tbl inner join sequence_col_tbl on outer_tbl.low_ndv_int = sequence_col_tbl.id limit 5;
 show trace;
 
-evaluate 'memoize with index scan on inner table';
+evaluate 'memoize with index scan on inner table - expect: memoize enabled';
 create index idx_inner_tbl_key on inner_tbl (join_key);
 update statistics on inner_tbl with fullscan;
 select /*+ recompile parallel(0) ordered use_nl(inner_tbl) */ count(*) from outer_tbl inner join inner_tbl on outer_tbl.low_ndv_int = inner_tbl.join_key;
 show trace;
 drop index idx_inner_tbl_key on inner_tbl;
 
+evaluate 'multi-row-per-key cache path: row-level output, memoize enabled (memoize_memory_limit=64M)';
+select /*+ recompile parallel(0) ordered use_nl(inner_dup) */ outer_tbl.low_ndv_int, inner_dup.payload, count(*) from outer_tbl inner join inner_dup on outer_tbl.low_ndv_int = inner_dup.join_key group by outer_tbl.low_ndv_int, inner_dup.payload order by outer_tbl.low_ndv_int, inner_dup.payload;
+select /*+ recompile parallel(0) ordered use_nl(inner_dup) */ outer_tbl.low_ndv_int, count(inner_dup.payload) from outer_tbl left outer join inner_dup on outer_tbl.low_ndv_int = inner_dup.join_key and inner_dup.payload <> 'b' group by outer_tbl.low_ndv_int order by outer_tbl.low_ndv_int;
+
+set system parameters 'memoize_memory_limit=0';
+evaluate 'multi-row-per-key cache path: same queries, memoize disabled (memoize_memory_limit=0) - row-level output must match the enabled run above exactly';
+select /*+ recompile parallel(0) ordered use_nl(inner_dup) */ outer_tbl.low_ndv_int, inner_dup.payload, count(*) from outer_tbl inner join inner_dup on outer_tbl.low_ndv_int = inner_dup.join_key group by outer_tbl.low_ndv_int, inner_dup.payload order by outer_tbl.low_ndv_int, inner_dup.payload;
+select /*+ recompile parallel(0) ordered use_nl(inner_dup) */ outer_tbl.low_ndv_int, count(inner_dup.payload) from outer_tbl left outer join inner_dup on outer_tbl.low_ndv_int = inner_dup.join_key and inner_dup.payload <> 'b' group by outer_tbl.low_ndv_int order by outer_tbl.low_ndv_int;
+
 set trace off;
 set system parameters 'memoize_memory_limit=default';
 
 -- cleanup
 drop view if exists low_ndv_view;
+drop table if exists inner_dup;
 drop table if exists sequence_col_tbl;
 drop table if exists multiset_col_tbl;
 drop table if exists set_col_tbl;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26345

## 개요
NLJ에서 inner 테이블 조인 키가 반복될 때 inner scan 결과를 조인 컬럼 값 기준으로
캐싱하여 중복 스캔을 방지. 신규 시스템 파라미터: `memoize_memory_limit`
(0 = 비활성화).

**활성화 조건 (런타임)**: 옵티마이저 단계에는 memoize 관련 판정이 없고, 실행 중
`MEMOIZE_FREE_ITERATION_LIMIT`(1000, `memoize.hpp`)회 probe한 시점에 hit 비율이
50% 미만이면 그 순간 캐시를 즉시 disable함(`memoize.cpp`). 즉 기준은 "조인 컬럼의
전체 중복 비율"이 아니라 "처음 1000번 probe 안에서 hit이 몇 번 나오는가"임 — 이 값은
NDV뿐 아니라 heap 스캔 순서에도 영향을 받음 (아래 업데이트 참고).

## 변경 파일
- `cases/cbrd_26345.sql`
- `answers/cbrd_26345.answer`

## 테스트 케이스 구성
- NDV별 활성화 매트릭스: 8개 컬럼 타입(unique~low NDV) × `memoize_memory_limit` 64M/0
- 조인 형태별 활성화: 3-way join, view-to-table join, 인덱스 스캔 inner
- memoize가 발동하면 안 되는 케이스: cartesian product, `TABLE()` 파생 inner, SET/MULTISET/SEQUENCE 컬럼 projection
- 멀티로우 캐시 정합성: 한 키에 여러 행이 매칭될 때 on/off 결과가 행 단위로 일치하는지 비교

## 검증 결과 (최종)
| 버전 | 빌드 | 결과 |
|------|------|------|
| `11.5.0.2405-a2c3e03` | release / debug, sql/ sql_by_cci | 전체 **OK** |

=============================================================================

## 업데이트 이력

### 2026-08-07: 리뷰 반영 시나리오 추가, 제외 사유, 빌드 이슈로 인한 수정

**리뷰로 추가한 시나리오**
- 3-way join / view-to-table join 런타임 활성화 확인 (view는 옵티마이저에 NDV 통계를 노출하지 않아도 런타임 판정이라 정상 활성화됨)
- 카티전 곱(조인 조건 없음), `TARGET_SET` 기반 `TABLE()`이 inner인 경우 — memoize 미발동 확인
- SET/MULTISET/SEQUENCE 컬럼: `count(*)` 방식에서 컬럼 직접 projection 방식으로 재작성 — 이 제약은 값이 **SELECT 절에 실제로 projection될 때만** 발동하고, 테이블에 존재하거나 조인 조건에만 쓰이는 것으로는 발동하지 않음을 확인
- inner 테이블 인덱스 스캔 시 memoize 동작 확인

**리뷰로 제외한 사항**: cache-full → `enabled:false`
- [PR #6555](https://github.com/CUBRID/cubrid/pull/6555)(최초 구현, cache-full 시 storage 즉시 파괴) → [PR #6652](https://github.com/CUBRID/cubrid/pull/6652)(즉시 파괴 제거, `enabled` 필드 신설, 1000회/50% hit비율 기준 도입) → [PR #6877](https://github.com/CUBRID/cubrid/pull/6877)(즉시 파괴 재도입) → [PR #7018](https://github.com/CUBRID/cubrid/pull/7018)(trace 출력에 `hit>0` 조건 추가)
- 결론: `enabled:false`는 #6652~#6877 사이 빌드에서만 관찰 가능하고, 그 이후(현재 및 향후 모든 빌드 포함)는 disable 즉시 storage가 파괴되어 trace 자체가 안 남음 — TC에서 검증 불가능하여 제외

**수정: HASH JOIN 기본 선택 회귀 대응**
- [PR #6782](https://github.com/CUBRID/cubrid/pull/6782) / [CBRD-26475](http://jira.cubrid.org/browse/CBRD-26475) 이후 옵티마이저가 `USE_HASH` 힌트 없이도 기본으로 HASH JOIN을 선택 — memoize는 NLJ 전용이라 개입 기회 자체가 사라짐. 배포 빌드 이분탐색으로 `11.5.0.2334-739d506`(통과) vs `11.5.0.2335-39bdc0a`(실패), 정확히 1커밋 차이로 확인
- 의도된 성능 개선이라 TC 쪽에서만 대응: 모든 NLJ 의존 쿼리에 `ordered use_nl(<inner테이블>)` 힌트 추가 (`use_nl` 단독으로는 옵티마이저가 반대 방향 조합으로 우회 가능함을 확인)

**수정: `mid_ndv_varchar` NDV를 1000 → 300으로 변경**
- 특정 빌드 구간 이후 이 시나리오가  `MEMOIZE` 활성화가 안 되는 현상을 확인

### 2026-08-10: 추가 리뷰 반영, 원인 재검증

**원인 재검증 (1000→300 수정의 실제 근거)**

리뷰 의견에 따라 재검증한 결과, 원인은 **heap 스캔 순서 변화**로 확인함. memoize의 런타임 판정은 처음 1000번 probe 시점의 hit 비율로 결정되는데, 문제가 되는 빌드 구간을 전후로 heap 스캔 순서가 삽입 순서와 얼마나 어긋나는지가 급격히 달라짐을 직접 측정으로 확인:

- 이전 빌드: 0 (10만 행 전체가 삽입 순서와 물리적 스캔 순서 완전히 일치)
- 이후 빌드: 99,187 (첫 1000행 중 distinct 803개)

NDV=1000이 마침 판정 임계치(1000)와 같은 자릿수라, 스캔 순서가 흐트러지는 정도에 따라 첫 1000-probe 안의 hit 비율이 50% 문턱을 넘을지 말지가 오락가락하게 됨. **최종 수정한 NDV=300은** `MEMOIZE_FREE_ITERATION_LIMIT`(1000) 대비 충분히 작아, 스캔 순서와 무관하게 최소 hit 비율 70%가 보장됨 (`(1000-300)/1000`).

**추가 리뷰(1건) 반영 사항**
- `half_ndv_varchar`(NDV=49999)/`third_ndv_varchar`(NDV=33333) 라벨 수정: "no memoize" 결과 자체는 맞지만 근거가 "중복 비율"로 잘못 표기돼 있었음 — 실제 근거는 NDV가 1000-probe 한계를 초과한다는 것이고, 중복 비율(50.001%, 66.7%)은 현재 런타임 판정과 무관함을 명시
- `inner_dup` 테이블 및 멀티로우 캐시 경로 시나리오 추가: 기존 inner 테이블은 키가 유니크해서 캐시 엔트리에 행이 2개 이상 들어가는 경로가 한 번도 검증되지 않았음 — 한 키에 여러 행이 매칭되는 경우의 row-level 결과를 memoize on/off 양쪽에서 비교
- cache-full 제외 사유 주석에 관련 코드 위치(`clear_memoize_storage()`, trace 출력 조건) 명시
- "expect: no memoize" 시나리오들이 "생성 안 됨/런타임 disable/hit 0"을 구분하지 못한다는 한계를 주석으로 명시 (전역 회귀 방어는 "expect: memoize enabled" 시나리오들이 담당)

**추가 정리**
- 파일 헤더 주석을 전체 시나리오 구성을 반영하도록 확장
- `evaluate` 라벨 문구 스타일 통일
- 위치 기반 `group by`/`order by`(`1, 2`)를 컬럼명으로 변경


---

**업데이트 (2026-09-16): bagus-kim 리뷰 반영, 제외 사유**

bagus-kim 님이 제안하신 order-by 추가(SET/MULTISET/SEQUENCE 시나리오)를 그대로 적용해 확인하는 과정에서, 기존 "expect: no memoize" 라벨의 근거 자체가 흔들리는 지점을 발견해 CBRD-26345 issue에 문의드렸습니다.

개발자 확인 결과(이슈 코멘트 참고):
- 원소 타입이 지정된 컬렉션(SET(INT)/MULTISET(INT)/SEQUENCE(INT))은 memoize 제외 대상이 아니며, 반복 키가 충분하면 정상적으로 캐시됩니다.
- 원소 타입 미지정 SET만 실제로 제외 대상입니다.
- LIMIT만으로 조기 종료된 상태에서 trace가 안 보이는 것을 "타입 제외 성공"으로 판정하면 안 됩니다.

이에 따라 기존 3개 시나리오(SET/MULTISET/SEQUENCE column real projection)를 타입 지정 여부로 분리하고, LIMIT 5/50/ORDER BY/전체스캔 4가지 조건 × 64M/0 비교로 재구성했습니다. 구체적인 시나리오 설계는 이슈에 첨부된 test.md를 따랐습니다.

Refer to CBRD-26345

---

참고: view-to-table join 시나리오(low_ndv_view 사용)의 trace에 parallel(0) 힌트를 줬음에도 (parallel workers: ...) 줄이 나타나는 문제(bagus-kim 리뷰 별도 지적)는, view merge 시 PARALLEL 힌트 필드가 유실되는 엔진 결함으로 확인됐습니다. 이 TC와는 별개로 개발자에게 이슈 등록 예정이며, 해당 결함이 수정되면 이 시나리오의 trace 출력이 바뀌므로 그때 .answer도 함께 갱신이 필요합니다. 이번 커밋에서는 반영하지 않았습니다.
