### PR TITLE
[CBRD-26522] Add sql testcase for Support NL join during parallel heap scan

### DIFF
--- a/sql/_36_guava/cbrd_26522/answers/cbrd_26522.answer
+++ b/sql/_36_guava/cbrd_26522/answers/cbrd_26522.answer
@@ -32,16 +32,16 @@ trace
 Query Plan:
   SORT (order by)
     NESTED LOOPS (inner join)
-      TABLE SCAN (dba.t?)
-      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+      TABLE SCAN (dba.ta)
+      INDEX SCAN (dba.tb.pk_tb_id) (key range: [dba.ta].id=[dba.tb].id, covered: true)
 
-  rewritten query: select /*+ ORDERED */ [dba.t?].id from [dba.t?] [dba.t?], [dba.t?] [dba.t?] where [dba.t?].id=[dba.t?].id order by ?
+  rewritten query: select /*+ ORDERED */ [dba.tb].id from [dba.ta] [dba.ta], [dba.tb] [dba.tb] where [dba.ta].id=[dba.tb].id order by ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
          (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
-      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+      SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
@@ -59,15 +59,15 @@ trace
 Query Plan:
   SORT (order by)
     NESTED LOOPS (inner join)
-      TABLE SCAN (dba.t?)
-      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+      TABLE SCAN (dba.ta)
+      INDEX SCAN (dba.tb.pk_tb_id) (key range: [dba.ta].id=[dba.tb].id, covered: true)
 
-  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.t?].id from [dba.t?] [dba.t?], [dba.t?] [dba.t?] where [dba.t?].id=[dba.t?].id order by ?
+  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.tb].id from [dba.ta] [dba.ta], [dba.tb] [dba.tb] where [dba.ta].id=[dba.tb].id order by ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
@@ -76,7 +76,7 @@ Trace Statistics:
 Case 2: outer(left) NL join, count only -> buildvalue     
 
 ===================================================
-count(t2.id)    
+count(tb.id)    
 5     
 
 ===================================================
@@ -84,20 +84,20 @@ trace
 
 Query Plan:
   NESTED LOOPS (left outer join)
-    TABLE SCAN (dba.t?)
-    INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+    TABLE SCAN (dba.ta)
+    INDEX SCAN (dba.tb.pk_tb_id) (key range: [dba.ta].id=[dba.tb].id, covered: true)
 
