### PR TITLE
[CBRD-26670] Add sql testcase for session-variable-in-analytic crash cases to the parallel uncorrelated subquery

### DIFF
--- a/sql/_36_guava/cbrd_26104/answers/cbrd_26104.answer
+++ b/sql/_36_guava/cbrd_26104/answers/cbrd_26104.answer
@@ -961,10 +961,10 @@ Trace Statistics:
              (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.tbl_a), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.tbl_b), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================

--- a/sql/_36_guava/cbrd_26104/answers/cbrd_26104.answer
+++ b/sql/_36_guava/cbrd_26104/answers/cbrd_26104.answer
@@ -1137,7 +1137,7 @@ Trace Statistics:
 ===================================================
 0
 ===================================================
-1
+6
 ===================================================
     
 CBRD-26670: session var wrapping an analytic function (original repro) - should not crash     
@@ -1145,6 +1145,8 @@ CBRD-26670: session var wrapping an analytic function (original repro) - should 
 ===================================================
 @v := count(b) over (partition by a+a order by b+b)    
 1     
+2     
+3     
 
 ===================================================
 trace    
@@ -1176,6 +1178,8 @@ CBRD-26670: session var inside the analytic argument - should not crash
 ===================================================
 count(@v := b) over (partition by a order by b)    
 1     
+2     
+3     
 
 ===================================================
 trace    
@@ -1207,6 +1211,8 @@ CBRD-26670: session var in the analytic PARTITION BY - should not crash
 ===================================================
 count(b) over (partition by @v := a order by b)    
 1     
+2     
+3     
 
 ===================================================
 trace    
@@ -1238,6 +1244,8 @@ CBRD-26670: session var in the analytic window ORDER BY - should not crash
 ===================================================
 count(b) over (partition by a order by @v := b)    
 1     
+2     
+3     
 
 ===================================================
 trace    
@@ -1269,6 +1277,8 @@ CBRD-26670: NO_PARALLEL_SUBQUERY (serial) control - should not crash
 ===================================================
 @v := count(b) over (partition by a+a order by b+b)    
 1     
+2     
+3     
 
 ===================================================
 trace    

--- a/sql/_36_guava/cbrd_26104/answers/cbrd_26104.answer
+++ b/sql/_36_guava/cbrd_26104/answers/cbrd_26104.answer
@@ -1132,3 +1132,166 @@ Trace Statistics:
 
 ===================================================
 0
+===================================================
+0
+===================================================
+0
+===================================================
+1
+===================================================
+    
+CBRD-26670: session var wrapping an analytic function (original repro) - should not crash     
+
+===================================================
+@v := count(b) over (partition by a+a order by b+b)    
+1     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.zt)
+
+  rewritten query: select @v := count([dba.zt].b) over (partition by ? order by ?) from [dba.zt] [dba.zt]
+
+  TABLE SCAN (dba.zt)
+
+  rewritten query: select @v := count([dba.zt].b) over (partition by ? order by ?) from [dba.zt] [dba.zt]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.zt), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.zt), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+CBRD-26670: session var inside the analytic argument - should not crash     
+
+===================================================
+count(@v := b) over (partition by a order by b)    
+1     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.zt)
+
+  rewritten query: select count(@v := [dba.zt].b) over (partition by ? order by ?) from [dba.zt] [dba.zt]
+
+  TABLE SCAN (dba.zt)
+
+  rewritten query: select count(@v := [dba.zt].b) over (partition by ? order by ?) from [dba.zt] [dba.zt]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.zt), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.zt), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+CBRD-26670: session var in the analytic PARTITION BY - should not crash     
+
+===================================================
+count(b) over (partition by @v := a order by b)    
+1     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.zt)
+
+  rewritten query: select count([dba.zt].b) over (partition by ? order by ?) from [dba.zt] [dba.zt]
+
+  TABLE SCAN (dba.zt)
+
+  rewritten query: select count([dba.zt].b) over (partition by ? order by ?) from [dba.zt] [dba.zt]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.zt), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.zt), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+CBRD-26670: session var in the analytic window ORDER BY - should not crash     
+
+===================================================
+count(b) over (partition by a order by @v := b)    
+1     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.zt)
+
+  rewritten query: select count([dba.zt].b) over (partition by ? order by ?) from [dba.zt] [dba.zt]
+
+  TABLE SCAN (dba.zt)
+
+  rewritten query: select count([dba.zt].b) over (partition by ? order by ?) from [dba.zt] [dba.zt]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.zt), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.zt), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+CBRD-26670: NO_PARALLEL_SUBQUERY (serial) control - should not crash     
+
+===================================================
+@v := count(b) over (partition by a+a order by b+b)    
+1     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.zt)
+
+  rewritten query: select /*+ NO_PARALLEL_SUBQUERY */ @v := count([dba.zt].b) over (partition by ? order by ?) from [dba.zt] [dba.zt]
+
+  TABLE SCAN (dba.zt)
+
+  rewritten query: select /*+ NO_PARALLEL_SUBQUERY */ @v := count([dba.zt].b) over (partition by ? order by ?) from [dba.zt] [dba.zt]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.zt), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.zt), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+0

--- a/sql/_36_guava/cbrd_26104/cases/cbrd_26104.sql
+++ b/sql/_36_guava/cbrd_26104/cases/cbrd_26104.sql
@@ -214,7 +214,9 @@ drop table if exists tta, ttb, ttc, ttd;
 -- NO_PARALLEL_SUBQUERY (serial) control. All must run without crashing.
 drop table if exists zt;
 create table zt (a int, b int);
