### PR TITLE
[CBRD-26931] Fix timing-dependent isolation test broken by scalar subquery precomputation

### DIFF
--- a/isolation/_01_ReadCommitted/primary_key_column/aggregate/answer/delete_select_04.answer
+++ b/isolation/_01_ReadCommitted/primary_key_column/aggregate/answer/delete_select_04.answer
@@ -1,12 +1,12 @@
 | 10 rows affected
 | 10 rows affected
+| 5 rows affected
 | 1 row affected
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
 |    0    9  
 | 1 row selected
-| 5 rows affected
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/primary_key_column/aggregate/delete_select_04.ctl
+++ b/isolation/_01_ReadCommitted/primary_key_column/aggregate/delete_select_04.ctl
@@ -36,12 +36,12 @@ C1: commit;
 MC: wait until C1 ready;
 
 /* test case */
-C1: UPDATE tb1 SET id=id+10 WHERE id%2=0 and (select sleep(10)=0)<>0;
+C1: UPDATE tb1 SET id=id+10 WHERE id%2=0;
+MC: wait until C1 ready;
 /*MC: wait until C1 ready;*/
-MC: sleep 1;
 
-C2: DELETE FROM tb1 WHERE id=1 or id=18 and (select sleep(5)=0)<>0;
-MC: sleep 1;
+C2: DELETE FROM tb1 WHERE id=1 or id=18;
+MC: wait until C2 ready;
 
 /* expected (0,99999) */ 
 C3: SELECT MIN(id),MAX(id) FROM tb1;


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-26931

**배경 / 증상**

isolation/_01_ReadCommitted/primary_key_column/aggregate/delete_select_04.ctl 이 빌드 11.5.0.2297-978b628부터 실패합니다. 직전 11.5.0.2290-d0b2904까지는 통과했습니다.

- diff는 값 차이가 아니라 출력 순서 차이뿐입니다. C2 DELETE의 1 row affected가 C3 SELECT의 결과 뒤로 이동했습니다.
- MIN/MAX 결과값 (0,9), (3,18)은 두 빌드에서 동일하며 정확합니다 → 제품 데이터 정합성 문제 아님.
---
**원인** 

C2원래 문장: `DELETE FROM tb1 WHERE id=1 or id=18 and (select sleep(5)=0)<>0;`
C2 문장은 우선순위상` id=1 OR (id=18 AND (select sleep(5)=0)<>0)` 이고, 데이터에 id=18 행이 없습니다. id=18 행이 없으니 모든 행에서 id=18이 false → 오른쪽 항 전체가 항상 false.
따라서 술어는 사실상 WHERE id=1 로 축소됩니다. → id=1 한 건만 삭제.
만약 원래 의도가 "C2를 5초 느리게" 였다면 `(id=1 or id=18) and (select sleep(5)=0)=0` 처럼 괄호를 썼어야 했고, 그랬다면 두 빌드 모두 항상 5초였을 겁니다.

동일 환경(client 3대)에서 C2 DELETE를 두 빌드에서 측정:

11.5.0.2290-d0b2904:
```
csql> DELETE FROM tb1 WHERE id=1 or id=18 and (select sleep(5)=0)<>0;
1 row affected. (0.015000 sec)
```

11.5.0.2297-978b628:
```
csql> DELETE FROM tb1 WHERE id=1 or id=18 and (select sleep(5)=0)<>0;
1 row affected. (5.009019 sec)
```

CBRD-26931이 "비상관 스칼라 부질의를 스캔 전에 main thread에서 1회 선평가"하도록 변경하면서, 기존엔 도달하지 않던 (select sleep(5)=0)이 실행됩니다. 그 결과 C2 DELETE가 약 5초 지연되어, 완료 메시지가 C3 결과 뒤로 밀린 것입니다. 

---
**수정 내용**

TC의 본 검증 의도(미vacuum 데이터 + 커밋되지 않은 동시 DML 상황에서 RC의 MIN/MAX가 마지막 커밋 스냅샷만 봐야 한다)의 핵심은 "실행 중"이 아니라 "커밋되지 않은 상태" 입니다. sleep을 제거하고 `MC: wait until Cn ready; `를 이용하여 결정적 동기화로 전환했습니다.

- sleep 제거: "미커밋" 상태는 wait until ready(문장 완료 보장) + commit 미수행으로 결정적 성립. sleep은 검증 의도와 무관하다고 판단됨.
- id=18 조항 유지: C2(RC)가 C1의 커밋되지 않은 변경(8→18)을 보지 않는지를 검증하는 격리 확인 목적이므로 그대로 두고, 내부 sleep만 제거 → C2는 id=1만 삭제(1 row).
- 미vacuum 데이터 생성(prep) 및 MIN/MAX 검증 로직은 그대로 유지.

---
**요약**
동작(값)은 정상이며, CBRD-26931이 드러낸 것은 TC의 타이밍 의존 설계 결함입니다. 결정적 동기화로 전환하여 검증 의도를 보존하면서  fail을 해소했습니다.