-  rewritten query: select count([dba.t?].id) from [dba.t?] [dba.t?] left outer join [dba.t?] [dba.t?] on [dba.t?].id=[dba.t?].id where ([dba.t?].col?< ?:? )
+  rewritten query: select count([dba.tb].id) from [dba.ta] [dba.ta] left outer join [dba.tb] [dba.tb] on [dba.ta].id=[dba.tb].id where ([dba.ta].cola< ?:? )
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
          (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
-      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+      SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
      
 
 ===================================================
-count(t2.id)    
+count(tb.id)    
 5     
 
 ===================================================
@@ -105,15 +105,15 @@ trace
 
 Query Plan:
   NESTED LOOPS (left outer join)
-    TABLE SCAN (dba.t?)
-    INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+    TABLE SCAN (dba.ta)
+    INDEX SCAN (dba.tb.pk_tb_id) (key range: [dba.ta].id=[dba.tb].id, covered: true)
 
-  rewritten query: select /*+ NO_PARALLEL_SCAN */ count([dba.t?].id) from [dba.t?] [dba.t?] left outer join [dba.t?] [dba.t?] on [dba.t?].id=[dba.t?].id where ([dba.t?].col?< ?:? )
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count([dba.tb].id) from [dba.ta] [dba.ta] left outer join [dba.tb] [dba.tb] on [dba.ta].id=[dba.tb].id where ([dba.ta].cola< ?:? )
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
      
 
 ===================================================
@@ -134,16 +134,16 @@ trace
 Query Plan:
   SORT (order by)
     NESTED LOOPS (cross join)
-      TABLE SCAN (dba.t?)
-      TABLE SCAN (dba.t?)
+      TABLE SCAN (dba.ta)
+      TABLE SCAN (dba.tb)
 
-  rewritten query: select /*+ ORDERED */ [dba.t?].id, [dba.t?].id from [dba.t?] [dba.t?], [dba.t?] [dba.t?] where  cast([dba.t?].col? as integer)<? order by ?, ?
+  rewritten query: select /*+ ORDERED */ [dba.ta].id, [dba.tb].id from [dba.ta] [dba.ta], [dba.tb] [dba.tb] where  cast([dba.ta].cola as integer)<? order by ?, ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
          (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
-      SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
@@ -161,15 +161,15 @@ trace
 Query Plan:
   SORT (order by)
     NESTED LOOPS (cross join)
-      TABLE SCAN (dba.t?)
-      TABLE SCAN (dba.t?)
+      TABLE SCAN (dba.ta)
+      TABLE SCAN (dba.tb)
 
-  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.t?].id, [dba.t?].id from [dba.t?] [dba.t?], [dba.t?] [dba.t?] where  cast([dba.t?].col? as integer)<? order by ?, ?
+  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.ta].id, [dba.tb].id from [dba.ta] [dba.ta], [dba.tb] [dba.tb] where  cast([dba.ta].cola as integer)<? order by ?, ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
@@ -180,7 +180,7 @@ Case 4: SP on the 2nd table (cannot parallelize #2) -> row by row
 ===================================================
 0
 ===================================================
-sp1(t2.id)    
+sp_inc(tb.id)    
 2     
 3     
 4     
@@ -193,17 +193,17 @@ trace
 Query Plan:
   SORT (order by)
     NESTED LOOPS (inner join)
-      TABLE SCAN (dba.t?)
-      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+      TABLE SCAN (dba.ta)
+      INDEX SCAN (dba.tb.pk_tb_id) (key range: [dba.ta].id=[dba.tb].id, covered: true)
 
-  rewritten query: select /*+ ORDERED */ [dba.sp?]([dba.t?].id) from [dba.t?] [dba.t?] inner join [dba.t?] [dba.t?] on [dba.t?].id=[dba.t?].id order by ?
+  rewritten query: select /*+ ORDERED */ [dba.sp_inc]([dba.tb].id) from [dba.ta] [dba.ta] inner join [dba.tb] [dba.tb] on [dba.ta].id=[dba.tb].id order by ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
-    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
          (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
-      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+      SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
@@ -225,14 +225,14 @@ trace
 Query Plan:
   SORT (order by)
     NESTED LOOPS (cross join)
-      TABLE SCAN (dba.t?)
+      TABLE SCAN (dba.ta)
       TABLE SCAN (tset)
 
-  rewritten query: select /*+ ORDERED */ [dba.t?].id, tset.v from [dba.t?] [dba.t?], table({?, ?, ?}) tset (v) where  cast([dba.t?].col? as integer)<? order by ?, ?
+  rewritten query: select /*+ ORDERED */ [dba.ta].id, tset.v from [dba.ta] [dba.ta], table({?, ?, ?}) tset (v) where  cast([dba.ta].cola as integer)<? order by ?, ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
          (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
       SCAN (set time: ?, fetch: ?, ioread: ?)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
@@ -252,14 +252,14 @@ trace
 Query Plan:
   SORT (order by)
     NESTED LOOPS (inner join)
-      TABLE SCAN (dba.t?)
+      TABLE SCAN (dba.ta)
       TABLE SCAN (jt)
 
-  rewritten query: select /*+ ORDERED */ [dba.t?].id, jt.col from [dba.t?] [dba.t?], (json_table ('{"a":[?,[?,?]]}', '$."a"[*]' columns (col integer PATH '$' NULL ON EMPTY NULL ON ERROR )) as jt) where  cast([dba.t?].col? as integer)<? and [dba.t?].id=jt.col order by ?, ?
+  rewritten query: select /*+ ORDERED */ [dba.ta].id, jt.col from [dba.ta] [dba.ta], (json_table ('{"a":[?,[?,?]]}', '$."a"[*]' columns (col integer PATH '$' NULL ON EMPTY NULL ON ERROR )) as jt) where  cast([dba.ta].cola as integer)<? and [dba.ta].id=jt.col order by ?, ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
          (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
       SCAN (noscan time: ?, fetch: ?, ioread: ?)
      
@@ -269,7 +269,7 @@ Trace Statistics:
 Case 7: natural left join, outer heap scan + inner index scan (CBRD-26596 shape) -> mergeable list     
 
 ===================================================
-id    col1    id    
+id    cola    id    
 1     00000000000000000001     1     
 2     00000000000000000002     2     
 3     00000000000000000003     3     
@@ -287,21 +287,21 @@ trace
 Query Plan:
   SORT (order by)
     NESTED LOOPS (left outer join)
-      TABLE SCAN (dba.t?)
-      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+      TABLE SCAN (dba.ta)
+      INDEX SCAN (dba.tb.pk_tb_id) (key range: [dba.ta].id=[dba.tb].id, covered: true)
 
-  rewritten query: select [dba.t?].id, [dba.t?].col?, [dba.t?].id from [dba.t?] [dba.t?] natural  left outer join [dba.t?] [dba.t?] on [dba.t?].id=[dba.t?].id where  cast([dba.t?].col? as integer)<=? order by ?, ?, ?
+  rewritten query: select [dba.ta].id, [dba.ta].cola, [dba.tb].id from [dba.ta] [dba.ta] natural  left outer join [dba.tb] [dba.tb] on [dba.ta].id=[dba.tb].id where  cast([dba.ta].cola as integer)<=? order by ?, ?, ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
          (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
-      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+      SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
 ===================================================
-id    col1    id    
+id    cola    id    
 1     00000000000000000001     1     
 2     00000000000000000002     2     
 3     00000000000000000003     3     
@@ -319,15 +319,15 @@ trace
 Query Plan:
   SORT (order by)
     NESTED LOOPS (left outer join)
-      TABLE SCAN (dba.t?)
-      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+      TABLE SCAN (dba.ta)
+      INDEX SCAN (dba.tb.pk_tb_id) (key range: [dba.ta].id=[dba.tb].id, covered: true)
 
-  rewritten query: select /*+ NO_PARALLEL_SCAN */ [dba.t?].id, [dba.t?].col?, [dba.t?].id from [dba.t?] [dba.t?] natural  left outer join [dba.t?] [dba.t?] on [dba.t?].id=[dba.t?].id where  cast([dba.t?].col? as integer)<=? order by ?, ?, ?
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ [dba.ta].id, [dba.ta].cola, [dba.tb].id from [dba.ta] [dba.ta] natural  left outer join [dba.tb] [dba.tb] on [dba.ta].id=[dba.tb].id where  cast([dba.ta].cola as integer)<=? order by ?, ?, ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
@@ -336,7 +336,7 @@ Trace Statistics:
 Case 8: 3-way NL join, driving heap scan parallel + two inner index probes -> mergeable list     
 
 ===================================================
-col2    id    id    
+colb    id    id    
 00000000000000000001     1     1     
 00000000000000000002     2     2     
 00000000000000000003     3     3     
@@ -348,23 +348,23 @@ Query Plan:
   SORT (order by)
     NESTED LOOPS (inner join)
       NESTED LOOPS (inner join)
-        TABLE SCAN (dba.t?)
-        INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
-      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+        TABLE SCAN (dba.ta)
+        INDEX SCAN (dba.tb.pk_tb_id) (key range: [dba.ta].id=[dba.tb].id, covered: true)
+      INDEX SCAN (dba.tc.pk_tc_id) (key range: [dba.tb].id=[dba.tc].id, covered: true)
 
-  rewritten query: select /*+ ORDERED */ [dba.t?].col?, [dba.t?].id, [dba.t?].id from [dba.t?] [dba.t?], [dba.t?] [dba.t?], [dba.t?] [dba.t?] where [dba.t?].id=[dba.t?].id and [dba.t?].id=[dba.t?].id order by ?, ?
+  rewritten query: select /*+ ORDERED */ [dba.ta].colb, [dba.tb].id, [dba.tc].id from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].id=[dba.tb].id and [dba.tb].id=[dba.tc].id order by ?, ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
          (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
-      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-        SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+      SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+        SCAN (index: dba.tc.pk_tc_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
 ===================================================
-col2    id    id    
+colb    id    id    
 00000000000000000001     1     1     
 00000000000000000002     2     2     
 00000000000000000003     3     3     
@@ -376,17 +376,17 @@ Query Plan:
   SORT (order by)
     NESTED LOOPS (inner join)
       NESTED LOOPS (inner join)
-        TABLE SCAN (dba.t?)
-        INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
-      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+        TABLE SCAN (dba.ta)
+        INDEX SCAN (dba.tb.pk_tb_id) (key range: [dba.ta].id=[dba.tb].id, covered: true)
+      INDEX SCAN (dba.tc.pk_tc_id) (key range: [dba.tb].id=[dba.tc].id, covered: true)
 
-  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.t?].col?, [dba.t?].id, [dba.t?].id from [dba.t?] [dba.t?], [dba.t?] [dba.t?], [dba.t?] [dba.t?] where [dba.t?].id=[dba.t?].id and [dba.t?].id=[dba.t?].id order by ?, ?
+  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.ta].colb, [dba.tb].id, [dba.tc].id from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].id=[dba.tb].id and [dba.tb].id=[dba.tc].id order by ?, ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-        SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+        SCAN (index: dba.tc.pk_tc_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
@@ -395,7 +395,7 @@ Trace Statistics:
 Case 9: GROUP BY over NL join -> mergeable list     
 
 ===================================================
-col2    count(*)    
+colb    count(*)    
 00000000000000000000     1     
 00000000000000000001     1     
 00000000000000000002     1     
@@ -408,21 +408,21 @@ trace
 Query Plan:
   SORT (group by)
     NESTED LOOPS (inner join)
-      TABLE SCAN (dba.t?)
-      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+      TABLE SCAN (dba.ta)
+      INDEX SCAN (dba.tb.pk_tb_id) (key range: [dba.ta].id=[dba.tb].id, covered: true)
 
-  rewritten query: select /*+ ORDERED */ [dba.t?].col?, count(*) from [dba.t?] [dba.t?], [dba.t?] [dba.t?] where [dba.t?].id=[dba.t?].id group by [dba.t?].col?
+  rewritten query: select /*+ ORDERED */ [dba.ta].colb, count(*) from [dba.ta] [dba.ta], [dba.tb] [dba.tb] where [dba.ta].id=[dba.tb].id group by [dba.ta].colb
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
          (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
-      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+      SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     GROUPBY (time: ?, hash: partial, sort: true, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
-col2    count(*)    
+colb    count(*)    
 00000000000000000000     1     
 00000000000000000001     1     
 00000000000000000002     1     
@@ -435,15 +435,15 @@ trace
 Query Plan:
   SORT (group by)
     NESTED LOOPS (inner join)
-      TABLE SCAN (dba.t?)
-      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+      TABLE SCAN (dba.ta)
+      INDEX SCAN (dba.tb.pk_tb_id) (key range: [dba.ta].id=[dba.tb].id, covered: true)
 
-  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.t?].col?, count(*) from [dba.t?] [dba.t?], [dba.t?] [dba.t?] where [dba.t?].id=[dba.t?].id group by [dba.t?].col?
+  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.ta].colb, count(*) from [dba.ta] [dba.ta], [dba.tb] [dba.tb] where [dba.ta].id=[dba.tb].id group by [dba.ta].colb
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
      
 
@@ -452,7 +452,7 @@ Trace Statistics:
 Case 10: explicit PARALLEL(2) hint on NL join -> mergeable list     
 
 ===================================================
-id    col2    
+id    colb    
 1     00000000000000000001     
 2     00000000000000000002     
 3     00000000000000000003     
@@ -465,21 +465,21 @@ trace
 Query Plan:
   SORT (order by)
     NESTED LOOPS (inner join)
-      TABLE SCAN (dba.t?)
-      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+      TABLE SCAN (dba.ta)
+      INDEX SCAN (dba.tb.pk_tb_id) (key range: [dba.ta].id=[dba.tb].id, covered: true)
 
-  rewritten query: select /*+ ORDERED PARALLEL(?) */ [dba.t?].id, [dba.t?].col? from [dba.t?] [dba.t?], [dba.t?] [dba.t?] where [dba.t?].id=[dba.t?].id order by ?
+  rewritten query: select /*+ ORDERED PARALLEL(?) */ [dba.tb].id, [dba.ta].colb from [dba.ta] [dba.ta], [dba.tb] [dba.tb] where [dba.ta].id=[dba.tb].id order by ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
          (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
-      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+      SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
 ===================================================
-id    col2    
+id    colb    
 1     00000000000000000001     
 2     00000000000000000002     
 3     00000000000000000003     
@@ -492,15 +492,15 @@ trace
 Query Plan:
   SORT (order by)
     NESTED LOOPS (inner join)
-      TABLE SCAN (dba.t?)
-      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+      TABLE SCAN (dba.ta)
+      INDEX SCAN (dba.tb.pk_tb_id) (key range: [dba.ta].id=[dba.tb].id, covered: true)
 
-  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.t?].id, [dba.t?].col? from [dba.t?] [dba.t?], [dba.t?] [dba.t?] where [dba.t?].id=[dba.t?].id order by ?
+  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.tb].id, [dba.ta].colb from [dba.ta] [dba.ta], [dba.tb] [dba.tb] where [dba.ta].id=[dba.tb].id order by ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
@@ -521,14 +521,14 @@ Query Plan:
   SORT (order by)
     NESTED LOOPS (inner join)
       TABLE SCAN (x)
-      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=x.v, covered: true)
+      INDEX SCAN (dba.ta.pk_ta_id) (key range: [dba.ta].id=x.v, covered: true)
 
-  rewritten query: select /*+ ORDERED */ x.v, [dba.t?].id from table({?, ?, ?}) x (v), [dba.t?] [dba.t?] where [dba.t?].id=x.v order by ?, ?
+  rewritten query: select /*+ ORDERED */ x.v, [dba.ta].id from table({?, ?, ?}) x (v), [dba.ta] [dba.ta] where [dba.ta].id=x.v order by ?, ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (set time: ?, fetch: ?, ioread: ?)
-      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+      SCAN (index: dba.ta.pk_ta_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 

--- a/sql/_36_guava/cbrd_26522/answers/cbrd_26522.answer
+++ b/sql/_36_guava/cbrd_26522/answers/cbrd_26522.answer
@@ -1,0 +1,536 @@
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+4000
+===================================================
+5
+===================================================
+3
+===================================================
+0
+===================================================
+    
+Case 1: simple NL join (driving heap scan) -> mergeable list     
+
+===================================================
+id    
+1     
+2     
+3     
+4     
+5     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (dba.t?)
+      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+
+  rewritten query: select /*+ ORDERED */ [dba.t?].id from [dba.t?] [dba.t?], [dba.t?] [dba.t?] where [dba.t?].id=[dba.t?].id order by ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
+      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+id    
+1     
+2     
+3     
+4     
+5     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (dba.t?)
+      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+
+  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.t?].id from [dba.t?] [dba.t?], [dba.t?] [dba.t?] where [dba.t?].id=[dba.t?].id order by ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 2: outer(left) NL join, count only -> buildvalue     
+
+===================================================
+count(t2.id)    
+5     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (left outer join)
+    TABLE SCAN (dba.t?)
+    INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+
+  rewritten query: select count([dba.t?].id) from [dba.t?] [dba.t?] left outer join [dba.t?] [dba.t?] on [dba.t?].id=[dba.t?].id where ([dba.t?].col?< ?:? )
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+     
+
+===================================================
+count(t2.id)    
+5     
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (left outer join)
+    TABLE SCAN (dba.t?)
+    INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count([dba.t?].id) from [dba.t?] [dba.t?] left outer join [dba.t?] [dba.t?] on [dba.t?].id=[dba.t?].id where ([dba.t?].col?< ?:? )
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+     
+
+===================================================
+    
+Case 3: cross join -> mergeable list     
+
+===================================================
+id    id    
+1     1     
+1     2     
+1     3     
+1     4     
+1     5     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (cross join)
+      TABLE SCAN (dba.t?)
+      TABLE SCAN (dba.t?)
+
+  rewritten query: select /*+ ORDERED */ [dba.t?].id, [dba.t?].id from [dba.t?] [dba.t?], [dba.t?] [dba.t?] where  cast([dba.t?].col? as integer)<? order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
+      SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+id    id    
+1     1     
+1     2     
+1     3     
+1     4     
+1     5     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (cross join)
+      TABLE SCAN (dba.t?)
+      TABLE SCAN (dba.t?)
+
+  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.t?].id, [dba.t?].id from [dba.t?] [dba.t?], [dba.t?] [dba.t?] where  cast([dba.t?].col? as integer)<? order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 4: SP on the 2nd table (cannot parallelize #2) -> row by row     
+
+===================================================
+0
+===================================================
+sp1(t2.id)    
+2     
+3     
+4     
+5     
+6     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (dba.t?)
+      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+
+  rewritten query: select /*+ ORDERED */ [dba.sp?]([dba.t?].id) from [dba.t?] [dba.t?] inner join [dba.t?] [dba.t?] on [dba.t?].id=[dba.t?].id order by ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
+      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+0
+===================================================
+    
+Case 5: 2nd table scan spec is set (cannot parallelize #3) -> row by row     
+
+===================================================
+id    v    
+1     1     
+1     2     
+1     3     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (cross join)
+      TABLE SCAN (dba.t?)
+      TABLE SCAN (tset)
+
+  rewritten query: select /*+ ORDERED */ [dba.t?].id, tset.v from [dba.t?] [dba.t?], table({?, ?, ?}) tset (v) where  cast([dba.t?].col? as integer)<? order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
+      SCAN (set time: ?, fetch: ?, ioread: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 6: 2nd table JSON_TABLE scan (cannot parallelize #4) -> row by row     
+
+===================================================
+id    col    
+1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (dba.t?)
+      TABLE SCAN (jt)
+
+  rewritten query: select /*+ ORDERED */ [dba.t?].id, jt.col from [dba.t?] [dba.t?], (json_table ('{"a":[?,[?,?]]}', '$."a"[*]' columns (col integer PATH '$' NULL ON EMPTY NULL ON ERROR )) as jt) where  cast([dba.t?].col? as integer)<? and [dba.t?].id=jt.col order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
+      SCAN (noscan time: ?, fetch: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 7: natural left join, outer heap scan + inner index scan (CBRD-26596 shape) -> mergeable list     
+
+===================================================
+id    col1    id    
+1     00000000000000000001     1     
+2     00000000000000000002     2     
+3     00000000000000000003     3     
+4     00000000000000000004     4     
+5     00000000000000000005     5     
+6     00000000000000000006     null     
+7     00000000000000000007     null     
+8     00000000000000000008     null     
+9     00000000000000000009     null     
+10     00000000000000000010     null     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (dba.t?)
+      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+
+  rewritten query: select [dba.t?].id, [dba.t?].col?, [dba.t?].id from [dba.t?] [dba.t?] natural  left outer join [dba.t?] [dba.t?] on [dba.t?].id=[dba.t?].id where  cast([dba.t?].col? as integer)<=? order by ?, ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
+      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+id    col1    id    
+1     00000000000000000001     1     
+2     00000000000000000002     2     
+3     00000000000000000003     3     
+4     00000000000000000004     4     
+5     00000000000000000005     5     
+6     00000000000000000006     null     
+7     00000000000000000007     null     
+8     00000000000000000008     null     
+9     00000000000000000009     null     
+10     00000000000000000010     null     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (dba.t?)
+      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ [dba.t?].id, [dba.t?].col?, [dba.t?].id from [dba.t?] [dba.t?] natural  left outer join [dba.t?] [dba.t?] on [dba.t?].id=[dba.t?].id where  cast([dba.t?].col? as integer)<=? order by ?, ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 8: 3-way NL join, driving heap scan parallel + two inner index probes -> mergeable list     
+
+===================================================
+col2    id    id    
+00000000000000000001     1     1     
+00000000000000000002     2     2     
+00000000000000000003     3     3     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (inner join)
+      NESTED LOOPS (inner join)
+        TABLE SCAN (dba.t?)
+        INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+
+  rewritten query: select /*+ ORDERED */ [dba.t?].col?, [dba.t?].id, [dba.t?].id from [dba.t?] [dba.t?], [dba.t?] [dba.t?], [dba.t?] [dba.t?] where [dba.t?].id=[dba.t?].id and [dba.t?].id=[dba.t?].id order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
+      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+        SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+col2    id    id    
+00000000000000000001     1     1     
+00000000000000000002     2     2     
+00000000000000000003     3     3     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (inner join)
+      NESTED LOOPS (inner join)
+        TABLE SCAN (dba.t?)
+        INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+
+  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.t?].col?, [dba.t?].id, [dba.t?].id from [dba.t?] [dba.t?], [dba.t?] [dba.t?], [dba.t?] [dba.t?] where [dba.t?].id=[dba.t?].id and [dba.t?].id=[dba.t?].id order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+        SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 9: GROUP BY over NL join -> mergeable list     
+
+===================================================
+col2    count(*)    
+00000000000000000000     1     
+00000000000000000001     1     
+00000000000000000002     1     
+00000000000000000003     1     
+00000000000000000004     1     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (dba.t?)
+      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+
+  rewritten query: select /*+ ORDERED */ [dba.t?].col?, count(*) from [dba.t?] [dba.t?], [dba.t?] [dba.t?] where [dba.t?].id=[dba.t?].id group by [dba.t?].col?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
+      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    GROUPBY (time: ?, hash: partial, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+col2    count(*)    
+00000000000000000000     1     
+00000000000000000001     1     
+00000000000000000002     1     
+00000000000000000003     1     
+00000000000000000004     1     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (dba.t?)
+      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+
+  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.t?].col?, count(*) from [dba.t?] [dba.t?], [dba.t?] [dba.t?] where [dba.t?].id=[dba.t?].id group by [dba.t?].col?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+Case 10: explicit PARALLEL(2) hint on NL join -> mergeable list     
+
+===================================================
+id    col2    
+1     00000000000000000001     
+2     00000000000000000002     
+3     00000000000000000003     
+4     00000000000000000004     
+5     00000000000000000000     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (dba.t?)
+      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+
+  rewritten query: select /*+ ORDERED PARALLEL(?) */ [dba.t?].id, [dba.t?].col? from [dba.t?] [dba.t?], [dba.t?] [dba.t?] where [dba.t?].id=[dba.t?].id order by ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
+      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+id    col2    
+1     00000000000000000001     
+2     00000000000000000002     
+3     00000000000000000003     
+4     00000000000000000004     
+5     00000000000000000000     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (dba.t?)
+      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=[dba.t?].id, covered: true)
+
+  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.t?].id, [dba.t?].col? from [dba.t?] [dba.t?], [dba.t?] [dba.t?] where [dba.t?].id=[dba.t?].id order by ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.t?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 11: first(driving) table is a set collection, not parallel-heap-scannable (cannot parallelize #1) -> not parallelized     
+
+===================================================
+v    id    
+1     1     
+2     2     
+3     3     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (x)
+      INDEX SCAN (dba.t?.pk_t?_id) (key range: [dba.t?].id=x.v, covered: true)
+
+  rewritten query: select /*+ ORDERED */ x.v, [dba.t?].id from table({?, ?, ?}) x (v), [dba.t?] [dba.t?] where [dba.t?].id=x.v order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (set time: ?, fetch: ?, ioread: ?)
+      SCAN (index: dba.t?.pk_t?_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+0

--- a/sql/_36_guava/cbrd_26522/answers/cbrd_26522.answer
+++ b/sql/_36_guava/cbrd_26522/answers/cbrd_26522.answer
@@ -7,7 +7,7 @@
 ===================================================
 0
 ===================================================
-4000
+8000
 ===================================================
 5
 ===================================================
@@ -87,7 +87,7 @@ Query Plan:
     TABLE SCAN (dba.ta)
     INDEX SCAN (dba.tb.pk_tb_id) (key range: [dba.ta].id=[dba.tb].id, covered: true)
 
-  rewritten query: select count([dba.tb].id) from [dba.ta] [dba.ta] left outer join [dba.tb] [dba.tb] on [dba.ta].id=[dba.tb].id where ([dba.ta].cola< ?:? )
+  rewritten query: select count([dba.tb].id) from [dba.ta] [dba.ta] left outer join [dba.tb] [dba.tb] on [dba.ta].id=[dba.tb].id where  cast([dba.ta].cola as integer)<?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -108,7 +108,7 @@ Query Plan:
     TABLE SCAN (dba.ta)
     INDEX SCAN (dba.tb.pk_tb_id) (key range: [dba.ta].id=[dba.tb].id, covered: true)
 
-  rewritten query: select /*+ NO_PARALLEL_SCAN */ count([dba.tb].id) from [dba.ta] [dba.ta] left outer join [dba.tb] [dba.tb] on [dba.ta].id=[dba.tb].id where ([dba.ta].cola< ?:? )
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count([dba.tb].id) from [dba.ta] [dba.ta] left outer join [dba.tb] [dba.tb] on [dba.ta].id=[dba.tb].id where  cast([dba.ta].cola as integer)<?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -208,6 +208,33 @@ Trace Statistics:
      
 
 ===================================================
+sp_inc(tb.id)    
+2     
+3     
+4     
+5     
+6     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (dba.ta)
+      INDEX SCAN (dba.tb.pk_tb_id) (key range: [dba.ta].id=[dba.tb].id, covered: true)
+
+  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.sp_inc]([dba.tb].id) from [dba.ta] [dba.ta] inner join [dba.tb] [dba.tb] on [dba.ta].id=[dba.tb].id order by ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
 0
 ===================================================
     
@@ -239,6 +266,30 @@ Trace Statistics:
      
 
 ===================================================
+id    v    
+1     1     
+1     2     
+1     3     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (cross join)
+      TABLE SCAN (dba.ta)
+      TABLE SCAN (tset)
+
+  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.ta].id, tset.v from [dba.ta] [dba.ta], table({?, ?, ?}) tset (v) where  cast([dba.ta].cola as integer)<? order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (set time: ?, fetch: ?, ioread: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
     
 Case 6: 2nd table JSON_TABLE scan (cannot parallelize #4) -> row by row     
 
@@ -261,6 +312,27 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
          (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
+      SCAN (noscan time: ?, fetch: ?, ioread: ?)
+     
+
+===================================================
+id    col    
+1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (dba.ta)
+      TABLE SCAN (jt)
+
+  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.ta].id, jt.col from [dba.ta] [dba.ta], (json_table ('{"a":[?,[?,?]]}', '$."a"[*]' columns (col integer PATH '$' NULL ON EMPTY NULL ON ERROR )) as jt) where  cast([dba.ta].cola as integer)<? and [dba.ta].id=jt.col order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (noscan time: ?, fetch: ?, ioread: ?)
      
 
@@ -530,6 +602,81 @@ Trace Statistics:
     SCAN (set time: ?, fetch: ?, ioread: ?)
       SCAN (index: dba.ta.pk_ta_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 12: driving heap table below parallel_scan_page_threshold (cannot parallelize #1) -> not parallelized     
+
+===================================================
+val    id    
+1     1     
+2     2     
+3     3     
+4     4     
+5     5     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (dba.tb)
+      INDEX SCAN (dba.ta.pk_ta_id) (key range: [dba.tb].id=[dba.ta].id, covered: true)
+
+  rewritten query: select /*+ ORDERED */ [dba.tb].val, [dba.ta].id from [dba.tb] [dba.tb], [dba.ta] [dba.ta] where [dba.tb].id=[dba.ta].id order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.ta.pk_ta_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 13: parallel NL join with empty driving result -> no phantom rows     
+
+===================================================
+id    
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (dba.ta)
+      INDEX SCAN (dba.tb.pk_tb_id) (key range: [dba.ta].id=[dba.tb].id, covered: true)
+
+  rewritten query: select /*+ ORDERED */ [dba.tb].id from [dba.ta] [dba.ta], [dba.tb] [dba.tb] where [dba.ta].id=[dba.tb].id and  cast([dba.ta].cola as integer)<? order by ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
+      SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+     
+
+===================================================
+id    
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (dba.ta)
+      INDEX SCAN (dba.tb.pk_tb_id) (key range: [dba.ta].id=[dba.tb].id, covered: true)
+
+  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ [dba.tb].id from [dba.ta] [dba.ta], [dba.tb] [dba.tb] where [dba.ta].id=[dba.tb].id and  cast([dba.ta].cola as integer)<? order by ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
      
 
 ===================================================

--- a/sql/_36_guava/cbrd_26522/cases/cbrd_26522.sql
+++ b/sql/_36_guava/cbrd_26522/cases/cbrd_26522.sql
@@ -4,11 +4,15 @@
  *
  *  Parallel heap scan is enabled automatically here: CTP runs SQL tests with
  *  test_mode=yes, which lowers parallel_scan_page_threshold from its default
- *  (2048) to 32. t1 below is ~4000 rows (> 32 heap pages), so its heap scan is
+ *  (2048) to 32. ta below is ~4000 rows (> 32 heap pages), so its heap scan is
  *  executed in parallel and the NL join is evaluated inside each parallel worker.
  *  The (parallel workers: ...) line and the "gather:" mode in "show trace" show
  *  whether the driving heap scan ran in parallel and how results were gathered
  *  (mergeable list / buildvalue / row by row).
+ *
+ *  Note: table/column names use letters (ta/tb/tc, cola..colf), not digits,
+ *  because CTP masks digits in the trace output to '?' -- digit-named objects
+ *  (t1, col1, ...) would all collapse to "t?"/"col?" and become indistinguishable.
  *
  *  Correctness: every parallel case (mergeable list and the buildvalue/count
  *  case) runs the parallel query AND the same query with the NO_PARALLEL_SCAN
@@ -37,109 +41,109 @@
  *    Case 11: first(driving) table = set collection -> not parallel-heap-scannable (cannot parallelize #1)
  */
 
-drop table if exists t1, t2, t3;
-create table t1 (id int primary key, col1 varchar(20), col2 varchar(20), col3 varchar(20), col4 varchar(20), col5 varchar(20), col6 varchar(20));
-create table t2 (id int primary key);
-create table t3 (id int primary key);
+drop table if exists ta, tb, tc;
+create table ta (id int primary key, cola varchar(20), colb varchar(20), colc varchar(20), cold varchar(20), cole varchar(20), colf varchar(20));
+create table tb (id int primary key);
+create table tc (id int primary key);
 
-insert into t1
+insert into ta
 select rownum, lpad(rownum,20,'0'), lpad(rownum % 5,20,'0'), lpad(rownum,20,'0'), lpad(rownum,20,'0'), lpad(rownum,20,'0'), lpad(rownum,20,'0')
 from db_class a, db_class b, db_class c, db_class d, db_class e limit 4000;
-insert into t2 select rownum from db_class limit 5;
-insert into t3 select rownum from db_class limit 3;
+insert into tb select rownum from db_class limit 5;
+insert into tc select rownum from db_class limit 3;
 
 set trace on;
 
 
 evaluate 'Case 1: simple NL join (driving heap scan) -> mergeable list';
-select /*+ recompile ordered */ t2.id from t1, t2 where t1.id = t2.id order by 1;
+select /*+ recompile ordered */ tb.id from ta, tb where ta.id = tb.id order by 1;
 show trace;
 -- serial reference: result must match the parallel block above
-select /*+ recompile ordered no_parallel_scan */ t2.id from t1, t2 where t1.id = t2.id order by 1;
+select /*+ recompile ordered no_parallel_scan */ tb.id from ta, tb where ta.id = tb.id order by 1;
 show trace;
 
 
 evaluate 'Case 2: outer(left) NL join, count only -> buildvalue';
-select /*+ recompile */ count(t2.id) from t1 left join t2 on t1.id = t2.id where t1.col1 < 6;
+select /*+ recompile */ count(tb.id) from ta left join tb on ta.id = tb.id where ta.cola < 6;
 show trace;
 -- serial reference: result must match the parallel block above
-select /*+ recompile no_parallel_scan */ count(t2.id) from t1 left join t2 on t1.id = t2.id where t1.col1 < 6;
+select /*+ recompile no_parallel_scan */ count(tb.id) from ta left join tb on ta.id = tb.id where ta.cola < 6;
 show trace;
 
 
 evaluate 'Case 3: cross join -> mergeable list';
-select /*+ recompile ordered */ t1.id, t2.id from t1, t2 where cast(t1.col1 as int) < 2 order by 1, 2;
+select /*+ recompile ordered */ ta.id, tb.id from ta, tb where cast(ta.cola as int) < 2 order by 1, 2;
 show trace;
 -- serial reference: result must match the parallel block above
-select /*+ recompile ordered no_parallel_scan */ t1.id, t2.id from t1, t2 where cast(t1.col1 as int) < 2 order by 1, 2;
+select /*+ recompile ordered no_parallel_scan */ ta.id, tb.id from ta, tb where cast(ta.cola as int) < 2 order by 1, 2;
 show trace;
 
 
 evaluate 'Case 4: SP on the 2nd table (cannot parallelize #2) -> row by row';
-create or replace function sp1(n integer) return integer deterministic
+create or replace function sp_inc(n integer) return integer deterministic
 is
 begin
     return n + 1;
 end;
 
-select /*+ recompile ordered */ sp1(t2.id) from t1 join t2 on t1.id = t2.id order by 1;
+select /*+ recompile ordered */ sp_inc(tb.id) from ta join tb on ta.id = tb.id order by 1;
 show trace;
 
-drop function sp1;
+drop function sp_inc;
 
 
 evaluate 'Case 5: 2nd table scan spec is set (cannot parallelize #3) -> row by row';
-select /*+ recompile ordered */ t1.id, tset.v from t1, table({1,2,3}) as tset(v) where cast(t1.col1 as int) < 2 order by 1, 2;
+select /*+ recompile ordered */ ta.id, tset.v from ta, table({1,2,3}) as tset(v) where cast(ta.cola as int) < 2 order by 1, 2;
 show trace;
 
 
 evaluate 'Case 6: 2nd table JSON_TABLE scan (cannot parallelize #4) -> row by row';
-select /*+ recompile ordered */ t1.id, jt.col
-from t1, json_table('{"a":[1,[2,3]]}', '$.a[*]' columns (col int path '$')) as jt
-where cast(t1.col1 as int) < 2 and t1.id = jt.col
+select /*+ recompile ordered */ ta.id, jt.col
+from ta, json_table('{"a":[1,[2,3]]}', '$.a[*]' columns (col int path '$')) as jt
+where cast(ta.cola as int) < 2 and ta.id = jt.col
 order by 1, 2;
 show trace;
 
 
 evaluate 'Case 7: natural left join, outer heap scan + inner index scan (CBRD-26596 shape) -> mergeable list';
-select /*+ recompile */ t1.id, t1.col1, t2.id from t1 natural left join t2 where cast(t1.col1 as int) <= 10 order by 1, 2, 3;
+select /*+ recompile */ ta.id, ta.cola, tb.id from ta natural left join tb where cast(ta.cola as int) <= 10 order by 1, 2, 3;
 show trace;
 -- serial reference: result must match the parallel block above
-select /*+ recompile no_parallel_scan */ t1.id, t1.col1, t2.id from t1 natural left join t2 where cast(t1.col1 as int) <= 10 order by 1, 2, 3;
+select /*+ recompile no_parallel_scan */ ta.id, ta.cola, tb.id from ta natural left join tb where cast(ta.cola as int) <= 10 order by 1, 2, 3;
 show trace;
 
 
 evaluate 'Case 8: 3-way NL join, driving heap scan parallel + two inner index probes -> mergeable list';
--- order by a non-indexed t1 column so the driving t1 stays a heap scan (parallel)
-select /*+ recompile ordered */ t1.col2, t2.id, t3.id from t1, t2, t3 where t1.id = t2.id and t2.id = t3.id order by 1, 2;
+-- order by a non-indexed ta column so the driving ta stays a heap scan (parallel)
+select /*+ recompile ordered */ ta.colb, tb.id, tc.id from ta, tb, tc where ta.id = tb.id and tb.id = tc.id order by 1, 2;
 show trace;
 -- serial reference: result must match the parallel block above
-select /*+ recompile ordered no_parallel_scan */ t1.col2, t2.id, t3.id from t1, t2, t3 where t1.id = t2.id and t2.id = t3.id order by 1, 2;
+select /*+ recompile ordered no_parallel_scan */ ta.colb, tb.id, tc.id from ta, tb, tc where ta.id = tb.id and tb.id = tc.id order by 1, 2;
 show trace;
 
 
 evaluate 'Case 9: GROUP BY over NL join -> mergeable list';
-select /*+ recompile ordered */ t1.col2, count(*) from t1, t2 where t1.id = t2.id group by t1.col2 order by 1;
+select /*+ recompile ordered */ ta.colb, count(*) from ta, tb where ta.id = tb.id group by ta.colb order by 1;
 show trace;
 -- serial reference: result must match the parallel block above
-select /*+ recompile ordered no_parallel_scan */ t1.col2, count(*) from t1, t2 where t1.id = t2.id group by t1.col2 order by 1;
+select /*+ recompile ordered no_parallel_scan */ ta.colb, count(*) from ta, tb where ta.id = tb.id group by ta.colb order by 1;
 show trace;
 
 
 evaluate 'Case 10: explicit PARALLEL(2) hint on NL join -> mergeable list';
--- order by the inner-table key so the driving t1 stays a heap scan (parallel)
-select /*+ recompile ordered parallel(2) */ t2.id, t1.col2 from t1, t2 where t1.id = t2.id order by 1;
+-- order by the inner-table key so the driving ta stays a heap scan (parallel)
+select /*+ recompile ordered parallel(2) */ tb.id, ta.colb from ta, tb where ta.id = tb.id order by 1;
 show trace;
 -- serial reference: result must match the parallel block above
-select /*+ recompile ordered no_parallel_scan */ t2.id, t1.col2 from t1, t2 where t1.id = t2.id order by 1;
+select /*+ recompile ordered no_parallel_scan */ tb.id, ta.colb from ta, tb where ta.id = tb.id order by 1;
 show trace;
 
 
 evaluate 'Case 11: first(driving) table is a set collection, not parallel-heap-scannable (cannot parallelize #1) -> not parallelized';
 -- the driving spec is a set (not a class heap scan), so the NL join is not parallelized
 -- (no "parallel workers" line under the driving scan)
-select /*+ recompile ordered */ x.v, t1.id from table({1,2,3}) as x(v), t1 where t1.id = x.v order by 1, 2;
+select /*+ recompile ordered */ x.v, ta.id from table({1,2,3}) as x(v), ta where ta.id = x.v order by 1, 2;
 show trace;
 
 
-drop table if exists t1, t2, t3;
+drop table if exists ta, tb, tc;

--- a/sql/_36_guava/cbrd_26522/cases/cbrd_26522.sql
+++ b/sql/_36_guava/cbrd_26522/cases/cbrd_26522.sql
@@ -4,11 +4,11 @@
  *
  *  Parallel heap scan is enabled automatically here: CTP runs SQL tests with
  *  test_mode=yes, which lowers parallel_scan_page_threshold from its default
- *  (2048) to 32. ta below is ~4000 rows (> 32 heap pages), so its heap scan is
- *  executed in parallel and the NL join is evaluated inside each parallel worker.
- *  The (parallel workers: ...) line and the "gather:" mode in "show trace" show
- *  whether the driving heap scan ran in parallel and how results were gathered
- *  (mergeable list / buildvalue / row by row).
+ *  (2048) to 32. ta below is ~8000 rows (comfortably > 32 heap pages), so its
+ *  heap scan is executed in parallel and the NL join is evaluated inside each
+ *  parallel worker. The (parallel workers: ...) line and the "gather:" mode in
+ *  "show trace" show whether the driving heap scan ran in parallel and how
+ *  results were gathered (mergeable list / buildvalue / row by row).
  *
  *  Note: table/column names use letters (ta/tb/tc, cola..colf), not digits,
  *  because CTP masks digits in the trace output to '?' -- digit-named objects
@@ -19,10 +19,11 @@
  *  hint (serial). Both result blocks must be identical -- this proves the
  *  parallel NL join produces no missing/duplicate rows (and the parallel
  *  buildvalue aggregate matches the serial count), and makes answer
- *  regeneration self-checking.
+ *  regeneration self-checking. The row-by-row fallback cases (4/5/6) and the
+ *  empty-input case (13) carry the same serial cross-check.
  *
  *  The four "cannot parallelize NL join" conditions from the issue are all covered:
- *    #1 first(driving) table not parallel-heap-scannable -> Case 11
+ *    #1 first(driving) table not parallel-heap-scannable -> Case 11 (set spec), Case 12 (below page threshold)
  *    #2 JAVASP (stored procedure)                        -> Case 4
  *    #3 trailing table scan spec is set                  -> Case 5
  *    #4 trailing table contains a JSON_TABLE scan        -> Case 6
@@ -31,25 +32,27 @@
  *    Case 1:  simple NL join            -> mergeable list  (+ serial twin)
  *    Case 2:  outer(left) NL join count -> buildvalue (count only)  (+ serial twin)
  *    Case 3:  cross join                -> mergeable list  (+ serial twin)
- *    Case 4:  SP on the 2nd table       -> row by row (cannot parallelize #2)
- *    Case 5:  2nd table scan spec = set -> row by row (cannot parallelize #3)
- *    Case 6:  2nd table JSON_TABLE scan -> row by row (cannot parallelize #4)
+ *    Case 4:  SP on the 2nd table       -> row by row (cannot parallelize #2)  (+ serial twin)
+ *    Case 5:  2nd table scan spec = set -> row by row (cannot parallelize #3)  (+ serial twin)
+ *    Case 6:  2nd table JSON_TABLE scan -> row by row (cannot parallelize #4)  (+ serial twin)
  *    Case 7:  natural left join         -> mergeable list  (+ serial twin, CBRD-26596 shape)
  *    Case 8:  3-way NL join             -> mergeable list  (+ serial twin)
  *    Case 9:  GROUP BY over NL join     -> mergeable list  (+ serial twin)
  *    Case 10: explicit PARALLEL(2) hint -> mergeable list  (+ serial twin)
- *    Case 11: first(driving) table = set collection -> not parallel-heap-scannable (cannot parallelize #1)
+ *    Case 11: first(driving) table = set collection -> not heap-scannable (cannot parallelize #1)
+ *    Case 12: driving heap table below page threshold -> not parallelized (cannot parallelize #1)
+ *    Case 13: parallel NL join with empty driving result -> no phantom rows  (+ serial twin)
  */
 
 drop table if exists ta, tb, tc;
 create table ta (id int primary key, cola varchar(20), colb varchar(20), colc varchar(20), cold varchar(20), cole varchar(20), colf varchar(20));
-create table tb (id int primary key);
+create table tb (id int primary key, val int);
 create table tc (id int primary key);
 
 insert into ta
 select rownum, lpad(rownum,20,'0'), lpad(rownum % 5,20,'0'), lpad(rownum,20,'0'), lpad(rownum,20,'0'), lpad(rownum,20,'0'), lpad(rownum,20,'0')
-from db_class a, db_class b, db_class c, db_class d, db_class e limit 4000;
-insert into tb select rownum from db_class limit 5;
+from db_class a, db_class b, db_class c, db_class d, db_class e limit 8000;
+insert into tb select rownum, rownum from db_class limit 5;
 insert into tc select rownum from db_class limit 3;
 
 set trace on;
@@ -64,10 +67,10 @@ show trace;
 
 
 evaluate 'Case 2: outer(left) NL join, count only -> buildvalue';
-select /*+ recompile */ count(tb.id) from ta left join tb on ta.id = tb.id where ta.cola < 6;
+select /*+ recompile */ count(tb.id) from ta left join tb on ta.id = tb.id where cast(ta.cola as int) < 6;
 show trace;
 -- serial reference: result must match the parallel block above
-select /*+ recompile no_parallel_scan */ count(tb.id) from ta left join tb on ta.id = tb.id where ta.cola < 6;
+select /*+ recompile no_parallel_scan */ count(tb.id) from ta left join tb on ta.id = tb.id where cast(ta.cola as int) < 6;
 show trace;
 
 
@@ -88,6 +91,9 @@ end;
 
 select /*+ recompile ordered */ sp_inc(tb.id) from ta join tb on ta.id = tb.id order by 1;
 show trace;
+-- serial reference: result must match the parallel block above
+select /*+ recompile ordered no_parallel_scan */ sp_inc(tb.id) from ta join tb on ta.id = tb.id order by 1;
+show trace;
 
 drop function sp_inc;
 
@@ -95,10 +101,19 @@ drop function sp_inc;
 evaluate 'Case 5: 2nd table scan spec is set (cannot parallelize #3) -> row by row';
 select /*+ recompile ordered */ ta.id, tset.v from ta, table({1,2,3}) as tset(v) where cast(ta.cola as int) < 2 order by 1, 2;
 show trace;
+-- serial reference: result must match the parallel block above
+select /*+ recompile ordered no_parallel_scan */ ta.id, tset.v from ta, table({1,2,3}) as tset(v) where cast(ta.cola as int) < 2 order by 1, 2;
+show trace;
 
 
 evaluate 'Case 6: 2nd table JSON_TABLE scan (cannot parallelize #4) -> row by row';
 select /*+ recompile ordered */ ta.id, jt.col
+from ta, json_table('{"a":[1,[2,3]]}', '$.a[*]' columns (col int path '$')) as jt
+where cast(ta.cola as int) < 2 and ta.id = jt.col
+order by 1, 2;
+show trace;
+-- serial reference: result must match the parallel block above
+select /*+ recompile ordered no_parallel_scan */ ta.id, jt.col
 from ta, json_table('{"a":[1,[2,3]]}', '$.a[*]' columns (col int path '$')) as jt
 where cast(ta.cola as int) < 2 and ta.id = jt.col
 order by 1, 2;
@@ -143,6 +158,26 @@ evaluate 'Case 11: first(driving) table is a set collection, not parallel-heap-s
 -- the driving spec is a set (not a class heap scan), so the NL join is not parallelized
 -- (no "parallel workers" line under the driving scan)
 select /*+ recompile ordered */ x.v, ta.id from table({1,2,3}) as x(v), ta where ta.id = x.v order by 1, 2;
+show trace;
+
+
+evaluate 'Case 12: driving heap table below parallel_scan_page_threshold (cannot parallelize #1) -> not parallelized';
+-- tb is a heap-scannable class but only 5 rows (heap pages < threshold 32), so even
+-- as a class heap scan the driving scan must NOT be parallelized (no "parallel workers"
+-- line under the driving scan). This differs from Case 11, where the driving spec (a set
+-- collection) is not heap-scannable at all. tb.val (non-indexed) is selected to force a
+-- heap scan on the small driving table instead of a covered index scan.
+select /*+ recompile ordered */ tb.val, ta.id from tb, ta where tb.id = ta.id order by 1, 2;
+show trace;
+
+
+evaluate 'Case 13: parallel NL join with empty driving result -> no phantom rows';
+-- the sarg eliminates every driving row inside the parallel workers; both blocks must
+-- return 0 rows (proves parallel gather adds no phantom/duplicate rows on empty input)
+select /*+ recompile ordered */ tb.id from ta, tb where ta.id = tb.id and cast(ta.cola as int) < 1 order by 1;
+show trace;
+-- serial reference: result must match the parallel block above
+select /*+ recompile ordered no_parallel_scan */ tb.id from ta, tb where ta.id = tb.id and cast(ta.cola as int) < 1 order by 1;
 show trace;
 
 

--- a/sql/_36_guava/cbrd_26522/cases/cbrd_26522.sql
+++ b/sql/_36_guava/cbrd_26522/cases/cbrd_26522.sql
@@ -1,0 +1,145 @@
+/**
+ *  This test case verifies CBRD-26522 : Support NL join during parallel heap scan
+ *  (follow-up of CBRD-25447 : Support parallel heap scan)
+ *
+ *  Parallel heap scan is enabled automatically here: CTP runs SQL tests with
+ *  test_mode=yes, which lowers parallel_scan_page_threshold from its default
+ *  (2048) to 32. t1 below is ~4000 rows (> 32 heap pages), so its heap scan is
+ *  executed in parallel and the NL join is evaluated inside each parallel worker.
+ *  The (parallel workers: ...) line and the "gather:" mode in "show trace" show
+ *  whether the driving heap scan ran in parallel and how results were gathered
+ *  (mergeable list / buildvalue / row by row).
+ *
+ *  Correctness: every parallel case (mergeable list and the buildvalue/count
+ *  case) runs the parallel query AND the same query with the NO_PARALLEL_SCAN
+ *  hint (serial). Both result blocks must be identical -- this proves the
+ *  parallel NL join produces no missing/duplicate rows (and the parallel
+ *  buildvalue aggregate matches the serial count), and makes answer
+ *  regeneration self-checking.
+ *
+ *  The four "cannot parallelize NL join" conditions from the issue are all covered:
+ *    #1 first(driving) table not parallel-heap-scannable -> Case 11
+ *    #2 JAVASP (stored procedure)                        -> Case 4
+ *    #3 trailing table scan spec is set                  -> Case 5
+ *    #4 trailing table contains a JSON_TABLE scan        -> Case 6
+ *
+ *  Coverage:
+ *    Case 1:  simple NL join            -> mergeable list  (+ serial twin)
+ *    Case 2:  outer(left) NL join count -> buildvalue (count only)  (+ serial twin)
+ *    Case 3:  cross join                -> mergeable list  (+ serial twin)
+ *    Case 4:  SP on the 2nd table       -> row by row (cannot parallelize #2)
+ *    Case 5:  2nd table scan spec = set -> row by row (cannot parallelize #3)
+ *    Case 6:  2nd table JSON_TABLE scan -> row by row (cannot parallelize #4)
+ *    Case 7:  natural left join         -> mergeable list  (+ serial twin, CBRD-26596 shape)
+ *    Case 8:  3-way NL join             -> mergeable list  (+ serial twin)
+ *    Case 9:  GROUP BY over NL join     -> mergeable list  (+ serial twin)
+ *    Case 10: explicit PARALLEL(2) hint -> mergeable list  (+ serial twin)
+ *    Case 11: first(driving) table = set collection -> not parallel-heap-scannable (cannot parallelize #1)
+ */
+
+drop table if exists t1, t2, t3;
+create table t1 (id int primary key, col1 varchar(20), col2 varchar(20), col3 varchar(20), col4 varchar(20), col5 varchar(20), col6 varchar(20));
+create table t2 (id int primary key);
+create table t3 (id int primary key);
+
+insert into t1
+select rownum, lpad(rownum,20,'0'), lpad(rownum % 5,20,'0'), lpad(rownum,20,'0'), lpad(rownum,20,'0'), lpad(rownum,20,'0'), lpad(rownum,20,'0')
+from db_class a, db_class b, db_class c, db_class d, db_class e limit 4000;
+insert into t2 select rownum from db_class limit 5;
+insert into t3 select rownum from db_class limit 3;
+
+set trace on;
+
+
+evaluate 'Case 1: simple NL join (driving heap scan) -> mergeable list';
+select /*+ recompile ordered */ t2.id from t1, t2 where t1.id = t2.id order by 1;
+show trace;
+-- serial reference: result must match the parallel block above
+select /*+ recompile ordered no_parallel_scan */ t2.id from t1, t2 where t1.id = t2.id order by 1;
+show trace;
+
+
+evaluate 'Case 2: outer(left) NL join, count only -> buildvalue';
+select /*+ recompile */ count(t2.id) from t1 left join t2 on t1.id = t2.id where t1.col1 < 6;
+show trace;
+-- serial reference: result must match the parallel block above
+select /*+ recompile no_parallel_scan */ count(t2.id) from t1 left join t2 on t1.id = t2.id where t1.col1 < 6;
+show trace;
+
+
+evaluate 'Case 3: cross join -> mergeable list';
+select /*+ recompile ordered */ t1.id, t2.id from t1, t2 where cast(t1.col1 as int) < 2 order by 1, 2;
+show trace;
+-- serial reference: result must match the parallel block above
+select /*+ recompile ordered no_parallel_scan */ t1.id, t2.id from t1, t2 where cast(t1.col1 as int) < 2 order by 1, 2;
+show trace;
+
+
+evaluate 'Case 4: SP on the 2nd table (cannot parallelize #2) -> row by row';
+create or replace function sp1(n integer) return integer deterministic
+is
+begin
+    return n + 1;
+end;
+
+select /*+ recompile ordered */ sp1(t2.id) from t1 join t2 on t1.id = t2.id order by 1;
+show trace;
+
+drop function sp1;
+
+
+evaluate 'Case 5: 2nd table scan spec is set (cannot parallelize #3) -> row by row';
+select /*+ recompile ordered */ t1.id, tset.v from t1, table({1,2,3}) as tset(v) where cast(t1.col1 as int) < 2 order by 1, 2;
+show trace;
+
+
+evaluate 'Case 6: 2nd table JSON_TABLE scan (cannot parallelize #4) -> row by row';
+select /*+ recompile ordered */ t1.id, jt.col
+from t1, json_table('{"a":[1,[2,3]]}', '$.a[*]' columns (col int path '$')) as jt
+where cast(t1.col1 as int) < 2 and t1.id = jt.col
+order by 1, 2;
+show trace;
+
+
+evaluate 'Case 7: natural left join, outer heap scan + inner index scan (CBRD-26596 shape) -> mergeable list';
+select /*+ recompile */ t1.id, t1.col1, t2.id from t1 natural left join t2 where cast(t1.col1 as int) <= 10 order by 1, 2, 3;
+show trace;
+-- serial reference: result must match the parallel block above
+select /*+ recompile no_parallel_scan */ t1.id, t1.col1, t2.id from t1 natural left join t2 where cast(t1.col1 as int) <= 10 order by 1, 2, 3;
+show trace;
+
+
+evaluate 'Case 8: 3-way NL join, driving heap scan parallel + two inner index probes -> mergeable list';
+-- order by a non-indexed t1 column so the driving t1 stays a heap scan (parallel)
+select /*+ recompile ordered */ t1.col2, t2.id, t3.id from t1, t2, t3 where t1.id = t2.id and t2.id = t3.id order by 1, 2;
+show trace;
+-- serial reference: result must match the parallel block above
+select /*+ recompile ordered no_parallel_scan */ t1.col2, t2.id, t3.id from t1, t2, t3 where t1.id = t2.id and t2.id = t3.id order by 1, 2;
+show trace;
+
+
+evaluate 'Case 9: GROUP BY over NL join -> mergeable list';
+select /*+ recompile ordered */ t1.col2, count(*) from t1, t2 where t1.id = t2.id group by t1.col2 order by 1;
+show trace;
+-- serial reference: result must match the parallel block above
+select /*+ recompile ordered no_parallel_scan */ t1.col2, count(*) from t1, t2 where t1.id = t2.id group by t1.col2 order by 1;
+show trace;
+
+
+evaluate 'Case 10: explicit PARALLEL(2) hint on NL join -> mergeable list';
+-- order by the inner-table key so the driving t1 stays a heap scan (parallel)
+select /*+ recompile ordered parallel(2) */ t2.id, t1.col2 from t1, t2 where t1.id = t2.id order by 1;
+show trace;
+-- serial reference: result must match the parallel block above
+select /*+ recompile ordered no_parallel_scan */ t2.id, t1.col2 from t1, t2 where t1.id = t2.id order by 1;
+show trace;
+
+
+evaluate 'Case 11: first(driving) table is a set collection, not parallel-heap-scannable (cannot parallelize #1) -> not parallelized';
+-- the driving spec is a set (not a class heap scan), so the NL join is not parallelized
+-- (no "parallel workers" line under the driving scan)
+select /*+ recompile ordered */ x.v, t1.id from table({1,2,3}) as x(v), t1 where t1.id = x.v order by 1, 2;
+show trace;
+
+
+drop table if exists t1, t2, t3;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26522

## Purpose

CBRD-26522(Support NL join during parallel heap scan)의 동작을 검증하는 신규 SQL 테스트케이스를 추가합니다.

기존에는 join driving 테이블이 heap scan인 경우 NL join을 row-by-row로 중앙 처리하여 성능이 저하됐으나, CBRD-26522에서 각 parallel heap scan thread가 NL join을 평가·수집(mergeable-list / count-only)하도록 개선되었습니다. 본 테스트케이스는 이 기능이 다양한 조인 형태에서 올바르게 병렬화되는지, 그리고 병렬화가 불가능한 조건에서는 정확히 fallback 되는지를 `show trace`의 `gather:` 모드로 검증합니다.

## Scenario coverage (11 cases)

병렬 heap scan 하에서 NL join의 `gather:` 모드를 검증합니다.

| Case | 시나리오 | 기대 동작 |
|---|---|---|
| 1  | 단순 NL join (driving heap scan) | 병렬, `gather: mergeable list` |
| 2  | outer(left) NL join, count only | 병렬, `gather: buildvalue` |
| 3  | cross join | 병렬, `gather: mergeable list` |
| 4  | 후행 테이블에 SP(JAVASP) 포함 | `gather: row by row` (병렬 불가 ②) |
| 5  | 후행 테이블 scan spec이 set | `gather: row by row` (병렬 불가 ③) |
| 6  | 후행 테이블에 JSON_TABLE 스캔 | `gather: row by row` (병렬 불가 ④) |
| 7  | natural left join (outer heap scan + inner index scan) | 병렬, `gather: mergeable list` |
| 8  | 3-way NL join | 병렬, `gather: mergeable list` |
| 9  | GROUP BY over NL join | 병렬, `gather: mergeable list` |
| 10 | 명시적 `PARALLEL(2)` 힌트 | 병렬, `gather: mergeable list` |
| 11 | 첫(driving) 테이블이 set 컬렉션 | 병렬화 안 됨 (병렬 불가 ①) |

이슈에 명시된 **"parallel heap scan 시 NL join을 수행할 수 없는 경우" 4개 조건을 모두 커버**합니다.

- ① 첫 번째(driving) 테이블을 parallel heap scan 할 수 없는 경우 → Case 11
- ② JAVASP를 사용하는 경우 → Case 4
- ③ nljoin 후행 테이블의 scan spec이 set일 경우 → Case 5
- ④ nljoin 후행 테이블에 JSON_TABLE 스캔이 포함된 경우 → Case 6

## Correctness verification

병렬이 실제로 적용되는 모든 케이스(mergeable list 6개 + buildvalue 1개)는 동일 쿼리를 **병렬**과 **`NO_PARALLEL_SCAN`(직렬)** 로 각각 수행하고, 두 결과 블록이 답지에 나란히 고정됩니다. 두 블록은 반드시 동일해야 하므로:

- 병렬 NL join 수집 시 행 누락/중복이 없음을 보장
- 병렬 buildvalue 집계 결과 = 직렬 count 임을 보장
- 향후 답지 재생성 시 병렬 경로가 잘못된 값을 내면 두 블록 불일치로 즉시 드러남(자기검증)

## Notes

- **병렬 활성화**: 별도 파라미터 설정 없이 CTP의 `test_mode=yes`가 `parallel_scan_page_threshold`를 기본 2048 → 32로 낮추므로, ~4000행(> 32 heap page) 테이블에서 parallel heap scan이 자동 동작합니다(부모 테스트 cbrd_25447과 동일 방식).
- **`gather: buildvalue`**: CBRD-26522 병합 당시 trace 표기는 `count`였으나 이후 CBRD-26711(avg/sum 지원)에서 `buildvalue`로 개명되었습니다. 본 답지는 현재 develop 빌드 기준으로 생성되어 `buildvalue`로 표기됩니다.
- **미포함**: `nlj_keep_heap_page_pinned` 힌트는 이후 CBRD-26905에서 제거되어 사용하지 않았습니다.