-insert into zt values (1, 1);
+-- multiple partitions (a=1,2,3) with several rows each so the analytic actually
+-- forms partition boundaries and slides frames (greptile P2: single-row data)
+insert into zt values (1, 1), (1, 2), (1, 3), (2, 4), (2, 5), (3, 6);
 
 evaluate 'CBRD-26670: session var wrapping an analytic function (original repro) - should not crash';
 (select @v:=count(b) over (partition by a+a order by b+b) from zt)

--- a/sql/_36_guava/cbrd_26104/cases/cbrd_26104.sql
+++ b/sql/_36_guava/cbrd_26104/cases/cbrd_26104.sql
@@ -1,4 +1,4 @@
--- Verification for CBRD-26104, CBRD-26200, CBRD-26206, CBRD-26178
+-- Verification for CBRD-26104, CBRD-26200, CBRD-26206, CBRD-26178, CBRD-26670
 -- Check if uncorrelated subqueries(inline view) are executed in parallel.
 -- Check if queries are executed in the usual way when parallel execution is not possible.
 -- NO_PARALLEL_SUBQUERY hint is used to disable parallel execution of uncorrelated subqueries.
@@ -205,3 +205,45 @@ where (select ca from ttd) > 0 and tta.ca = ttb.ca and ttb.ca = ttc.ca;
 show trace;
 
 drop table if exists tta, ttb, ttc, ttd;
+
+-- CBRD-26670: a session variable evaluated inside an analytic (window) function
+-- slips past the guard that blocks session-variable evaluation in parallel
+-- uncorrelated subqueries -> segmentation fault before the fix. Cover the
+-- session variable in each position the detection must recurse into (wrapping
+-- the analytic, the analytic argument, PARTITION BY, window ORDER BY), plus a
+-- NO_PARALLEL_SUBQUERY (serial) control. All must run without crashing.
+drop table if exists zt;
+create table zt (a int, b int);
+insert into zt values (1, 1);
+
+evaluate 'CBRD-26670: session var wrapping an analytic function (original repro) - should not crash';
+(select @v:=count(b) over (partition by a+a order by b+b) from zt)
+union
+(select @v:=count(b) over (partition by a+a order by b+b) from zt);
+show trace;
+
+evaluate 'CBRD-26670: session var inside the analytic argument - should not crash';
+(select count(@v:=b) over (partition by a order by b) from zt)
+union
+(select count(@v:=b) over (partition by a order by b) from zt);
+show trace;
+
+evaluate 'CBRD-26670: session var in the analytic PARTITION BY - should not crash';
+(select count(b) over (partition by @v:=a order by b) from zt)
+union
+(select count(b) over (partition by @v:=a order by b) from zt);
+show trace;
+
+evaluate 'CBRD-26670: session var in the analytic window ORDER BY - should not crash';
+(select count(b) over (partition by a order by @v:=b) from zt)
+union
+(select count(b) over (partition by a order by @v:=b) from zt);
+show trace;
+
+evaluate 'CBRD-26670: NO_PARALLEL_SUBQUERY (serial) control - should not crash';
+(select /*+ NO_PARALLEL_SUBQUERY */ @v:=count(b) over (partition by a+a order by b+b) from zt)
+union
+(select /*+ NO_PARALLEL_SUBQUERY */ @v:=count(b) over (partition by a+a order by b+b) from zt);
+show trace;
+
+drop table if exists zt;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26670

### Summary

CBRD-26670(병렬 부질의 실행 시 세션변수를 분석함수 안에서 평가할 경우 crash)의 회귀 검증을 추가합니다.

버그: UNION 등으로 만들어진 **parallel uncorrelated subquery**의 SELECT 리스트에서 세션 변수(`@v`)가 **analytic(window) 함수 안에서** 평가되면, 세션 변수 평가를 차단하는 guard의 탐지 로직을 우회해 병렬 경로로 진입하고, thread-unsafe한 세션 변수 접근으로 **segmentation fault**가 발생합니다. Fix는 analytic 함수 내부의 세션 변수까지 탐지하도록 guard를 보완해 병렬 실행을 안전하게 차단합니다.

CBRD-26670은 **CBRD-26104(Parallel uncorrelated subquery)의 sub-task**이므로, 별도 TC를 만들지 않고 부모 이슈의 기존 SQL 테스트케이스에 케이스를 추가합니다. 이 파일은 이미 관련 이슈(CBRD-26104/26200/26206/26178)를 한곳에서 검증하고 있으며, 세그폴트 회귀 케이스(CBRD-26178/26206)도 동일한 방식으로 포함되어 있습니다.

```
sql/_36_guava/cbrd_26104/cases/cbrd_26104.sql      (+5 cases)
sql/_36_guava/cbrd_26104/answers/cbrd_26104.answer (regenerated)
```

### 추가한 케이스 (5)

세션 변수가 analytic 관련 구문의 **어느 위치**에 있어도 guard가 탐지하는지(수정된 재귀 탐지) + 직렬 경로 안전성을 커버합니다.

| # | 케이스 | 세션 변수 위치 |
|---|---|---|
| 1 | 원 repro | analytic을 감싸는 대입 `@v := count(b) over (...)` |
| 2 | analytic 인자 내부 | `count(@v := b) over (...)` |
| 3 | 윈도우 PARTITION BY | `over (partition by @v := a ...)` |
| 4 | 윈도우 ORDER BY | `over (... order by @v := b)` |
| 5 | 직렬 control | `NO_PARALLEL_SUBQUERY` 힌트로 직렬 실행 |

모든 케이스가 UNION 형태의 uncorrelated subquery로 구성되어 병렬 경로 판단을 거칩니다. 기대: **crash 없이 정상 실행**(fix 후 guard가 병렬을 차단 → 직렬 안전 실행).
