### PR TITLE
[CBRD-26473] Add SQL test case for analytic function sort skipping

### DIFF
--- a/sql/_36_guava/cbrd_26473/answers/cbrd_26473.answer
+++ b/sql/_36_guava/cbrd_26473/answers/cbrd_26473.answer
@@ -5344,3 +5344,231 @@ joined_cnt    bad_a1    bad_a2
 
 ===================================================
 0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+1000
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+1000
+===================================================
+0
+===================================================
+    
+104. ORDER BY only, order key is a prefix of midx_01(val,id) - sort skipped     
+
+===================================================
+val    rn    
+0     1     
+0     2     
+0     3     
+0     4     
+0     5     
+0     6     
+0     7     
+0     8     
+0     9     
+0     10     
+0     11     
+0     12     
+0     13     
+0     14     
+0     15     
+0     16     
+0     17     
+0     18     
+0     19     
+0     20     
+0     21     
+0     22     
+0     23     
+0     24     
+0     25     
+0     26     
+0     27     
+0     28     
+0     29     
+0     30     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].val, row_number() over (order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+105. ORDER BY only, order key is the full index key (val, id) - sort skipped     
+
+===================================================
+val    id    rn    
+0     10     1     
+0     20     2     
+0     30     3     
+0     40     4     
+0     50     5     
+0     60     6     
+0     70     7     
+0     80     8     
+0     90     9     
+0     100     10     
+0     110     11     
+0     120     12     
+0     130     13     
+0     140     14     
+0     150     15     
+0     160     16     
+0     170     17     
+0     180     18     
+0     190     19     
+0     200     20     
+0     210     21     
+0     220     22     
+0     230     23     
+0     240     24     
+0     250     25     
+0     260     26     
+0     270     27     
+0     280     28     
+0     290     29     
+0     300     30     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].val, [dba.test_table].id, row_number() over (order by ?, ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+106. ORDER BY only, mixed ASC/DESC key (val, id desc) the ASC index cannot supply - sort required     
+
+===================================================
+val    id    rn    
+0     1000     1     
+0     990     2     
+0     980     3     
+0     970     4     
+0     960     5     
+0     950     6     
+0     940     7     
+0     930     8     
+0     920     9     
+0     910     10     
+0     900     11     
+0     890     12     
+0     880     13     
+0     870     14     
+0     860     15     
+0     850     16     
+0     840     17     
+0     830     18     
+0     820     19     
+0     810     20     
+0     800     21     
+0     790     22     
+0     780     23     
+0     770     24     
+0     760     25     
+0     750     26     
+0     740     27     
+0     730     28     
+0     720     29     
+0     710     30     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].val, [dba.test_table].id, row_number() over (order by ?, ? desc ) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+107. ORDER BY only, NULLS FIRST matches the ASC index default (NULLs stored first) - sort skipped     
+
+===================================================
+val    rn    
+null     1     
+null     2     
+null     3     
+null     4     
+null     5     
+null     6     
+null     7     
+null     8     
+null     9     
+null     10     
+null     11     
+null     12     
+null     13     
+null     14     
+null     15     
+null     16     
+null     17     
+null     18     
+null     19     
+null     20     
+null     21     
+null     22     
+null     23     
+null     24     
+null     25     
+null     26     
+null     27     
+null     28     
+null     29     
+null     30     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table_null.nidx_?) (key range: ([dba.test_table_null].id>= ?:? ), covered: true)
+
+  rewritten query: select /*+ INDEX_SS */ [dba.test_table_null].val, row_number() over (order by ? nulls first ) from [dba.test_table_null] [dba.test_table_null] where ([dba.test_table_null].id>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table_null].nidx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table_null.nidx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+0
+===================================================
+0
+===================================================
+0

--- a/sql/_36_guava/cbrd_26473/answers/cbrd_26473.answer
+++ b/sql/_36_guava/cbrd_26473/answers/cbrd_26473.answer
@@ -56,7 +56,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -107,8 +107,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -159,8 +160,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -212,7 +214,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -263,7 +267,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -314,8 +318,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -366,8 +371,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -419,7 +425,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -470,7 +478,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -521,8 +529,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -573,8 +582,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -626,7 +636,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -677,7 +689,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -728,8 +740,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -780,8 +793,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -833,7 +847,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -884,7 +900,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?) (stopkey)
      
 
 ===================================================
@@ -935,8 +951,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -987,8 +1004,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -1040,7 +1058,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -1091,7 +1111,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?) (stopkey)
      
 
 ===================================================
@@ -1142,8 +1162,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -1194,8 +1215,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -1247,7 +1269,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -1298,7 +1322,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?) (stopkey)
      
 
 ===================================================
@@ -1349,8 +1373,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -1401,8 +1426,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -1454,7 +1480,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -1505,7 +1533,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -1556,8 +1584,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -1608,8 +1637,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -1661,7 +1691,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -1712,7 +1744,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -1763,8 +1795,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -1815,8 +1848,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -1868,7 +1902,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -1919,7 +1955,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -1970,8 +2006,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -2022,8 +2059,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -2075,7 +2113,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -2126,7 +2166,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?) (stopkey)
      
 
 ===================================================
@@ -2177,8 +2217,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -2229,8 +2270,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -2282,7 +2324,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -2333,7 +2377,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -2384,8 +2428,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -2436,8 +2481,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -2489,7 +2535,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -2540,7 +2588,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -2591,8 +2639,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -2643,8 +2692,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -2696,7 +2746,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -2747,7 +2799,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -2798,8 +2850,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -2850,8 +2903,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -2903,7 +2957,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -2954,7 +3010,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -3005,8 +3061,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -3057,8 +3114,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -3110,7 +3168,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -3161,7 +3221,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -3212,8 +3272,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -3264,8 +3325,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -3317,7 +3379,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -3368,7 +3432,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -3419,8 +3483,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -3471,8 +3536,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -3524,7 +3590,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -3575,7 +3643,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -3626,8 +3694,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -3678,8 +3747,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -3731,7 +3801,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -3782,7 +3854,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -3833,8 +3905,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -3885,8 +3958,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -3938,7 +4012,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -3989,7 +4065,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -4040,8 +4116,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -4092,8 +4169,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -4145,7 +4223,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -4196,7 +4276,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -4247,8 +4327,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -4299,8 +4380,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -4352,7 +4434,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -4403,7 +4487,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -4454,8 +4538,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -4506,8 +4591,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -4559,7 +4645,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -4610,7 +4698,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -4661,8 +4749,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -4713,8 +4802,9 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -4766,7 +4856,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -4818,7 +4910,9 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -4869,8 +4963,8 @@ c1    c2    c3    c4    a1    a2
 0     0     2     770     8     26     
 0     0     2     875     9     27     
 0     0     2     980     10     28     
-0     1     0     15     1     29     
-0     1     0     120     2     30     
+0     1     0     15     1     1     
+0     1     0     120     2     2     
 
 ===================================================
 trace    
@@ -4883,8 +4977,120 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.t_group.gidx), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?) (stopkey)
      
+
+===================================================
+    
+095. CBRD-27125 - three analytics of DIFFERENT families share one sort key (c1,c2,c3 order by c4): they collapse into a single ANALYTIC # group and every one must still see the partition boundary     
+
+===================================================
+c1    c2    c3    c4    a1    a2    a3    
+0     0     0     105     1     105     null     
+0     0     0     210     2     315     105     
+0     0     0     315     3     630     210     
+0     0     0     420     4     1050     315     
+0     0     0     525     5     1575     420     
+0     0     0     630     6     2205     525     
+0     0     0     735     7     2940     630     
+0     0     0     840     8     3780     735     
+0     0     0     945     9     4725     840     
+0     0     1     70     1     70     null     
+0     0     1     175     2     245     70     
+0     0     1     280     3     525     175     
+0     0     1     385     4     910     280     
+0     0     1     490     5     1400     385     
+0     0     1     595     6     1995     490     
+0     0     1     700     7     2695     595     
+0     0     1     805     8     3500     700     
+0     0     1     910     9     4410     805     
+0     0     2     35     1     35     null     
+0     0     2     140     2     175     35     
+0     0     2     245     3     420     140     
+0     0     2     350     4     770     245     
+0     0     2     455     5     1225     350     
+0     0     2     560     6     1785     455     
+0     0     2     665     7     2450     560     
+0     0     2     770     8     3220     665     
+0     0     2     875     9     4095     770     
+0     0     2     980     10     5075     875     
+0     1     0     15     1     15     null     
+0     1     0     120     2     135     15     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.t_group.gidx) (key range: ([dba.t_group].c?>= ?:? ), covered: true)
+
+  rewritten query: select [dba.t_group].c?, [dba.t_group].c?, [dba.t_group].c?, [dba.t_group].c?, row_number() over (partition by ?, ?, ? order by ?), sum([dba.t_group].c?) over (partition by ?, ?, ? order by ?), lag([dba.t_group].c?, ?, null) over (partition by ?, ?, ? order by ?) from [dba.t_group] [dba.t_group] where ([dba.t_group].c?>= ?:? ) and (inst_num()<= ?:? ) using index [dba.t_group].gidx(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.t_group.gidx), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+096. CBRD-27125 - merge plus promotion: incompatible analytic written FIRST, the two mergeable ones after (2 ANALYTIC lines, the merged group first)     
+
+===================================================
+c1    c2    c3    c4    a0    a1    a2    
+2     0     1     7     1     1     11     
+4     0     2     14     2     1     20     
+1     0     0     21     3     1     1     
+3     0     1     28     4     1     10     
+0     0     2     35     5     1     19     
+2     0     0     42     6     1     1     
+4     0     1     49     7     1     10     
+1     0     2     56     8     1     20     
+3     0     0     63     9     1     1     
+0     0     1     70     10     1     10     
+2     0     2     77     11     1     21     
+4     0     0     84     12     1     1     
+1     0     1     91     13     1     11     
+3     0     2     98     14     1     20     
+0     0     0     105     15     1     1     
+2     0     1     112     16     2     12     
+4     0     2     119     17     2     21     
+1     0     0     126     18     2     2     
+3     0     1     133     19     2     11     
+0     0     2     140     20     2     20     
+2     0     0     147     21     2     2     
+4     0     1     154     22     2     11     
+1     0     2     161     23     2     21     
+3     0     0     168     24     2     2     
+0     0     1     175     25     2     11     
+2     0     2     182     26     2     22     
+4     0     0     189     27     2     2     
+1     0     1     196     28     2     12     
+3     0     2     203     29     2     21     
+0     0     0     210     30     2     2     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.t_group.gidx) (key range: ([dba.t_group].c?>= ?:? ), covered: true)
+
+  rewritten query: select [dba.t_group].c?, [dba.t_group].c?, [dba.t_group].c?, [dba.t_group].c?, row_number() over (partition by ? order by ?), row_number() over (partition by ?, ?, ? order by ?), row_number() over (partition by ?, ? order by ?, ?) from [dba.t_group] [dba.t_group] where ([dba.t_group].c?>= ?:? ) and (inst_num()<= ?:? ) using index [dba.t_group].gidx(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.t_group.gidx), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
+     
+
+===================================================
+    
+097. CBRD-27123 - same columns in a different sort-key order describe the same partitioning, so the two row_numbers must agree on every row (expect total 1000, mismatch 0)     
+
+===================================================
+total    mismatch    
+1000     0     
 
 ===================================================
 0
@@ -4902,7 +5108,7 @@ Trace Statistics:
 0
 ===================================================
     
-095. Partition on leading index columns (c1, c2, c3), no ORDER BY - sort skipped     
+098. Partition on leading index columns (c1, c2, c3), no ORDER BY - sort skipped     
 
 ===================================================
 c1    c2    c3    rn    
@@ -4948,12 +5154,12 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table_?.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?) (stopkey)
      
 
 ===================================================
     
-096. ORDER BY c4 (not an index column) - sort required     
+099. ORDER BY c4 (not an index column) - sort required     
 
 ===================================================
 c1    c2    c3    rn    
@@ -5000,11 +5206,12 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table_?.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
     
-097. use_desc_idx with ascending OVER order - descending scan conflicts, sort required     
+100. use_desc_idx with ascending OVER order - descending scan conflicts, sort required     
 
 ===================================================
 c1    c2    c3    rn    
@@ -5051,11 +5258,12 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table_?.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
     
-098. use_desc_idx with all-descending OVER order - matches descending scan, sort skipped     
+101. use_desc_idx with all-descending OVER order - matches descending scan, sort skipped     
 
 ===================================================
 c1    c2    c3    rn    
@@ -5101,7 +5309,7 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table_?.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?) (stopkey)
      
 
 ===================================================
@@ -5120,7 +5328,7 @@ Trace Statistics:
 0
 ===================================================
     
-099. ORDER BY mod(c4,10) - function-based index column that varies inside the partition, sort skipped     
+102. ORDER BY mod(c4,10) - function-based index column that varies inside the partition, sort skipped     
 
 ===================================================
 c1    c2    c3    m    rn    
@@ -5166,12 +5374,12 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table_?.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?) (stopkey)
      
 
 ===================================================
     
-100. same query forced onto a sequential scan - sort required, result block must be identical to the skipped one     
+103. same query forced onto a sequential scan - sort required, result block must be identical to the skipped one     
 
 ===================================================
 c1    c2    c3    m    rn    
@@ -5218,11 +5426,12 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (table: dba.test_table_?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
     
-101. control - ORDER BY c4 itself, which is not an index column expression - sort required and the numbering differs from the mod(c4,10) ordering     
+104. control - ORDER BY c4 itself, which is not an index column expression - sort required and the numbering differs from the mod(c4,10) ordering     
 
 ===================================================
 c1    c2    c3    m    rn    
@@ -5269,6 +5478,7 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table_?.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
@@ -5285,7 +5495,15 @@ Trace Statistics:
 1000
 ===================================================
     
-102. merged analytics vs the same analytics computed one per query - values must match (expect joined_cnt 1000, bad_a1 0, bad_a2 0)     
+105. CBRD-27125 - sort-skip path vs forced-sort path: analytic values must be identical (expect joined_cnt 1000, mismatch_cnt 0)     
+
+===================================================
+joined_cnt    mismatch_cnt    
+1000     0     
+
+===================================================
+    
+106. merged analytics vs the same analytics computed one per query - values must match (expect joined_cnt 1000, bad_a1 0, bad_a2 0)     
 
 ===================================================
 joined_cnt    bad_a1    bad_a2    
@@ -5313,7 +5531,7 @@ joined_cnt    bad_a1    bad_a2
 0
 ===================================================
     
-103. ORDER BY only, order key is a prefix of midx_01(val,id) - sort skipped     
+107. ORDER BY only, order key is a prefix of midx_01(val,id) - sort skipped     
 
 ===================================================
 val    rn    
@@ -5359,12 +5577,12 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?) (stopkey)
      
 
 ===================================================
     
-104. ORDER BY only, order key is the full index key (val, id) - sort skipped     
+108. ORDER BY only, order key is the full index key (val, id) - sort skipped     
 
 ===================================================
 val    id    rn    
@@ -5410,12 +5628,12 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?) (stopkey)
      
 
 ===================================================
     
-105. ORDER BY only, mixed ASC/DESC key (val, id desc) the ASC index cannot supply - sort required     
+109. ORDER BY only, mixed ASC/DESC key (val, id desc) the ASC index cannot supply - sort required     
 
 ===================================================
 val    id    rn    
@@ -5462,11 +5680,12 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
     ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================
     
-106. ORDER BY only, NULLS FIRST matches the ASC index default (NULLs stored first) - sort skipped     
+110. ORDER BY only, NULLS FIRST matches the ASC index default (NULLs stored first) - sort skipped     
 
 ===================================================
 val    rn    
@@ -5512,7 +5731,59 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (index: dba.test_table_null.nidx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: false, page: ?, ioread: ?, rows: ?) (stopkey)
+     
+
+===================================================
+    
+111. CBRD-27145 - ORDER BY only, NULLS LAST opposes the ASC index default: the sort must be performed and the NULL rows must come last     
+
+===================================================
+val    rn    
+1     1     
+1     2     
+1     3     
+1     4     
+1     5     
+1     6     
+1     7     
+1     8     
+1     9     
+1     10     
+1     11     
+1     12     
+1     13     
+1     14     
+1     15     
+1     16     
+1     17     
+1     18     
+1     19     
+1     20     
+1     21     
+1     22     
+1     23     
+1     24     
+1     25     
+1     26     
+1     27     
+1     28     
+1     29     
+1     30     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table_null.nidx_?) (key range: ([dba.test_table_null].id>= ?:? ), covered: true)
+
+  rewritten query: select /*+ INDEX_SS */ [dba.test_table_null].val, row_number() over (order by ? nulls last ) from [dba.test_table_null] [dba.test_table_null] where ([dba.test_table_null].id>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table_null].nidx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table_null.nidx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
      
 
 ===================================================

--- a/sql/_36_guava/cbrd_26473/answers/cbrd_26473.answer
+++ b/sql/_36_guava/cbrd_26473/answers/cbrd_26473.answer
@@ -16,34 +16,34 @@
 id    val    ntile_1    
 10     0     1     
 20     0     1     
-30     0     1     
-40     0     1     
-50     0     1     
-60     0     1     
-70     0     1     
-80     0     1     
-90     0     1     
-100     0     1     
-110     0     1     
-120     0     1     
-130     0     1     
-140     0     1     
-150     0     1     
-160     0     1     
-170     0     1     
-180     0     1     
-190     0     1     
-200     0     1     
-210     0     2     
-220     0     2     
-230     0     2     
-240     0     2     
-250     0     2     
-260     0     2     
-270     0     2     
-280     0     2     
-290     0     2     
-300     0     2     
+30     0     2     
+40     0     2     
+50     0     3     
+60     0     3     
+70     0     4     
+80     0     4     
+90     0     5     
+100     0     5     
+110     0     6     
+120     0     6     
+130     0     7     
+140     0     7     
+150     0     8     
+160     0     8     
+170     0     9     
+180     0     9     
+190     0     10     
+200     0     10     
+210     0     11     
+220     0     11     
+230     0     12     
+240     0     12     
+250     0     13     
+260     0     13     
+270     0     14     
+280     0     14     
+290     0     15     
+300     0     15     
 
 ===================================================
 trace    
@@ -85,16 +85,16 @@ id    val    ntile_1    ntile_2
 18     8     1     1     
 19     9     1     1     
 20     0     1     1     
-21     1     1     1     
-22     2     1     1     
-23     3     1     1     
-24     4     1     1     
-25     5     1     1     
-26     6     1     1     
-27     7     1     1     
-28     8     1     1     
-29     9     1     1     
-30     0     1     1     
+21     1     2     1     
+22     2     2     1     
+23     3     2     1     
+24     4     2     1     
+25     5     2     1     
+26     6     2     1     
+27     7     2     1     
+28     8     2     1     
+29     9     2     1     
+30     0     2     1     
 
 ===================================================
 trace    
@@ -137,16 +137,16 @@ id    val    ntile_2    ntile_1
 18     8     1     1     
 19     9     1     1     
 20     0     1     1     
-21     1     1     1     
-22     2     1     1     
-23     3     1     1     
-24     4     1     1     
-25     5     1     1     
-26     6     1     1     
-27     7     1     1     
-28     8     1     1     
-29     9     1     1     
-30     0     1     1     
+21     1     1     2     
+22     2     1     2     
+23     3     1     2     
+24     4     1     2     
+25     5     1     2     
+26     6     1     2     
+27     7     1     2     
+28     8     1     2     
+29     9     1     2     
+30     0     1     2     
 
 ===================================================
 trace    
@@ -169,36 +169,36 @@ Trace Statistics:
 
 ===================================================
 id    val    ntile_1    ntile_2    
-1     1     5     1     
-2     2     5     1     
-3     3     5     1     
-4     4     5     1     
-5     5     5     1     
-6     6     5     1     
-7     7     5     1     
-8     8     5     1     
-9     9     5     1     
-10     0     5     1     
-11     1     5     1     
-12     2     5     1     
-13     3     5     1     
-14     4     5     1     
-15     5     5     1     
-16     6     5     1     
-17     7     5     1     
-18     8     5     1     
-19     9     5     1     
-20     0     5     1     
-21     1     5     1     
-22     2     5     1     
-23     3     5     1     
-24     4     5     1     
-25     5     5     1     
-26     6     5     1     
-27     7     5     1     
-28     8     5     1     
-29     9     5     1     
-30     0     5     1     
+1     1     50     1     
+2     2     50     1     
+3     3     50     1     
+4     4     50     1     
+5     5     50     1     
+6     6     50     1     
+7     7     50     1     
+8     8     50     1     
+9     9     50     1     
+10     0     50     1     
+11     1     50     1     
+12     2     50     1     
+13     3     50     1     
+14     4     50     1     
+15     5     50     1     
+16     6     50     1     
+17     7     50     1     
+18     8     50     1     
+19     9     50     1     
+20     0     50     1     
+21     1     49     1     
+22     2     49     1     
+23     3     49     1     
+24     4     49     1     
+25     5     49     1     
+26     6     49     1     
+27     7     49     1     
+28     8     49     1     
+29     9     49     1     
+30     0     49     1     
 
 ===================================================
 trace    
@@ -3327,35 +3327,35 @@ Trace Statistics:
 ===================================================
 id    val    nv_1    
 10     0     null     
-20     0     null     
-30     0     null     
-40     0     null     
-50     0     null     
-60     0     null     
-70     0     null     
-80     0     null     
-90     0     null     
-100     0     name_100     
-110     0     name_100     
-120     0     name_100     
-130     0     name_100     
-140     0     name_100     
-150     0     name_100     
-160     0     name_100     
-170     0     name_100     
-180     0     name_100     
-190     0     name_100     
-200     0     name_100     
-210     0     name_100     
-220     0     name_100     
-230     0     name_100     
-240     0     name_100     
-250     0     name_100     
-260     0     name_100     
-270     0     name_100     
-280     0     name_100     
-290     0     name_100     
-300     0     name_100     
+20     0     name_20     
+30     0     name_20     
+40     0     name_20     
+50     0     name_20     
+60     0     name_20     
+70     0     name_20     
+80     0     name_20     
+90     0     name_20     
+100     0     name_20     
+110     0     name_20     
+120     0     name_20     
+130     0     name_20     
+140     0     name_20     
+150     0     name_20     
+160     0     name_20     
+170     0     name_20     
+180     0     name_20     
+190     0     name_20     
+200     0     name_20     
+210     0     name_20     
+220     0     name_20     
+230     0     name_20     
+240     0     name_20     
+250     0     name_20     
+260     0     name_20     
+270     0     name_20     
+280     0     name_20     
+290     0     name_20     
+300     0     name_20     
 
 ===================================================
 trace    
@@ -3387,26 +3387,26 @@ id    val    nv_1    nv_2
 8     8     null     null     
 9     9     null     null     
 10     0     null     null     
-11     1     null     null     
-12     2     null     null     
-13     3     null     null     
-14     4     null     null     
-15     5     null     null     
-16     6     null     null     
-17     7     null     null     
-18     8     null     null     
-19     9     null     null     
-20     0     null     null     
-21     1     null     null     
-22     2     null     null     
-23     3     null     null     
-24     4     null     null     
-25     5     null     null     
-26     6     null     null     
-27     7     null     null     
-28     8     null     null     
-29     9     null     null     
-30     0     null     null     
+11     1     name_11     null     
+12     2     name_12     null     
+13     3     name_13     null     
+14     4     name_14     null     
+15     5     name_15     null     
+16     6     name_16     null     
+17     7     name_17     null     
+18     8     name_18     null     
+19     9     name_19     null     
+20     0     name_20     null     
+21     1     name_11     null     
+22     2     name_12     null     
+23     3     name_13     null     
+24     4     name_14     null     
+25     5     name_15     null     
+26     6     name_16     null     
+27     7     name_17     null     
+28     8     name_18     null     
+29     9     name_19     null     
+30     0     name_20     null     
 
 ===================================================
 trace    
@@ -3439,26 +3439,26 @@ id    val    nv_2    nv_1
 8     8     null     null     
 9     9     null     null     
 10     0     null     null     
-11     1     null     null     
-12     2     null     null     
-13     3     null     null     
-14     4     null     null     
-15     5     null     null     
-16     6     null     null     
-17     7     null     null     
-18     8     null     null     
-19     9     null     null     
-20     0     null     null     
-21     1     null     null     
-22     2     null     null     
-23     3     null     null     
-24     4     null     null     
-25     5     null     null     
-26     6     null     null     
-27     7     null     null     
-28     8     null     null     
-29     9     null     null     
-30     0     null     null     
+11     1     null     name_11     
+12     2     null     name_12     
+13     3     null     name_13     
+14     4     null     name_14     
+15     5     null     name_15     
+16     6     null     name_16     
+17     7     null     name_17     
+18     8     null     name_18     
+19     9     null     name_19     
+20     0     null     name_20     
+21     1     null     name_11     
+22     2     null     name_12     
+23     3     null     name_13     
+24     4     null     name_14     
+25     5     null     name_15     
+26     6     null     name_16     
+27     7     null     name_17     
+28     8     null     name_18     
+29     9     null     name_19     
+30     0     null     name_20     
 
 ===================================================
 trace    
@@ -3481,36 +3481,36 @@ Trace Statistics:
 
 ===================================================
 id    val    nv_1    nv_2    
-1     1     name_901     null     
-2     2     name_902     null     
-3     3     name_903     null     
-4     4     name_904     null     
-5     5     name_905     null     
-6     6     name_906     null     
-7     7     name_907     null     
-8     8     name_908     null     
-9     9     name_909     null     
-10     0     name_910     null     
-11     1     name_901     null     
-12     2     name_902     null     
-13     3     name_903     null     
-14     4     name_904     null     
-15     5     name_905     null     
-16     6     name_906     null     
-17     7     name_907     null     
-18     8     name_908     null     
-19     9     name_909     null     
-20     0     name_910     null     
-21     1     name_901     null     
-22     2     name_902     null     
-23     3     name_903     null     
-24     4     name_904     null     
-25     5     name_905     null     
-26     6     name_906     null     
-27     7     name_907     null     
-28     8     name_908     null     
-29     9     name_909     null     
-30     0     name_910     null     
+1     1     name_981     null     
+2     2     name_982     null     
+3     3     name_983     null     
+4     4     name_984     null     
+5     5     name_985     null     
+6     6     name_986     null     
+7     7     name_987     null     
+8     8     name_988     null     
+9     9     name_989     null     
+10     0     name_990     null     
+11     1     name_981     null     
+12     2     name_982     null     
+13     3     name_983     null     
+14     4     name_984     null     
+15     5     name_985     null     
+16     6     name_986     null     
+17     7     name_987     null     
+18     8     name_988     null     
+19     9     name_989     null     
+20     0     name_990     null     
+21     1     name_981     null     
+22     2     name_982     null     
+23     3     name_983     null     
+24     4     name_984     null     
+25     5     name_985     null     
+26     6     name_986     null     
+27     7     name_987     null     
+28     8     name_988     null     
+29     9     name_989     null     
+30     0     name_990     null     
 
 ===================================================
 trace    
@@ -4775,36 +4775,36 @@ Trace Statistics:
 
 ===================================================
 id    val    n_2    n_1    
-1     1     1     5     
-2     2     1     5     
-3     3     1     5     
-4     4     1     5     
-5     5     1     5     
-6     6     1     5     
-7     7     1     5     
-8     8     1     5     
-9     9     1     5     
-10     0     1     5     
-11     1     1     5     
-12     2     1     5     
-13     3     1     5     
-14     4     1     5     
-15     5     1     5     
-16     6     1     5     
-17     7     1     5     
-18     8     1     5     
-19     9     1     5     
-20     0     1     5     
-21     1     1     5     
-22     2     1     5     
-23     3     1     5     
-24     4     1     5     
-25     5     1     5     
-26     6     1     5     
-27     7     1     5     
-28     8     1     5     
-29     9     1     5     
-30     0     1     5     
+1     1     1     50     
+2     2     1     50     
+3     3     1     50     
+4     4     1     50     
+5     5     1     50     
+6     6     1     50     
+7     7     1     50     
+8     8     1     50     
+9     9     1     50     
+10     0     1     50     
+11     1     1     50     
+12     2     1     50     
+13     3     1     50     
+14     4     1     50     
+15     5     1     50     
+16     6     1     50     
+17     7     1     50     
+18     8     1     50     
+19     9     1     50     
+20     0     1     50     
+21     1     1     49     
+22     2     1     49     
+23     3     1     49     
+24     4     1     49     
+25     5     1     49     
+26     6     1     49     
+27     7     1     49     
+28     8     1     49     
+29     9     1     49     
+30     0     1     49     
 
 ===================================================
 trace    
@@ -5004,58 +5004,7 @@ Trace Statistics:
 
 ===================================================
     
-097. ORDER BY mod(c1, 10) (the function-based 4th index column) - sort skipped     
-
-===================================================
-c1    c2    c3    rn    
-0     c2_0     c3_0     1     
-0     c2_0     c3_0     2     
-0     c2_0     c3_0     3     
-0     c2_0     c3_0     4     
-0     c2_0     c3_0     5     
-0     c2_0     c3_0     6     
-0     c2_0     c3_0     7     
-0     c2_0     c3_0     8     
-0     c2_0     c3_0     9     
-0     c2_0     c3_0     10     
-1     c2_1     c3_1     1     
-1     c2_1     c3_1     2     
-1     c2_1     c3_1     3     
-1     c2_1     c3_1     4     
-1     c2_1     c3_1     5     
-1     c2_1     c3_1     6     
-1     c2_1     c3_1     7     
-1     c2_1     c3_1     8     
-1     c2_1     c3_1     9     
-1     c2_1     c3_1     10     
-2     c2_2     c3_2     1     
-2     c2_2     c3_2     2     
-2     c2_2     c3_2     3     
-2     c2_2     c3_2     4     
-2     c2_2     c3_2     5     
-2     c2_2     c3_2     6     
-2     c2_2     c3_2     7     
-2     c2_2     c3_2     8     
-2     c2_2     c3_2     9     
-2     c2_2     c3_2     10     
-
-===================================================
-trace    
-
-Query Plan:
-  INDEX SCAN (dba.test_table_?.midx_?) (key range: ([dba.test_table_?].c?>= ?:? ))
-
-  rewritten query: select [dba.test_table_?].c?, [dba.test_table_?].c?, [dba.test_table_?].c?, row_number() over (partition by ?, ?, ? order by ?) from [dba.test_table_?] [dba.test_table_?] where ([dba.test_table_?].c?>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table_?].midx_?(+)
-
-Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (index: dba.test_table_?.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
-     
-
-===================================================
-    
-098. use_desc_idx with ascending OVER order - descending scan conflicts, sort required     
+097. use_desc_idx with ascending OVER order - descending scan conflicts, sort required     
 
 ===================================================
 c1    c2    c3    rn    
@@ -5106,7 +5055,7 @@ Trace Statistics:
 
 ===================================================
     
-099. use_desc_idx with all-descending OVER order - matches descending scan, sort skipped     
+098. use_desc_idx with all-descending OVER order - matches descending scan, sort skipped     
 
 ===================================================
 c1    c2    c3    rn    
@@ -5171,7 +5120,7 @@ Trace Statistics:
 0
 ===================================================
     
-100. ORDER BY mod(c4,10) - function-based index column that varies inside the partition, sort skipped     
+099. ORDER BY mod(c4,10) - function-based index column that varies inside the partition, sort skipped     
 
 ===================================================
 c1    c2    c3    m    rn    
@@ -5222,7 +5171,7 @@ Trace Statistics:
 
 ===================================================
     
-101. same query forced onto a sequential scan - sort required, result block must be identical to the skipped one     
+100. same query forced onto a sequential scan - sort required, result block must be identical to the skipped one     
 
 ===================================================
 c1    c2    c3    m    rn    
@@ -5273,7 +5222,7 @@ Trace Statistics:
 
 ===================================================
     
-102. control - ORDER BY c4 itself, which is not an index column expression - sort required and the numbering differs from the mod(c4,10) ordering     
+101. control - ORDER BY c4 itself, which is not an index column expression - sort required and the numbering differs from the mod(c4,10) ordering     
 
 ===================================================
 c1    c2    c3    m    rn    
@@ -5336,7 +5285,7 @@ Trace Statistics:
 1000
 ===================================================
     
-103. merged analytics vs the same analytics computed one per query - values must match (expect joined_cnt 1000, bad_a1 0, bad_a2 0)     
+102. merged analytics vs the same analytics computed one per query - values must match (expect joined_cnt 1000, bad_a1 0, bad_a2 0)     
 
 ===================================================
 joined_cnt    bad_a1    bad_a2    
@@ -5364,7 +5313,7 @@ joined_cnt    bad_a1    bad_a2
 0
 ===================================================
     
-104. ORDER BY only, order key is a prefix of midx_01(val,id) - sort skipped     
+103. ORDER BY only, order key is a prefix of midx_01(val,id) - sort skipped     
 
 ===================================================
 val    rn    
@@ -5415,7 +5364,7 @@ Trace Statistics:
 
 ===================================================
     
-105. ORDER BY only, order key is the full index key (val, id) - sort skipped     
+104. ORDER BY only, order key is the full index key (val, id) - sort skipped     
 
 ===================================================
 val    id    rn    
@@ -5466,7 +5415,7 @@ Trace Statistics:
 
 ===================================================
     
-106. ORDER BY only, mixed ASC/DESC key (val, id desc) the ASC index cannot supply - sort required     
+105. ORDER BY only, mixed ASC/DESC key (val, id desc) the ASC index cannot supply - sort required     
 
 ===================================================
 val    id    rn    
@@ -5517,7 +5466,7 @@ Trace Statistics:
 
 ===================================================
     
-107. ORDER BY only, NULLS FIRST matches the ASC index default (NULLs stored first) - sort skipped     
+106. ORDER BY only, NULLS FIRST matches the ASC index default (NULLs stored first) - sort skipped     
 
 ===================================================
 val    rn    

--- a/sql/_36_guava/cbrd_26473/answers/cbrd_26473.answer
+++ b/sql/_36_guava/cbrd_26473/answers/cbrd_26473.answer
@@ -2930,6 +2930,38 @@ Trace Statistics:
      
 
 ===================================================
+    
+093. NTILE index-compatible DESC analytic written second - promoted ahead of the incompatible one (final row order reveals the execution order)     
+
+===================================================
+id    val    n_2    n_1    
+1     1     1     5     
+2     2     1     5     
+3     3     1     5     
+4     4     1     5     
+5     5     1     5     
+6     6     1     5     
+7     7     1     5     
+8     8     1     5     
+9     9     1     5     
+10     0     1     5     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, ntile(?) over (partition by ? order by ?), ntile(?) over (partition by ? order by ? desc ) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
 0
 ===================================================
 0
@@ -2945,7 +2977,7 @@ Trace Statistics:
 0
 ===================================================
     
-093. Two analytics share the sort key (c1,c2,c3,c4) - they merge into a single ANALYTIC # group (sort skipped); the trace prints one line per sort group, not per function     
+094. Two analytics share the sort key (c1,c2,c3,c4) - they merge into a single ANALYTIC # group (sort skipped); the trace prints one line per sort group, not per function     
 
 ===================================================
 c1    c2    c3    c4    a1    a2    
@@ -2990,7 +3022,7 @@ Trace Statistics:
 0
 ===================================================
     
-094. Partition on leading index columns (c1, c2, c3), no ORDER BY - sort skipped     
+095. Partition on leading index columns (c1, c2, c3), no ORDER BY - sort skipped     
 
 ===================================================
 c1    c2    c3    rn    
@@ -3021,7 +3053,7 @@ Trace Statistics:
 
 ===================================================
     
-095. ORDER BY c4 (not an index column) - sort required     
+096. ORDER BY c4 (not an index column) - sort required     
 
 ===================================================
 c1    c2    c3    rn    
@@ -3052,7 +3084,7 @@ Trace Statistics:
 
 ===================================================
     
-096. ORDER BY mod(c1, 10) (the function-based 4th index column) - sort skipped     
+097. ORDER BY mod(c1, 10) (the function-based 4th index column) - sort skipped     
 
 ===================================================
 c1    c2    c3    rn    
@@ -3083,7 +3115,7 @@ Trace Statistics:
 
 ===================================================
     
-097. use_desc_idx with ascending OVER order - descending scan conflicts, sort required     
+098. use_desc_idx with ascending OVER order - descending scan conflicts, sort required     
 
 ===================================================
 c1    c2    c3    rn    
@@ -3114,7 +3146,7 @@ Trace Statistics:
 
 ===================================================
     
-098. use_desc_idx with all-descending OVER order - matches descending scan, sort skipped     
+099. use_desc_idx with all-descending OVER order - matches descending scan, sort skipped     
 
 ===================================================
 c1    c2    c3    rn    

--- a/sql/_36_guava/cbrd_26473/answers/cbrd_26473.answer
+++ b/sql/_36_guava/cbrd_26473/answers/cbrd_26473.answer
@@ -1,0 +1,3149 @@
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+1000
+===================================================
+0
+===================================================
+    
+001. NTILE single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+ntile_1    
+1     
+1     
+1     
+1     
+1     
+1     
+1     
+1     
+1     
+1     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select ntile(?) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+002. NTILE two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    ntile_1    ntile_2    
+1     1     1     1     
+2     2     1     1     
+3     3     1     1     
+4     4     1     1     
+5     5     1     1     
+6     6     1     1     
+7     7     1     1     
+8     8     1     1     
+9     9     1     1     
+10     0     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, ntile(?) over (partition by ? order by ?), ntile(?) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+003. NTILE two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    ntile_2    ntile_1    
+1     1     1     1     
+2     2     1     1     
+3     3     1     1     
+4     4     1     1     
+5     5     1     1     
+6     6     1     1     
+7     7     1     1     
+8     8     1     1     
+9     9     1     1     
+10     0     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, ntile(?) over (partition by ? order by ?), ntile(?) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+004. NTILE conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    ntile_1    ntile_2    
+1     1     5     1     
+2     2     5     1     
+3     3     5     1     
+4     4     5     1     
+5     5     5     1     
+6     6     5     1     
+7     7     5     1     
+8     8     5     1     
+9     9     5     1     
+10     0     5     1     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, ntile(?) over (partition by ? order by ? desc ), ntile(?) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+005. MEDIAN single analytic - OVER(partition by val) covered by midx_01 leading column, sort skipped     
+
+===================================================
+md_1    
+505.0     
+505.0     
+505.0     
+505.0     
+505.0     
+505.0     
+505.0     
+505.0     
+505.0     
+505.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select median([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+006. MEDIAN two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    md_1    md_2    
+1     1     496.0     1.0     
+2     2     497.0     2.0     
+3     3     498.0     3.0     
+4     4     499.0     4.0     
+5     5     500.0     5.0     
+6     6     501.0     6.0     
+7     7     502.0     7.0     
+8     8     503.0     8.0     
+9     9     504.0     9.0     
+10     0     505.0     0.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, median([dba.test_table].id) over (partition by ? order by ?), median([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+007. MEDIAN two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    md_2    md_1    
+1     1     1.0     496.0     
+2     2     2.0     497.0     
+3     3     3.0     498.0     
+4     4     4.0     499.0     
+5     5     5.0     500.0     
+6     6     6.0     501.0     
+7     7     7.0     502.0     
+8     8     8.0     503.0     
+9     9     9.0     504.0     
+10     0     0.0     505.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, median([dba.test_table].val) over (partition by ? order by ?), median([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+008. MEDIAN partition column not in the index (val, name) - sort required     
+
+===================================================
+id    val    md_1    md_2    
+1     1     1.0     1.0     
+2     2     2.0     2.0     
+3     3     3.0     3.0     
+4     4     4.0     4.0     
+5     5     5.0     5.0     
+6     6     6.0     6.0     
+7     7     7.0     7.0     
+8     8     8.0     8.0     
+9     9     9.0     9.0     
+10     0     10.0     0.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, median([dba.test_table].id) over (partition by ?, ? order by ?), median([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+009. PERCENTILE_CONT single analytic - within group(order by id) over(partition by val) covered by midx_01, sort skipped     
+
+===================================================
+pc_1    
+505.0     
+505.0     
+505.0     
+505.0     
+505.0     
+505.0     
+505.0     
+505.0     
+505.0     
+505.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select percentile_cont( cast(?.? as double)) within group (order by [dba.test_table].id) over (partition by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+010. PERCENTILE_CONT two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    pc_1    pc_2    
+1     1     496.0     1.0     
+2     2     497.0     2.0     
+3     3     498.0     3.0     
+4     4     499.0     4.0     
+5     5     500.0     5.0     
+6     6     501.0     6.0     
+7     7     502.0     7.0     
+8     8     503.0     8.0     
+9     9     504.0     9.0     
+10     0     505.0     0.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, percentile_cont( cast(?.? as double)) within group (order by [dba.test_table].id) over (partition by ?), percentile_cont( cast(?.? as double)) within group (order by [dba.test_table].val) over (partition by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+011. PERCENTILE_CONT two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    pc_2    pc_1    
+1     1     1.0     496.0     
+2     2     2.0     497.0     
+3     3     3.0     498.0     
+4     4     4.0     499.0     
+5     5     5.0     500.0     
+6     6     6.0     501.0     
+7     7     7.0     502.0     
+8     8     8.0     503.0     
+9     9     9.0     504.0     
+10     0     0.0     505.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, percentile_cont( cast(?.? as double)) within group (order by [dba.test_table].val) over (partition by ?), percentile_cont( cast(?.? as double)) within group (order by [dba.test_table].id) over (partition by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+012. PERCENTILE_CONT conflicting DESC order (order by id desc) - sort required     
+
+===================================================
+id    val    pc_1    pc_2    
+1     1     496.0     1.0     
+2     2     497.0     2.0     
+3     3     498.0     3.0     
+4     4     499.0     4.0     
+5     5     500.0     5.0     
+6     6     501.0     6.0     
+7     7     502.0     7.0     
+8     8     503.0     8.0     
+9     9     504.0     9.0     
+10     0     505.0     0.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, percentile_cont( cast(?.? as double)) within group (order by [dba.test_table].id desc) over (partition by ?), percentile_cont( cast(?.? as double)) within group (order by [dba.test_table].val) over (partition by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+013. PERCENTILE_DISC single analytic - within group(order by id) over(partition by val) covered by midx_01, sort skipped     
+
+===================================================
+pd_1    
+500     
+500     
+500     
+500     
+500     
+500     
+500     
+500     
+500     
+500     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select percentile_disc( cast(?.? as double)) within group (order by [dba.test_table].id) over (partition by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+014. PERCENTILE_DISC two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    pd_1    pd_2    
+1     1     491     1     
+2     2     492     2     
+3     3     493     3     
+4     4     494     4     
+5     5     495     5     
+6     6     496     6     
+7     7     497     7     
+8     8     498     8     
+9     9     499     9     
+10     0     500     0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, percentile_disc( cast(?.? as double)) within group (order by [dba.test_table].id) over (partition by ?), percentile_disc( cast(?.? as double)) within group (order by [dba.test_table].val) over (partition by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+015. PERCENTILE_DISC two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    pd_2    pd_1    
+1     1     1     491     
+2     2     2     492     
+3     3     3     493     
+4     4     4     494     
+5     5     5     495     
+6     6     6     496     
+7     7     7     497     
+8     8     8     498     
+9     9     9     499     
+10     0     0     500     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, percentile_disc( cast(?.? as double)) within group (order by [dba.test_table].val) over (partition by ?), percentile_disc( cast(?.? as double)) within group (order by [dba.test_table].id) over (partition by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+016. PERCENTILE_DISC conflicting DESC order (order by id desc) - sort required     
+
+===================================================
+id    val    pd_1    pd_2    
+1     1     501     1     
+2     2     502     2     
+3     3     503     3     
+4     4     504     4     
+5     5     505     5     
+6     6     506     6     
+7     7     507     7     
+8     8     508     8     
+9     9     509     9     
+10     0     510     0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, percentile_disc( cast(?.? as double)) within group (order by [dba.test_table].id desc) over (partition by ?), percentile_disc( cast(?.? as double)) within group (order by [dba.test_table].val) over (partition by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+017. ROW_NUMBER single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+rn_1    
+1     
+2     
+3     
+4     
+5     
+6     
+7     
+8     
+9     
+10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select row_number() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+018. ROW_NUMBER two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    rn_1    rn_2    
+1     1     1     1     
+2     2     1     1     
+3     3     1     1     
+4     4     1     1     
+5     5     1     1     
+6     6     1     1     
+7     7     1     1     
+8     8     1     1     
+9     9     1     1     
+10     0     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, row_number() over (partition by ? order by ?), row_number() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+019. ROW_NUMBER two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    rn_2    rn_1    
+1     1     1     1     
+2     2     1     1     
+3     3     1     1     
+4     4     1     1     
+5     5     1     1     
+6     6     1     1     
+7     7     1     1     
+8     8     1     1     
+9     9     1     1     
+10     0     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, row_number() over (partition by ? order by ?), row_number() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+020. ROW_NUMBER conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    rn_1    rn_2    
+1     1     100     1     
+2     2     100     1     
+3     3     100     1     
+4     4     100     1     
+5     5     100     1     
+6     6     100     1     
+7     7     100     1     
+8     8     100     1     
+9     9     100     1     
+10     0     100     1     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, row_number() over (partition by ? order by ? desc ), row_number() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+021. RANK single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+rk_1    
+1     
+2     
+3     
+4     
+5     
+6     
+7     
+8     
+9     
+10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select rank() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+022. RANK two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    rk_1    rk_2    
+1     1     1     1     
+2     2     1     1     
+3     3     1     1     
+4     4     1     1     
+5     5     1     1     
+6     6     1     1     
+7     7     1     1     
+8     8     1     1     
+9     9     1     1     
+10     0     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, rank() over (partition by ? order by ?), rank() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+023. RANK two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    rk_2    rk_1    
+1     1     1     1     
+2     2     1     1     
+3     3     1     1     
+4     4     1     1     
+5     5     1     1     
+6     6     1     1     
+7     7     1     1     
+8     8     1     1     
+9     9     1     1     
+10     0     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, rank() over (partition by ? order by ?), rank() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+024. RANK conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    rk_1    rk_2    
+1     1     100     1     
+2     2     100     1     
+3     3     100     1     
+4     4     100     1     
+5     5     100     1     
+6     6     100     1     
+7     7     100     1     
+8     8     100     1     
+9     9     100     1     
+10     0     100     1     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, rank() over (partition by ? order by ? desc ), rank() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+025. DENSE_RANK single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+dr_1    
+1     
+2     
+3     
+4     
+5     
+6     
+7     
+8     
+9     
+10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select dense_rank() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+026. DENSE_RANK two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    dr_1    dr_2    
+1     1     1     1     
+2     2     1     1     
+3     3     1     1     
+4     4     1     1     
+5     5     1     1     
+6     6     1     1     
+7     7     1     1     
+8     8     1     1     
+9     9     1     1     
+10     0     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, dense_rank() over (partition by ? order by ?), dense_rank() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+027. DENSE_RANK two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    dr_2    dr_1    
+1     1     1     1     
+2     2     1     1     
+3     3     1     1     
+4     4     1     1     
+5     5     1     1     
+6     6     1     1     
+7     7     1     1     
+8     8     1     1     
+9     9     1     1     
+10     0     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, dense_rank() over (partition by ? order by ?), dense_rank() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+028. DENSE_RANK conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    dr_1    dr_2    
+1     1     100     1     
+2     2     100     1     
+3     3     100     1     
+4     4     100     1     
+5     5     100     1     
+6     6     100     1     
+7     7     100     1     
+8     8     100     1     
+9     9     100     1     
+10     0     100     1     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, dense_rank() over (partition by ? order by ? desc ), dense_rank() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+029. AVG single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+av_1    
+10.0     
+15.0     
+20.0     
+25.0     
+30.0     
+35.0     
+40.0     
+45.0     
+50.0     
+55.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select avg([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+030. AVG two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    av_1    av_2    
+1     1     1.0     1.0     
+2     2     2.0     2.0     
+3     3     3.0     3.0     
+4     4     4.0     4.0     
+5     5     5.0     5.0     
+6     6     6.0     6.0     
+7     7     7.0     7.0     
+8     8     8.0     8.0     
+9     9     9.0     9.0     
+10     0     10.0     0.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, avg([dba.test_table].id) over (partition by ? order by ?), avg([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+031. AVG two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    av_2    av_1    
+1     1     1.0     1.0     
+2     2     2.0     2.0     
+3     3     3.0     3.0     
+4     4     4.0     4.0     
+5     5     5.0     5.0     
+6     6     6.0     6.0     
+7     7     7.0     7.0     
+8     8     8.0     8.0     
+9     9     9.0     9.0     
+10     0     0.0     10.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, avg([dba.test_table].val) over (partition by ? order by ?), avg([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+032. AVG conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    av_1    av_2    
+1     1     496.0     1.0     
+2     2     497.0     2.0     
+3     3     498.0     3.0     
+4     4     499.0     4.0     
+5     5     500.0     5.0     
+6     6     501.0     6.0     
+7     7     502.0     7.0     
+8     8     503.0     8.0     
+9     9     504.0     9.0     
+10     0     505.0     0.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, avg([dba.test_table].id) over (partition by ? order by ? desc ), avg([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+033. COUNT single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+cnt_1    
+1     
+2     
+3     
+4     
+5     
+6     
+7     
+8     
+9     
+10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select count(*) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+034. COUNT two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    cnt_1    cnt_2    
+1     1     1     1     
+2     2     1     1     
+3     3     1     1     
+4     4     1     1     
+5     5     1     1     
+6     6     1     1     
+7     7     1     1     
+8     8     1     1     
+9     9     1     1     
+10     0     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, count(*) over (partition by ? order by ?), count([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+035. COUNT two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    cnt_2    cnt_1    
+1     1     1     1     
+2     2     1     1     
+3     3     1     1     
+4     4     1     1     
+5     5     1     1     
+6     6     1     1     
+7     7     1     1     
+8     8     1     1     
+9     9     1     1     
+10     0     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, count([dba.test_table].val) over (partition by ? order by ?), count(*) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+036. COUNT conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    cnt_1    cnt_2    
+1     1     100     1     
+2     2     100     1     
+3     3     100     1     
+4     4     100     1     
+5     5     100     1     
+6     6     100     1     
+7     7     100     1     
+8     8     100     1     
+9     9     100     1     
+10     0     100     1     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, count(*) over (partition by ? order by ? desc ), count([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+037. CUME_DIST single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+cd_1    
+0.01     
+0.02     
+0.03     
+0.04     
+0.05     
+0.06     
+0.07     
+0.08     
+0.09     
+0.1     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select cume_dist() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+038. CUME_DIST two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    cd_1    cd_2    
+1     1     0.01     1.0     
+2     2     0.01     1.0     
+3     3     0.01     1.0     
+4     4     0.01     1.0     
+5     5     0.01     1.0     
+6     6     0.01     1.0     
+7     7     0.01     1.0     
+8     8     0.01     1.0     
+9     9     0.01     1.0     
+10     0     0.01     1.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, cume_dist() over (partition by ? order by ?), cume_dist() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+039. CUME_DIST two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    cd_2    cd_1    
+1     1     1.0     0.01     
+2     2     1.0     0.01     
+3     3     1.0     0.01     
+4     4     1.0     0.01     
+5     5     1.0     0.01     
+6     6     1.0     0.01     
+7     7     1.0     0.01     
+8     8     1.0     0.01     
+9     9     1.0     0.01     
+10     0     1.0     0.01     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, cume_dist() over (partition by ? order by ?), cume_dist() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+040. CUME_DIST conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    cd_1    cd_2    
+1     1     1.0     1.0     
+2     2     1.0     1.0     
+3     3     1.0     1.0     
+4     4     1.0     1.0     
+5     5     1.0     1.0     
+6     6     1.0     1.0     
+7     7     1.0     1.0     
+8     8     1.0     1.0     
+9     9     1.0     1.0     
+10     0     1.0     1.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, cume_dist() over (partition by ? order by ? desc ), cume_dist() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+041. FIRST_VALUE single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+fv_1    
+name_10     
+name_10     
+name_10     
+name_10     
+name_10     
+name_10     
+name_10     
+name_10     
+name_10     
+name_10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select first_value([dba.test_table].[name]) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+042. FIRST_VALUE two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    fv_1    fv_2    
+1     1     name_1     name_1     
+2     2     name_2     name_2     
+3     3     name_3     name_3     
+4     4     name_4     name_4     
+5     5     name_5     name_5     
+6     6     name_6     name_6     
+7     7     name_7     name_7     
+8     8     name_8     name_8     
+9     9     name_9     name_9     
+10     0     name_10     name_10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, first_value([dba.test_table].[name]) over (partition by ? order by ?), first_value([dba.test_table].[name]) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+043. FIRST_VALUE two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    fv_2    fv_1    
+1     1     name_1     name_1     
+2     2     name_2     name_2     
+3     3     name_3     name_3     
+4     4     name_4     name_4     
+5     5     name_5     name_5     
+6     6     name_6     name_6     
+7     7     name_7     name_7     
+8     8     name_8     name_8     
+9     9     name_9     name_9     
+10     0     name_10     name_10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, first_value([dba.test_table].[name]) over (partition by ? order by ?), first_value([dba.test_table].[name]) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+044. FIRST_VALUE conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    fv_1    fv_2    
+1     1     name_991     name_1     
+2     2     name_992     name_2     
+3     3     name_993     name_3     
+4     4     name_994     name_4     
+5     5     name_995     name_5     
+6     6     name_996     name_6     
+7     7     name_997     name_7     
+8     8     name_998     name_8     
+9     9     name_999     name_9     
+10     0     name_1000     name_10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, first_value([dba.test_table].[name]) over (partition by ? order by ? desc ), first_value([dba.test_table].[name]) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+045. LAG single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+lg_1    
+null     
+name_10     
+name_20     
+name_30     
+name_40     
+name_50     
+name_60     
+name_70     
+name_80     
+name_90     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select lag([dba.test_table].[name], ?, null) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+046. LAG two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    lg_1    lg_2    
+1     1     null     null     
+2     2     null     null     
+3     3     null     null     
+4     4     null     null     
+5     5     null     null     
+6     6     null     null     
+7     7     null     null     
+8     8     null     null     
+9     9     null     null     
+10     0     null     null     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, lag([dba.test_table].[name], ?, null) over (partition by ? order by ?), lag([dba.test_table].[name], ?, null) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+047. LAG two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    lg_2    lg_1    
+1     1     null     null     
+2     2     null     null     
+3     3     null     null     
+4     4     null     null     
+5     5     null     null     
+6     6     null     null     
+7     7     null     null     
+8     8     null     null     
+9     9     null     null     
+10     0     null     null     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, lag([dba.test_table].[name], ?, null) over (partition by ? order by ?), lag([dba.test_table].[name], ?, null) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+048. LAG conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    lg_1    lg_2    
+1     1     name_11     null     
+2     2     name_12     null     
+3     3     name_13     null     
+4     4     name_14     null     
+5     5     name_15     null     
+6     6     name_16     null     
+7     7     name_17     null     
+8     8     name_18     null     
+9     9     name_19     null     
+10     0     name_20     null     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, lag([dba.test_table].[name], ?, null) over (partition by ? order by ? desc ), lag([dba.test_table].[name], ?, null) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+049. LAST_VALUE single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+lv_1    
+name_10     
+name_20     
+name_30     
+name_40     
+name_50     
+name_60     
+name_70     
+name_80     
+name_90     
+name_100     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select last_value([dba.test_table].[name]) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+050. LAST_VALUE two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    lv_1    lv_2    
+1     1     name_1     name_1     
+2     2     name_2     name_2     
+3     3     name_3     name_3     
+4     4     name_4     name_4     
+5     5     name_5     name_5     
+6     6     name_6     name_6     
+7     7     name_7     name_7     
+8     8     name_8     name_8     
+9     9     name_9     name_9     
+10     0     name_10     name_10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, last_value([dba.test_table].[name]) over (partition by ? order by ?), last_value([dba.test_table].[name]) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+051. LAST_VALUE two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    lv_2    lv_1    
+1     1     name_1     name_1     
+2     2     name_2     name_2     
+3     3     name_3     name_3     
+4     4     name_4     name_4     
+5     5     name_5     name_5     
+6     6     name_6     name_6     
+7     7     name_7     name_7     
+8     8     name_8     name_8     
+9     9     name_9     name_9     
+10     0     name_10     name_10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, last_value([dba.test_table].[name]) over (partition by ? order by ?), last_value([dba.test_table].[name]) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+052. LAST_VALUE conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    lv_1    lv_2    
+1     1     name_1     name_1     
+2     2     name_2     name_2     
+3     3     name_3     name_3     
+4     4     name_4     name_4     
+5     5     name_5     name_5     
+6     6     name_6     name_6     
+7     7     name_7     name_7     
+8     8     name_8     name_8     
+9     9     name_9     name_9     
+10     0     name_10     name_10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, last_value([dba.test_table].[name]) over (partition by ? order by ? desc ), last_value([dba.test_table].[name]) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+053. LEAD single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+ld_1    
+name_20     
+name_30     
+name_40     
+name_50     
+name_60     
+name_70     
+name_80     
+name_90     
+name_100     
+name_110     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select lead([dba.test_table].[name], ?, null) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+054. LEAD two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    ld_1    ld_2    
+1     1     name_11     null     
+2     2     name_12     null     
+3     3     name_13     null     
+4     4     name_14     null     
+5     5     name_15     null     
+6     6     name_16     null     
+7     7     name_17     null     
+8     8     name_18     null     
+9     9     name_19     null     
+10     0     name_20     null     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, lead([dba.test_table].[name], ?, null) over (partition by ? order by ?), lead([dba.test_table].[name], ?, null) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+055. LEAD two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    ld_2    ld_1    
+1     1     null     name_11     
+2     2     null     name_12     
+3     3     null     name_13     
+4     4     null     name_14     
+5     5     null     name_15     
+6     6     null     name_16     
+7     7     null     name_17     
+8     8     null     name_18     
+9     9     null     name_19     
+10     0     null     name_20     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, lead([dba.test_table].[name], ?, null) over (partition by ? order by ?), lead([dba.test_table].[name], ?, null) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+056. LEAD conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    ld_1    ld_2    
+1     1     null     null     
+2     2     null     null     
+3     3     null     null     
+4     4     null     null     
+5     5     null     null     
+6     6     null     null     
+7     7     null     null     
+8     8     null     null     
+9     9     null     null     
+10     0     null     null     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, lead([dba.test_table].[name], ?, null) over (partition by ? order by ? desc ), lead([dba.test_table].[name], ?, null) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+057. MAX single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+mx_1    
+10     
+20     
+30     
+40     
+50     
+60     
+70     
+80     
+90     
+100     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select max([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+058. MAX two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    mx_1    mx_2    
+1     1     1     1     
+2     2     2     2     
+3     3     3     3     
+4     4     4     4     
+5     5     5     5     
+6     6     6     6     
+7     7     7     7     
+8     8     8     8     
+9     9     9     9     
+10     0     10     0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, max([dba.test_table].id) over (partition by ? order by ?), max([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+059. MAX two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    mx_2    mx_1    
+1     1     1     1     
+2     2     2     2     
+3     3     3     3     
+4     4     4     4     
+5     5     5     5     
+6     6     6     6     
+7     7     7     7     
+8     8     8     8     
+9     9     9     9     
+10     0     0     10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, max([dba.test_table].val) over (partition by ? order by ?), max([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+060. MAX conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    mx_1    mx_2    
+1     1     991     1     
+2     2     992     2     
+3     3     993     3     
+4     4     994     4     
+5     5     995     5     
+6     6     996     6     
+7     7     997     7     
+8     8     998     8     
+9     9     999     9     
+10     0     1000     0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, max([dba.test_table].id) over (partition by ? order by ? desc ), max([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+061. MIN single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+mn_1    
+10     
+10     
+10     
+10     
+10     
+10     
+10     
+10     
+10     
+10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select min([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+062. MIN two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    mn_1    mn_2    
+1     1     1     1     
+2     2     2     2     
+3     3     3     3     
+4     4     4     4     
+5     5     5     5     
+6     6     6     6     
+7     7     7     7     
+8     8     8     8     
+9     9     9     9     
+10     0     10     0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, min([dba.test_table].id) over (partition by ? order by ?), min([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+063. MIN two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    mn_2    mn_1    
+1     1     1     1     
+2     2     2     2     
+3     3     3     3     
+4     4     4     4     
+5     5     5     5     
+6     6     6     6     
+7     7     7     7     
+8     8     8     8     
+9     9     9     9     
+10     0     0     10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, min([dba.test_table].val) over (partition by ? order by ?), min([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+064. MIN conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    mn_1    mn_2    
+1     1     1     1     
+2     2     2     2     
+3     3     3     3     
+4     4     4     4     
+5     5     5     5     
+6     6     6     6     
+7     7     7     7     
+8     8     8     8     
+9     9     9     9     
+10     0     10     0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, min([dba.test_table].id) over (partition by ? order by ? desc ), min([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+065. NTH_VALUE single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+nv_1    
+null     
+null     
+null     
+null     
+null     
+null     
+null     
+null     
+null     
+name_100     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select nth_value([dba.test_table].[name], ?) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+066. NTH_VALUE two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    nv_1    nv_2    
+1     1     null     null     
+2     2     null     null     
+3     3     null     null     
+4     4     null     null     
+5     5     null     null     
+6     6     null     null     
+7     7     null     null     
+8     8     null     null     
+9     9     null     null     
+10     0     null     null     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, nth_value([dba.test_table].[name], ?) over (partition by ? order by ?), nth_value([dba.test_table].[name], ?) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+067. NTH_VALUE two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    nv_2    nv_1    
+1     1     null     null     
+2     2     null     null     
+3     3     null     null     
+4     4     null     null     
+5     5     null     null     
+6     6     null     null     
+7     7     null     null     
+8     8     null     null     
+9     9     null     null     
+10     0     null     null     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, nth_value([dba.test_table].[name], ?) over (partition by ? order by ?), nth_value([dba.test_table].[name], ?) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+068. NTH_VALUE conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    nv_1    nv_2    
+1     1     name_901     null     
+2     2     name_902     null     
+3     3     name_903     null     
+4     4     name_904     null     
+5     5     name_905     null     
+6     6     name_906     null     
+7     7     name_907     null     
+8     8     name_908     null     
+9     9     name_909     null     
+10     0     name_910     null     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, nth_value([dba.test_table].[name], ?) over (partition by ? order by ? desc ), nth_value([dba.test_table].[name], ?) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+069. PERCENT_RANK single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+pr_1    
+0.0     
+0.010101010101010102     
+0.020202020202020204     
+0.030303030303030304     
+0.04040404040404041     
+0.050505050505050504     
+0.06060606060606061     
+0.0707070707070707     
+0.08080808080808081     
+0.09090909090909091     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select percent_rank() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+070. PERCENT_RANK two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    pr_1    pr_2    
+1     1     0.0     0.0     
+2     2     0.0     0.0     
+3     3     0.0     0.0     
+4     4     0.0     0.0     
+5     5     0.0     0.0     
+6     6     0.0     0.0     
+7     7     0.0     0.0     
+8     8     0.0     0.0     
+9     9     0.0     0.0     
+10     0     0.0     0.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, percent_rank() over (partition by ? order by ?), percent_rank() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+071. PERCENT_RANK two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    pr_2    pr_1    
+1     1     0.0     0.0     
+2     2     0.0     0.0     
+3     3     0.0     0.0     
+4     4     0.0     0.0     
+5     5     0.0     0.0     
+6     6     0.0     0.0     
+7     7     0.0     0.0     
+8     8     0.0     0.0     
+9     9     0.0     0.0     
+10     0     0.0     0.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, percent_rank() over (partition by ? order by ?), percent_rank() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+072. PERCENT_RANK conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    pr_1    pr_2    
+1     1     1.0     0.0     
+2     2     1.0     0.0     
+3     3     1.0     0.0     
+4     4     1.0     0.0     
+5     5     1.0     0.0     
+6     6     1.0     0.0     
+7     7     1.0     0.0     
+8     8     1.0     0.0     
+9     9     1.0     0.0     
+10     0     1.0     0.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, percent_rank() over (partition by ? order by ? desc ), percent_rank() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+073. STDDEV_POP single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+sp_1    
+0.0     
+5.0     
+8.16496580927726     
+11.180339887498949     
+14.142135623730951     
+17.07825127659933     
+20.0     
+22.9128784747792     
+25.81988897471611     
+28.722813232690143     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select stddev_pop([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+074. STDDEV_POP two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    sp_1    sp_2    
+1     1     0.0     0.0     
+2     2     0.0     0.0     
+3     3     0.0     0.0     
+4     4     0.0     0.0     
+5     5     0.0     0.0     
+6     6     0.0     0.0     
+7     7     0.0     0.0     
+8     8     0.0     0.0     
+9     9     0.0     0.0     
+10     0     0.0     0.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, stddev_pop([dba.test_table].id) over (partition by ? order by ?), stddev_pop([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+075. STDDEV_POP two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    sp_2    sp_1    
+1     1     0.0     0.0     
+2     2     0.0     0.0     
+3     3     0.0     0.0     
+4     4     0.0     0.0     
+5     5     0.0     0.0     
+6     6     0.0     0.0     
+7     7     0.0     0.0     
+8     8     0.0     0.0     
+9     9     0.0     0.0     
+10     0     0.0     0.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, stddev_pop([dba.test_table].val) over (partition by ? order by ?), stddev_pop([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+076. STDDEV_POP conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    sp_1    sp_2    
+1     1     288.66070047722116     0.0     
+2     2     288.66070047722116     0.0     
+3     3     288.66070047722116     0.0     
+4     4     288.66070047722116     0.0     
+5     5     288.66070047722116     0.0     
+6     6     288.66070047722116     0.0     
+7     7     288.66070047722116     0.0     
+8     8     288.66070047722116     0.0     
+9     9     288.66070047722116     0.0     
+10     0     288.66070047722116     0.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, stddev_pop([dba.test_table].id) over (partition by ? order by ? desc ), stddev_pop([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+077. STDDEV_SAMP single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+ss_1    
+null     
+7.0710678118654755     
+10.0     
+12.909944487358056     
+15.811388300841896     
+18.708286933869708     
+21.602468994692874     
+24.49489742783178     
+27.386127875258307     
+30.276503540974907     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select stddev_samp([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+078. STDDEV_SAMP two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    ss_1    ss_2    
+1     1     null     null     
+2     2     null     null     
+3     3     null     null     
+4     4     null     null     
+5     5     null     null     
+6     6     null     null     
+7     7     null     null     
+8     8     null     null     
+9     9     null     null     
+10     0     null     null     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, stddev_samp([dba.test_table].id) over (partition by ? order by ?), stddev_samp([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+079. STDDEV_SAMP two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    ss_2    ss_1    
+1     1     null     null     
+2     2     null     null     
+3     3     null     null     
+4     4     null     null     
+5     5     null     null     
+6     6     null     null     
+7     7     null     null     
+8     8     null     null     
+9     9     null     null     
+10     0     null     null     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, stddev_samp([dba.test_table].val) over (partition by ? order by ?), stddev_samp([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+080. STDDEV_SAMP conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    ss_1    ss_2    
+1     1     290.1149197588202     null     
+2     2     290.1149197588202     null     
+3     3     290.1149197588202     null     
+4     4     290.1149197588202     null     
+5     5     290.1149197588202     null     
+6     6     290.1149197588201     null     
+7     7     290.11491975882024     null     
+8     8     290.1149197588202     null     
+9     9     290.1149197588202     null     
+10     0     290.1149197588202     null     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, stddev_samp([dba.test_table].id) over (partition by ? order by ? desc ), stddev_samp([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+081. SUM single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+sm_1    
+10     
+30     
+60     
+100     
+150     
+210     
+280     
+360     
+450     
+550     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select sum([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+082. SUM two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    sm_1    sm_2    
+1     1     1     1     
+2     2     2     2     
+3     3     3     3     
+4     4     4     4     
+5     5     5     5     
+6     6     6     6     
+7     7     7     7     
+8     8     8     8     
+9     9     9     9     
+10     0     10     0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, sum([dba.test_table].id) over (partition by ? order by ?), sum([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+083. SUM two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    sm_2    sm_1    
+1     1     1     1     
+2     2     2     2     
+3     3     3     3     
+4     4     4     4     
+5     5     5     5     
+6     6     6     6     
+7     7     7     7     
+8     8     8     8     
+9     9     9     9     
+10     0     0     10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, sum([dba.test_table].val) over (partition by ? order by ?), sum([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+084. SUM conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    sm_1    sm_2    
+1     1     49600     1     
+2     2     49700     2     
+3     3     49800     3     
+4     4     49900     4     
+5     5     50000     5     
+6     6     50100     6     
+7     7     50200     7     
+8     8     50300     8     
+9     9     50400     9     
+10     0     50500     0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, sum([dba.test_table].id) over (partition by ? order by ? desc ), sum([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+085. VAR_POP single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+vp_1    
+0.0     
+25.0     
+66.66666666666669     
+125.0     
+200.0     
+291.66666666666674     
+400.0     
+525.0     
+666.6666666666665     
+825.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select var_pop([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+086. VAR_POP two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    vp_1    vp_2    
+1     1     0.0     0.0     
+2     2     0.0     0.0     
+3     3     0.0     0.0     
+4     4     0.0     0.0     
+5     5     0.0     0.0     
+6     6     0.0     0.0     
+7     7     0.0     0.0     
+8     8     0.0     0.0     
+9     9     0.0     0.0     
+10     0     0.0     0.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, var_pop([dba.test_table].id) over (partition by ? order by ?), var_pop([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+087. VAR_POP two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    vp_2    vp_1    
+1     1     0.0     0.0     
+2     2     0.0     0.0     
+3     3     0.0     0.0     
+4     4     0.0     0.0     
+5     5     0.0     0.0     
+6     6     0.0     0.0     
+7     7     0.0     0.0     
+8     8     0.0     0.0     
+9     9     0.0     0.0     
+10     0     0.0     0.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, var_pop([dba.test_table].val) over (partition by ? order by ?), var_pop([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+088. VAR_POP conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    vp_1    vp_2    
+1     1     83325.0     0.0     
+2     2     83325.0     0.0     
+3     3     83325.0     0.0     
+4     4     83325.0     0.0     
+5     5     83325.0     0.0     
+6     6     83325.0     0.0     
+7     7     83325.0     0.0     
+8     8     83325.0     0.0     
+9     9     83325.0     0.0     
+10     0     83325.0     0.0     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, var_pop([dba.test_table].id) over (partition by ? order by ? desc ), var_pop([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+089. VAR_SAMP single analytic - OVER matches midx_01(val,id), sort skipped     
+
+===================================================
+vs_1    
+null     
+50.0     
+100.0     
+166.66666666666663     
+250.0     
+350.0     
+466.66666666666697     
+600.0     
+750.0     
+916.6666666666661     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select var_samp([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+090. VAR_SAMP two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required     
+
+===================================================
+id    val    vs_1    vs_2    
+1     1     null     null     
+2     2     null     null     
+3     3     null     null     
+4     4     null     null     
+5     5     null     null     
+6     6     null     null     
+7     7     null     null     
+8     8     null     null     
+9     9     null     null     
+10     0     null     null     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, var_samp([dba.test_table].id) over (partition by ? order by ?), var_samp([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+091. VAR_SAMP two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped     
+
+===================================================
+id    val    vs_2    vs_1    
+1     1     null     null     
+2     2     null     null     
+3     3     null     null     
+4     4     null     null     
+5     5     null     null     
+6     6     null     null     
+7     7     null     null     
+8     8     null     null     
+9     9     null     null     
+10     0     null     null     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, var_samp([dba.test_table].val) over (partition by ? order by ?), var_samp([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+092. VAR_SAMP conflicting DESC order on the ASC index - sort required     
+
+===================================================
+id    val    vs_1    vs_2    
+1     1     84166.66666666669     null     
+2     2     84166.66666666666     null     
+3     3     84166.66666666669     null     
+4     4     84166.66666666666     null     
+5     5     84166.66666666669     null     
+6     6     84166.66666666663     null     
+7     7     84166.66666666672     null     
+8     8     84166.66666666666     null     
+9     9     84166.66666666669     null     
+10     0     84166.66666666669     null     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, var_samp([dba.test_table].id) over (partition by ? order by ? desc ), var_samp([dba.test_table].val) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+1000
+===================================================
+0
+===================================================
+    
+093. Two analytics share the sort key (c1,c2,c3,c4) - they merge into a single ANALYTIC # group (sort skipped); the trace prints one line per sort group, not per function     
+
+===================================================
+c1    c2    c3    c4    a1    a2    
+0     0     0     105     1     1     
+0     0     0     210     2     2     
+0     0     0     315     3     3     
+0     0     0     420     4     4     
+0     0     0     525     5     5     
+0     0     0     630     6     6     
+0     0     0     735     7     7     
+0     0     0     840     8     8     
+0     0     0     945     9     9     
+0     0     1     70     1     10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.t_group.gidx) (key range: ([dba.t_group].c?>= ?:? ), covered: true)
+
+  rewritten query: select [dba.t_group].c?, [dba.t_group].c?, [dba.t_group].c?, [dba.t_group].c?, row_number() over (partition by ?, ?, ? order by ?), row_number() over (partition by ?, ? order by ?, ?) from [dba.t_group] [dba.t_group] where ([dba.t_group].c?>= ?:? ) and (inst_num()<= ?:? ) using index [dba.t_group].gidx(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.t_group.gidx), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+1000
+===================================================
+0
+===================================================
+    
+094. Partition on leading index columns (c1, c2, c3), no ORDER BY - sort skipped     
+
+===================================================
+c1    c2    c3    rn    
+0     c2_0     c3_0     1     
+0     c2_0     c3_0     2     
+0     c2_0     c3_0     3     
+0     c2_0     c3_0     4     
+0     c2_0     c3_0     5     
+0     c2_0     c3_0     6     
+0     c2_0     c3_0     7     
+0     c2_0     c3_0     8     
+0     c2_0     c3_0     9     
+0     c2_0     c3_0     10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table_?.midx_?) (key range: ([dba.test_table_?].c?>= ?:? ), covered: true)
+
+  rewritten query: select [dba.test_table_?].c?, [dba.test_table_?].c?, [dba.test_table_?].c?, row_number() over (partition by ?, ?, ?) from [dba.test_table_?] [dba.test_table_?] where ([dba.test_table_?].c?>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table_?].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table_?.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+095. ORDER BY c4 (not an index column) - sort required     
+
+===================================================
+c1    c2    c3    rn    
+0     c2_0     c3_0     1     
+0     c2_0     c3_0     2     
+0     c2_0     c3_0     3     
+0     c2_0     c3_0     4     
+0     c2_0     c3_0     5     
+0     c2_0     c3_0     6     
+0     c2_0     c3_0     7     
+0     c2_0     c3_0     8     
+0     c2_0     c3_0     9     
+0     c2_0     c3_0     10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table_?.midx_?) (key range: ([dba.test_table_?].c?>= ?:? ))
+
+  rewritten query: select [dba.test_table_?].c?, [dba.test_table_?].c?, [dba.test_table_?].c?, row_number() over (partition by ?, ?, ? order by ?) from [dba.test_table_?] [dba.test_table_?] where ([dba.test_table_?].c?>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table_?].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table_?.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+096. ORDER BY mod(c1, 10) (the function-based 4th index column) - sort skipped     
+
+===================================================
+c1    c2    c3    rn    
+0     c2_0     c3_0     1     
+0     c2_0     c3_0     2     
+0     c2_0     c3_0     3     
+0     c2_0     c3_0     4     
+0     c2_0     c3_0     5     
+0     c2_0     c3_0     6     
+0     c2_0     c3_0     7     
+0     c2_0     c3_0     8     
+0     c2_0     c3_0     9     
+0     c2_0     c3_0     10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table_?.midx_?) (key range: ([dba.test_table_?].c?>= ?:? ))
+
+  rewritten query: select [dba.test_table_?].c?, [dba.test_table_?].c?, [dba.test_table_?].c?, row_number() over (partition by ?, ?, ? order by ?) from [dba.test_table_?] [dba.test_table_?] where ([dba.test_table_?].c?>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table_?].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table_?.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+097. use_desc_idx with ascending OVER order - descending scan conflicts, sort required     
+
+===================================================
+c1    c2    c3    rn    
+0     c2_0     c3_0     1     
+0     c2_0     c3_0     2     
+0     c2_0     c3_0     3     
+0     c2_0     c3_0     4     
+0     c2_0     c3_0     5     
+0     c2_0     c3_0     6     
+0     c2_0     c3_0     7     
+0     c2_0     c3_0     8     
+0     c2_0     c3_0     9     
+0     c2_0     c3_0     10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table_?.midx_?) (key range: ([dba.test_table_?].c?>= ?:? ), desc_index forced: true)
+
+  rewritten query: select /*+ USE_DESC_IDX */ [dba.test_table_?].c?, [dba.test_table_?].c?, [dba.test_table_?].c?, row_number() over (partition by ?, ?, ? order by ?) from [dba.test_table_?] [dba.test_table_?] where ([dba.test_table_?].c?>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table_?].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table_?.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+098. use_desc_idx with all-descending OVER order - matches descending scan, sort skipped     
+
+===================================================
+c1    c2    c3    rn    
+99     c2_9     c3_9     1     
+99     c2_9     c3_9     2     
+99     c2_9     c3_9     3     
+99     c2_9     c3_9     4     
+99     c2_9     c3_9     5     
+99     c2_9     c3_9     6     
+99     c2_9     c3_9     7     
+99     c2_9     c3_9     8     
+99     c2_9     c3_9     9     
+99     c2_9     c3_9     10     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table_?.midx_?) (key range: ([dba.test_table_?].c?>= ?:? ), desc_index forced: true)
+
+  rewritten query: select /*+ USE_DESC_IDX */ [dba.test_table_?].c?, [dba.test_table_?].c?, [dba.test_table_?].c?, row_number() over (partition by ? desc , ? desc , ? desc  order by ? desc ) from [dba.test_table_?] [dba.test_table_?] where ([dba.test_table_?].c?>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table_?].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table_?.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+0
+===================================================
+0

--- a/sql/_36_guava/cbrd_26473/answers/cbrd_26473.answer
+++ b/sql/_36_guava/cbrd_26473/answers/cbrd_26473.answer
@@ -13,17 +13,37 @@
 001. NTILE single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-ntile_1    
-1     
-1     
-1     
-1     
-1     
-1     
-1     
-1     
-1     
-1     
+id    val    ntile_1    
+10     0     1     
+20     0     1     
+30     0     1     
+40     0     1     
+50     0     1     
+60     0     1     
+70     0     1     
+80     0     1     
+90     0     1     
+100     0     1     
+110     0     1     
+120     0     1     
+130     0     1     
+140     0     1     
+150     0     1     
+160     0     1     
+170     0     1     
+180     0     1     
+190     0     1     
+200     0     1     
+210     0     2     
+220     0     2     
+230     0     2     
+240     0     2     
+250     0     2     
+260     0     2     
+270     0     2     
+280     0     2     
+290     0     2     
+300     0     2     
 
 ===================================================
 trace    
@@ -31,7 +51,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
 
-  rewritten query: select ntile(?) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, ntile(?) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -55,6 +75,26 @@ id    val    ntile_1    ntile_2
 8     8     1     1     
 9     9     1     1     
 10     0     1     1     
+11     1     1     1     
+12     2     1     1     
+13     3     1     1     
+14     4     1     1     
+15     5     1     1     
+16     6     1     1     
+17     7     1     1     
+18     8     1     1     
+19     9     1     1     
+20     0     1     1     
+21     1     1     1     
+22     2     1     1     
+23     3     1     1     
+24     4     1     1     
+25     5     1     1     
+26     6     1     1     
+27     7     1     1     
+28     8     1     1     
+29     9     1     1     
+30     0     1     1     
 
 ===================================================
 trace    
@@ -87,6 +127,26 @@ id    val    ntile_2    ntile_1
 8     8     1     1     
 9     9     1     1     
 10     0     1     1     
+11     1     1     1     
+12     2     1     1     
+13     3     1     1     
+14     4     1     1     
+15     5     1     1     
+16     6     1     1     
+17     7     1     1     
+18     8     1     1     
+19     9     1     1     
+20     0     1     1     
+21     1     1     1     
+22     2     1     1     
+23     3     1     1     
+24     4     1     1     
+25     5     1     1     
+26     6     1     1     
+27     7     1     1     
+28     8     1     1     
+29     9     1     1     
+30     0     1     1     
 
 ===================================================
 trace    
@@ -119,6 +179,26 @@ id    val    ntile_1    ntile_2
 8     8     5     1     
 9     9     5     1     
 10     0     5     1     
+11     1     5     1     
+12     2     5     1     
+13     3     5     1     
+14     4     5     1     
+15     5     5     1     
+16     6     5     1     
+17     7     5     1     
+18     8     5     1     
+19     9     5     1     
+20     0     5     1     
+21     1     5     1     
+22     2     5     1     
+23     3     5     1     
+24     4     5     1     
+25     5     5     1     
+26     6     5     1     
+27     7     5     1     
+28     8     5     1     
+29     9     5     1     
+30     0     5     1     
 
 ===================================================
 trace    
@@ -140,17 +220,37 @@ Trace Statistics:
 005. MEDIAN single analytic - OVER(partition by val) covered by midx_01 leading column, sort skipped     
 
 ===================================================
-md_1    
-505.0     
-505.0     
-505.0     
-505.0     
-505.0     
-505.0     
-505.0     
-505.0     
-505.0     
-505.0     
+id    val    md_1    
+10     0     505.0     
+20     0     505.0     
+30     0     505.0     
+40     0     505.0     
+50     0     505.0     
+60     0     505.0     
+70     0     505.0     
+80     0     505.0     
+90     0     505.0     
+100     0     505.0     
+110     0     505.0     
+120     0     505.0     
+130     0     505.0     
+140     0     505.0     
+150     0     505.0     
+160     0     505.0     
+170     0     505.0     
+180     0     505.0     
+190     0     505.0     
+200     0     505.0     
+210     0     505.0     
+220     0     505.0     
+230     0     505.0     
+240     0     505.0     
+250     0     505.0     
+260     0     505.0     
+270     0     505.0     
+280     0     505.0     
+290     0     505.0     
+300     0     505.0     
 
 ===================================================
 trace    
@@ -158,7 +258,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
 
-  rewritten query: select median([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, median([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -182,6 +282,26 @@ id    val    md_1    md_2
 8     8     503.0     8.0     
 9     9     504.0     9.0     
 10     0     505.0     0.0     
+11     1     496.0     1.0     
+12     2     497.0     2.0     
+13     3     498.0     3.0     
+14     4     499.0     4.0     
+15     5     500.0     5.0     
+16     6     501.0     6.0     
+17     7     502.0     7.0     
+18     8     503.0     8.0     
+19     9     504.0     9.0     
+20     0     505.0     0.0     
+21     1     496.0     1.0     
+22     2     497.0     2.0     
+23     3     498.0     3.0     
+24     4     499.0     4.0     
+25     5     500.0     5.0     
+26     6     501.0     6.0     
+27     7     502.0     7.0     
+28     8     503.0     8.0     
+29     9     504.0     9.0     
+30     0     505.0     0.0     
 
 ===================================================
 trace    
@@ -214,6 +334,26 @@ id    val    md_2    md_1
 8     8     8.0     503.0     
 9     9     9.0     504.0     
 10     0     0.0     505.0     
+11     1     1.0     496.0     
+12     2     2.0     497.0     
+13     3     3.0     498.0     
+14     4     4.0     499.0     
+15     5     5.0     500.0     
+16     6     6.0     501.0     
+17     7     7.0     502.0     
+18     8     8.0     503.0     
+19     9     9.0     504.0     
+20     0     0.0     505.0     
+21     1     1.0     496.0     
+22     2     2.0     497.0     
+23     3     3.0     498.0     
+24     4     4.0     499.0     
+25     5     5.0     500.0     
+26     6     6.0     501.0     
+27     7     7.0     502.0     
+28     8     8.0     503.0     
+29     9     9.0     504.0     
+30     0     0.0     505.0     
 
 ===================================================
 trace    
@@ -246,6 +386,26 @@ id    val    md_1    md_2
 8     8     8.0     8.0     
 9     9     9.0     9.0     
 10     0     10.0     0.0     
+11     1     11.0     1.0     
+12     2     12.0     2.0     
+13     3     13.0     3.0     
+14     4     14.0     4.0     
+15     5     15.0     5.0     
+16     6     16.0     6.0     
+17     7     17.0     7.0     
+18     8     18.0     8.0     
+19     9     19.0     9.0     
+20     0     20.0     0.0     
+21     1     21.0     1.0     
+22     2     22.0     2.0     
+23     3     23.0     3.0     
+24     4     24.0     4.0     
+25     5     25.0     5.0     
+26     6     26.0     6.0     
+27     7     27.0     7.0     
+28     8     28.0     8.0     
+29     9     29.0     9.0     
+30     0     30.0     0.0     
 
 ===================================================
 trace    
@@ -267,17 +427,37 @@ Trace Statistics:
 009. PERCENTILE_CONT single analytic - within group(order by id) over(partition by val) covered by midx_01, sort skipped     
 
 ===================================================
-pc_1    
-505.0     
-505.0     
-505.0     
-505.0     
-505.0     
-505.0     
-505.0     
-505.0     
-505.0     
-505.0     
+id    val    pc_1    
+10     0     505.0     
+20     0     505.0     
+30     0     505.0     
+40     0     505.0     
+50     0     505.0     
+60     0     505.0     
+70     0     505.0     
+80     0     505.0     
+90     0     505.0     
+100     0     505.0     
+110     0     505.0     
+120     0     505.0     
+130     0     505.0     
+140     0     505.0     
+150     0     505.0     
+160     0     505.0     
+170     0     505.0     
+180     0     505.0     
+190     0     505.0     
+200     0     505.0     
+210     0     505.0     
+220     0     505.0     
+230     0     505.0     
+240     0     505.0     
+250     0     505.0     
+260     0     505.0     
+270     0     505.0     
+280     0     505.0     
+290     0     505.0     
+300     0     505.0     
 
 ===================================================
 trace    
@@ -285,7 +465,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
 
-  rewritten query: select percentile_cont( cast(?.? as double)) within group (order by [dba.test_table].id) over (partition by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, percentile_cont( cast(?.? as double)) within group (order by [dba.test_table].id) over (partition by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -309,6 +489,26 @@ id    val    pc_1    pc_2
 8     8     503.0     8.0     
 9     9     504.0     9.0     
 10     0     505.0     0.0     
+11     1     496.0     1.0     
+12     2     497.0     2.0     
+13     3     498.0     3.0     
+14     4     499.0     4.0     
+15     5     500.0     5.0     
+16     6     501.0     6.0     
+17     7     502.0     7.0     
+18     8     503.0     8.0     
+19     9     504.0     9.0     
+20     0     505.0     0.0     
+21     1     496.0     1.0     
+22     2     497.0     2.0     
+23     3     498.0     3.0     
+24     4     499.0     4.0     
+25     5     500.0     5.0     
+26     6     501.0     6.0     
+27     7     502.0     7.0     
+28     8     503.0     8.0     
+29     9     504.0     9.0     
+30     0     505.0     0.0     
 
 ===================================================
 trace    
@@ -341,6 +541,26 @@ id    val    pc_2    pc_1
 8     8     8.0     503.0     
 9     9     9.0     504.0     
 10     0     0.0     505.0     
+11     1     1.0     496.0     
+12     2     2.0     497.0     
+13     3     3.0     498.0     
+14     4     4.0     499.0     
+15     5     5.0     500.0     
+16     6     6.0     501.0     
+17     7     7.0     502.0     
+18     8     8.0     503.0     
+19     9     9.0     504.0     
+20     0     0.0     505.0     
+21     1     1.0     496.0     
+22     2     2.0     497.0     
+23     3     3.0     498.0     
+24     4     4.0     499.0     
+25     5     5.0     500.0     
+26     6     6.0     501.0     
+27     7     7.0     502.0     
+28     8     8.0     503.0     
+29     9     9.0     504.0     
+30     0     0.0     505.0     
 
 ===================================================
 trace    
@@ -373,6 +593,26 @@ id    val    pc_1    pc_2
 8     8     503.0     8.0     
 9     9     504.0     9.0     
 10     0     505.0     0.0     
+11     1     496.0     1.0     
+12     2     497.0     2.0     
+13     3     498.0     3.0     
+14     4     499.0     4.0     
+15     5     500.0     5.0     
+16     6     501.0     6.0     
+17     7     502.0     7.0     
+18     8     503.0     8.0     
+19     9     504.0     9.0     
+20     0     505.0     0.0     
+21     1     496.0     1.0     
+22     2     497.0     2.0     
+23     3     498.0     3.0     
+24     4     499.0     4.0     
+25     5     500.0     5.0     
+26     6     501.0     6.0     
+27     7     502.0     7.0     
+28     8     503.0     8.0     
+29     9     504.0     9.0     
+30     0     505.0     0.0     
 
 ===================================================
 trace    
@@ -394,17 +634,37 @@ Trace Statistics:
 013. PERCENTILE_DISC single analytic - within group(order by id) over(partition by val) covered by midx_01, sort skipped     
 
 ===================================================
-pd_1    
-500     
-500     
-500     
-500     
-500     
-500     
-500     
-500     
-500     
-500     
+id    val    pd_1    
+10     0     500     
+20     0     500     
+30     0     500     
+40     0     500     
+50     0     500     
+60     0     500     
+70     0     500     
+80     0     500     
+90     0     500     
+100     0     500     
+110     0     500     
+120     0     500     
+130     0     500     
+140     0     500     
+150     0     500     
+160     0     500     
+170     0     500     
+180     0     500     
+190     0     500     
+200     0     500     
+210     0     500     
+220     0     500     
+230     0     500     
+240     0     500     
+250     0     500     
+260     0     500     
+270     0     500     
+280     0     500     
+290     0     500     
+300     0     500     
 
 ===================================================
 trace    
@@ -412,7 +672,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
 
-  rewritten query: select percentile_disc( cast(?.? as double)) within group (order by [dba.test_table].id) over (partition by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, percentile_disc( cast(?.? as double)) within group (order by [dba.test_table].id) over (partition by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -436,6 +696,26 @@ id    val    pd_1    pd_2
 8     8     498     8     
 9     9     499     9     
 10     0     500     0     
+11     1     491     1     
+12     2     492     2     
+13     3     493     3     
+14     4     494     4     
+15     5     495     5     
+16     6     496     6     
+17     7     497     7     
+18     8     498     8     
+19     9     499     9     
+20     0     500     0     
+21     1     491     1     
+22     2     492     2     
+23     3     493     3     
+24     4     494     4     
+25     5     495     5     
+26     6     496     6     
+27     7     497     7     
+28     8     498     8     
+29     9     499     9     
+30     0     500     0     
 
 ===================================================
 trace    
@@ -468,6 +748,26 @@ id    val    pd_2    pd_1
 8     8     8     498     
 9     9     9     499     
 10     0     0     500     
+11     1     1     491     
+12     2     2     492     
+13     3     3     493     
+14     4     4     494     
+15     5     5     495     
+16     6     6     496     
+17     7     7     497     
+18     8     8     498     
+19     9     9     499     
+20     0     0     500     
+21     1     1     491     
+22     2     2     492     
+23     3     3     493     
+24     4     4     494     
+25     5     5     495     
+26     6     6     496     
+27     7     7     497     
+28     8     8     498     
+29     9     9     499     
+30     0     0     500     
 
 ===================================================
 trace    
@@ -500,6 +800,26 @@ id    val    pd_1    pd_2
 8     8     508     8     
 9     9     509     9     
 10     0     510     0     
+11     1     501     1     
+12     2     502     2     
+13     3     503     3     
+14     4     504     4     
+15     5     505     5     
+16     6     506     6     
+17     7     507     7     
+18     8     508     8     
+19     9     509     9     
+20     0     510     0     
+21     1     501     1     
+22     2     502     2     
+23     3     503     3     
+24     4     504     4     
+25     5     505     5     
+26     6     506     6     
+27     7     507     7     
+28     8     508     8     
+29     9     509     9     
+30     0     510     0     
 
 ===================================================
 trace    
@@ -521,17 +841,37 @@ Trace Statistics:
 017. ROW_NUMBER single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-rn_1    
-1     
-2     
-3     
-4     
-5     
-6     
-7     
-8     
-9     
-10     
+id    val    rn_1    
+10     0     1     
+20     0     2     
+30     0     3     
+40     0     4     
+50     0     5     
+60     0     6     
+70     0     7     
+80     0     8     
+90     0     9     
+100     0     10     
+110     0     11     
+120     0     12     
+130     0     13     
+140     0     14     
+150     0     15     
+160     0     16     
+170     0     17     
+180     0     18     
+190     0     19     
+200     0     20     
+210     0     21     
+220     0     22     
+230     0     23     
+240     0     24     
+250     0     25     
+260     0     26     
+270     0     27     
+280     0     28     
+290     0     29     
+300     0     30     
 
 ===================================================
 trace    
@@ -539,7 +879,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
 
-  rewritten query: select row_number() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, row_number() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -563,6 +903,26 @@ id    val    rn_1    rn_2
 8     8     1     1     
 9     9     1     1     
 10     0     1     1     
+11     1     2     1     
+12     2     2     1     
+13     3     2     1     
+14     4     2     1     
+15     5     2     1     
+16     6     2     1     
+17     7     2     1     
+18     8     2     1     
+19     9     2     1     
+20     0     2     1     
+21     1     3     1     
+22     2     3     1     
+23     3     3     1     
+24     4     3     1     
+25     5     3     1     
+26     6     3     1     
+27     7     3     1     
+28     8     3     1     
+29     9     3     1     
+30     0     3     1     
 
 ===================================================
 trace    
@@ -595,6 +955,26 @@ id    val    rn_2    rn_1
 8     8     1     1     
 9     9     1     1     
 10     0     1     1     
+11     1     1     2     
+12     2     1     2     
+13     3     1     2     
+14     4     1     2     
+15     5     1     2     
+16     6     1     2     
+17     7     1     2     
+18     8     1     2     
+19     9     1     2     
+20     0     1     2     
+21     1     1     3     
+22     2     1     3     
+23     3     1     3     
+24     4     1     3     
+25     5     1     3     
+26     6     1     3     
+27     7     1     3     
+28     8     1     3     
+29     9     1     3     
+30     0     1     3     
 
 ===================================================
 trace    
@@ -627,6 +1007,26 @@ id    val    rn_1    rn_2
 8     8     100     1     
 9     9     100     1     
 10     0     100     1     
+11     1     99     1     
+12     2     99     1     
+13     3     99     1     
+14     4     99     1     
+15     5     99     1     
+16     6     99     1     
+17     7     99     1     
+18     8     99     1     
+19     9     99     1     
+20     0     99     1     
+21     1     98     1     
+22     2     98     1     
+23     3     98     1     
+24     4     98     1     
+25     5     98     1     
+26     6     98     1     
+27     7     98     1     
+28     8     98     1     
+29     9     98     1     
+30     0     98     1     
 
 ===================================================
 trace    
@@ -648,17 +1048,37 @@ Trace Statistics:
 021. RANK single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-rk_1    
-1     
-2     
-3     
-4     
-5     
-6     
-7     
-8     
-9     
-10     
+id    val    rk_1    
+10     0     1     
+20     0     2     
+30     0     3     
+40     0     4     
+50     0     5     
+60     0     6     
+70     0     7     
+80     0     8     
+90     0     9     
+100     0     10     
+110     0     11     
+120     0     12     
+130     0     13     
+140     0     14     
+150     0     15     
+160     0     16     
+170     0     17     
+180     0     18     
+190     0     19     
+200     0     20     
+210     0     21     
+220     0     22     
+230     0     23     
+240     0     24     
+250     0     25     
+260     0     26     
+270     0     27     
+280     0     28     
+290     0     29     
+300     0     30     
 
 ===================================================
 trace    
@@ -666,7 +1086,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
 
-  rewritten query: select rank() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, rank() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -690,6 +1110,26 @@ id    val    rk_1    rk_2
 8     8     1     1     
 9     9     1     1     
 10     0     1     1     
+11     1     2     1     
+12     2     2     1     
+13     3     2     1     
+14     4     2     1     
+15     5     2     1     
+16     6     2     1     
+17     7     2     1     
+18     8     2     1     
+19     9     2     1     
+20     0     2     1     
+21     1     3     1     
+22     2     3     1     
+23     3     3     1     
+24     4     3     1     
+25     5     3     1     
+26     6     3     1     
+27     7     3     1     
+28     8     3     1     
+29     9     3     1     
+30     0     3     1     
 
 ===================================================
 trace    
@@ -722,6 +1162,26 @@ id    val    rk_2    rk_1
 8     8     1     1     
 9     9     1     1     
 10     0     1     1     
+11     1     1     2     
+12     2     1     2     
+13     3     1     2     
+14     4     1     2     
+15     5     1     2     
+16     6     1     2     
+17     7     1     2     
+18     8     1     2     
+19     9     1     2     
+20     0     1     2     
+21     1     1     3     
+22     2     1     3     
+23     3     1     3     
+24     4     1     3     
+25     5     1     3     
+26     6     1     3     
+27     7     1     3     
+28     8     1     3     
+29     9     1     3     
+30     0     1     3     
 
 ===================================================
 trace    
@@ -754,6 +1214,26 @@ id    val    rk_1    rk_2
 8     8     100     1     
 9     9     100     1     
 10     0     100     1     
+11     1     99     1     
+12     2     99     1     
+13     3     99     1     
+14     4     99     1     
+15     5     99     1     
+16     6     99     1     
+17     7     99     1     
+18     8     99     1     
+19     9     99     1     
+20     0     99     1     
+21     1     98     1     
+22     2     98     1     
+23     3     98     1     
+24     4     98     1     
+25     5     98     1     
+26     6     98     1     
+27     7     98     1     
+28     8     98     1     
+29     9     98     1     
+30     0     98     1     
 
 ===================================================
 trace    
@@ -775,17 +1255,37 @@ Trace Statistics:
 025. DENSE_RANK single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-dr_1    
-1     
-2     
-3     
-4     
-5     
-6     
-7     
-8     
-9     
-10     
+id    val    dr_1    
+10     0     1     
+20     0     2     
+30     0     3     
+40     0     4     
+50     0     5     
+60     0     6     
+70     0     7     
+80     0     8     
+90     0     9     
+100     0     10     
+110     0     11     
+120     0     12     
+130     0     13     
+140     0     14     
+150     0     15     
+160     0     16     
+170     0     17     
+180     0     18     
+190     0     19     
+200     0     20     
+210     0     21     
+220     0     22     
+230     0     23     
+240     0     24     
+250     0     25     
+260     0     26     
+270     0     27     
+280     0     28     
+290     0     29     
+300     0     30     
 
 ===================================================
 trace    
@@ -793,7 +1293,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
 
-  rewritten query: select dense_rank() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, dense_rank() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -817,6 +1317,26 @@ id    val    dr_1    dr_2
 8     8     1     1     
 9     9     1     1     
 10     0     1     1     
+11     1     2     1     
+12     2     2     1     
+13     3     2     1     
+14     4     2     1     
+15     5     2     1     
+16     6     2     1     
+17     7     2     1     
+18     8     2     1     
+19     9     2     1     
+20     0     2     1     
+21     1     3     1     
+22     2     3     1     
+23     3     3     1     
+24     4     3     1     
+25     5     3     1     
+26     6     3     1     
+27     7     3     1     
+28     8     3     1     
+29     9     3     1     
+30     0     3     1     
 
 ===================================================
 trace    
@@ -849,6 +1369,26 @@ id    val    dr_2    dr_1
 8     8     1     1     
 9     9     1     1     
 10     0     1     1     
+11     1     1     2     
+12     2     1     2     
+13     3     1     2     
+14     4     1     2     
+15     5     1     2     
+16     6     1     2     
+17     7     1     2     
+18     8     1     2     
+19     9     1     2     
+20     0     1     2     
+21     1     1     3     
+22     2     1     3     
+23     3     1     3     
+24     4     1     3     
+25     5     1     3     
+26     6     1     3     
+27     7     1     3     
+28     8     1     3     
+29     9     1     3     
+30     0     1     3     
 
 ===================================================
 trace    
@@ -881,6 +1421,26 @@ id    val    dr_1    dr_2
 8     8     100     1     
 9     9     100     1     
 10     0     100     1     
+11     1     99     1     
+12     2     99     1     
+13     3     99     1     
+14     4     99     1     
+15     5     99     1     
+16     6     99     1     
+17     7     99     1     
+18     8     99     1     
+19     9     99     1     
+20     0     99     1     
+21     1     98     1     
+22     2     98     1     
+23     3     98     1     
+24     4     98     1     
+25     5     98     1     
+26     6     98     1     
+27     7     98     1     
+28     8     98     1     
+29     9     98     1     
+30     0     98     1     
 
 ===================================================
 trace    
@@ -902,17 +1462,37 @@ Trace Statistics:
 029. AVG single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-av_1    
-10.0     
-15.0     
-20.0     
-25.0     
-30.0     
-35.0     
-40.0     
-45.0     
-50.0     
-55.0     
+id    val    av_1    
+10     0     10.0     
+20     0     15.0     
+30     0     20.0     
+40     0     25.0     
+50     0     30.0     
+60     0     35.0     
+70     0     40.0     
+80     0     45.0     
+90     0     50.0     
+100     0     55.0     
+110     0     60.0     
+120     0     65.0     
+130     0     70.0     
+140     0     75.0     
+150     0     80.0     
+160     0     85.0     
+170     0     90.0     
+180     0     95.0     
+190     0     100.0     
+200     0     105.0     
+210     0     110.0     
+220     0     115.0     
+230     0     120.0     
+240     0     125.0     
+250     0     130.0     
+260     0     135.0     
+270     0     140.0     
+280     0     145.0     
+290     0     150.0     
+300     0     155.0     
 
 ===================================================
 trace    
@@ -920,7 +1500,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
 
-  rewritten query: select avg([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, avg([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -944,6 +1524,26 @@ id    val    av_1    av_2
 8     8     8.0     8.0     
 9     9     9.0     9.0     
 10     0     10.0     0.0     
+11     1     6.0     1.0     
+12     2     7.0     2.0     
+13     3     8.0     3.0     
+14     4     9.0     4.0     
+15     5     10.0     5.0     
+16     6     11.0     6.0     
+17     7     12.0     7.0     
+18     8     13.0     8.0     
+19     9     14.0     9.0     
+20     0     15.0     0.0     
+21     1     11.0     1.0     
+22     2     12.0     2.0     
+23     3     13.0     3.0     
+24     4     14.0     4.0     
+25     5     15.0     5.0     
+26     6     16.0     6.0     
+27     7     17.0     7.0     
+28     8     18.0     8.0     
+29     9     19.0     9.0     
+30     0     20.0     0.0     
 
 ===================================================
 trace    
@@ -976,6 +1576,26 @@ id    val    av_2    av_1
 8     8     8.0     8.0     
 9     9     9.0     9.0     
 10     0     0.0     10.0     
+11     1     1.0     6.0     
+12     2     2.0     7.0     
+13     3     3.0     8.0     
+14     4     4.0     9.0     
+15     5     5.0     10.0     
+16     6     6.0     11.0     
+17     7     7.0     12.0     
+18     8     8.0     13.0     
+19     9     9.0     14.0     
+20     0     0.0     15.0     
+21     1     1.0     11.0     
+22     2     2.0     12.0     
+23     3     3.0     13.0     
+24     4     4.0     14.0     
+25     5     5.0     15.0     
+26     6     6.0     16.0     
+27     7     7.0     17.0     
+28     8     8.0     18.0     
+29     9     9.0     19.0     
+30     0     0.0     20.0     
 
 ===================================================
 trace    
@@ -1008,6 +1628,26 @@ id    val    av_1    av_2
 8     8     503.0     8.0     
 9     9     504.0     9.0     
 10     0     505.0     0.0     
+11     1     501.0     1.0     
+12     2     502.0     2.0     
+13     3     503.0     3.0     
+14     4     504.0     4.0     
+15     5     505.0     5.0     
+16     6     506.0     6.0     
+17     7     507.0     7.0     
+18     8     508.0     8.0     
+19     9     509.0     9.0     
+20     0     510.0     0.0     
+21     1     506.0     1.0     
+22     2     507.0     2.0     
+23     3     508.0     3.0     
+24     4     509.0     4.0     
+25     5     510.0     5.0     
+26     6     511.0     6.0     
+27     7     512.0     7.0     
+28     8     513.0     8.0     
+29     9     514.0     9.0     
+30     0     515.0     0.0     
 
 ===================================================
 trace    
@@ -1029,17 +1669,37 @@ Trace Statistics:
 033. COUNT single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-cnt_1    
-1     
-2     
-3     
-4     
-5     
-6     
-7     
-8     
-9     
-10     
+id    val    cnt_1    
+10     0     1     
+20     0     2     
+30     0     3     
+40     0     4     
+50     0     5     
+60     0     6     
+70     0     7     
+80     0     8     
+90     0     9     
+100     0     10     
+110     0     11     
+120     0     12     
+130     0     13     
+140     0     14     
+150     0     15     
+160     0     16     
+170     0     17     
+180     0     18     
+190     0     19     
+200     0     20     
+210     0     21     
+220     0     22     
+230     0     23     
+240     0     24     
+250     0     25     
+260     0     26     
+270     0     27     
+280     0     28     
+290     0     29     
+300     0     30     
 
 ===================================================
 trace    
@@ -1047,7 +1707,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
 
-  rewritten query: select count(*) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, count(*) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -1071,6 +1731,26 @@ id    val    cnt_1    cnt_2
 8     8     1     1     
 9     9     1     1     
 10     0     1     1     
+11     1     2     1     
+12     2     2     1     
+13     3     2     1     
+14     4     2     1     
+15     5     2     1     
+16     6     2     1     
+17     7     2     1     
+18     8     2     1     
+19     9     2     1     
+20     0     2     1     
+21     1     3     1     
+22     2     3     1     
+23     3     3     1     
+24     4     3     1     
+25     5     3     1     
+26     6     3     1     
+27     7     3     1     
+28     8     3     1     
+29     9     3     1     
+30     0     3     1     
 
 ===================================================
 trace    
@@ -1103,6 +1783,26 @@ id    val    cnt_2    cnt_1
 8     8     1     1     
 9     9     1     1     
 10     0     1     1     
+11     1     1     2     
+12     2     1     2     
+13     3     1     2     
+14     4     1     2     
+15     5     1     2     
+16     6     1     2     
+17     7     1     2     
+18     8     1     2     
+19     9     1     2     
+20     0     1     2     
+21     1     1     3     
+22     2     1     3     
+23     3     1     3     
+24     4     1     3     
+25     5     1     3     
+26     6     1     3     
+27     7     1     3     
+28     8     1     3     
+29     9     1     3     
+30     0     1     3     
 
 ===================================================
 trace    
@@ -1135,6 +1835,26 @@ id    val    cnt_1    cnt_2
 8     8     100     1     
 9     9     100     1     
 10     0     100     1     
+11     1     99     1     
+12     2     99     1     
+13     3     99     1     
+14     4     99     1     
+15     5     99     1     
+16     6     99     1     
+17     7     99     1     
+18     8     99     1     
+19     9     99     1     
+20     0     99     1     
+21     1     98     1     
+22     2     98     1     
+23     3     98     1     
+24     4     98     1     
+25     5     98     1     
+26     6     98     1     
+27     7     98     1     
+28     8     98     1     
+29     9     98     1     
+30     0     98     1     
 
 ===================================================
 trace    
@@ -1156,17 +1876,37 @@ Trace Statistics:
 037. CUME_DIST single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-cd_1    
-0.01     
-0.02     
-0.03     
-0.04     
-0.05     
-0.06     
-0.07     
-0.08     
-0.09     
-0.1     
+id    val    cd_1    
+10     0     0.01     
+20     0     0.02     
+30     0     0.03     
+40     0     0.04     
+50     0     0.05     
+60     0     0.06     
+70     0     0.07     
+80     0     0.08     
+90     0     0.09     
+100     0     0.1     
+110     0     0.11     
+120     0     0.12     
+130     0     0.13     
+140     0     0.14     
+150     0     0.15     
+160     0     0.16     
+170     0     0.17     
+180     0     0.18     
+190     0     0.19     
+200     0     0.2     
+210     0     0.21     
+220     0     0.22     
+230     0     0.23     
+240     0     0.24     
+250     0     0.25     
+260     0     0.26     
+270     0     0.27     
+280     0     0.28     
+290     0     0.29     
+300     0     0.3     
 
 ===================================================
 trace    
@@ -1174,7 +1914,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
 
-  rewritten query: select cume_dist() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, cume_dist() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -1198,6 +1938,26 @@ id    val    cd_1    cd_2
 8     8     0.01     1.0     
 9     9     0.01     1.0     
 10     0     0.01     1.0     
+11     1     0.02     1.0     
+12     2     0.02     1.0     
+13     3     0.02     1.0     
+14     4     0.02     1.0     
+15     5     0.02     1.0     
+16     6     0.02     1.0     
+17     7     0.02     1.0     
+18     8     0.02     1.0     
+19     9     0.02     1.0     
+20     0     0.02     1.0     
+21     1     0.03     1.0     
+22     2     0.03     1.0     
+23     3     0.03     1.0     
+24     4     0.03     1.0     
+25     5     0.03     1.0     
+26     6     0.03     1.0     
+27     7     0.03     1.0     
+28     8     0.03     1.0     
+29     9     0.03     1.0     
+30     0     0.03     1.0     
 
 ===================================================
 trace    
@@ -1230,6 +1990,26 @@ id    val    cd_2    cd_1
 8     8     1.0     0.01     
 9     9     1.0     0.01     
 10     0     1.0     0.01     
+11     1     1.0     0.02     
+12     2     1.0     0.02     
+13     3     1.0     0.02     
+14     4     1.0     0.02     
+15     5     1.0     0.02     
+16     6     1.0     0.02     
+17     7     1.0     0.02     
+18     8     1.0     0.02     
+19     9     1.0     0.02     
+20     0     1.0     0.02     
+21     1     1.0     0.03     
+22     2     1.0     0.03     
+23     3     1.0     0.03     
+24     4     1.0     0.03     
+25     5     1.0     0.03     
+26     6     1.0     0.03     
+27     7     1.0     0.03     
+28     8     1.0     0.03     
+29     9     1.0     0.03     
+30     0     1.0     0.03     
 
 ===================================================
 trace    
@@ -1262,6 +2042,26 @@ id    val    cd_1    cd_2
 8     8     1.0     1.0     
 9     9     1.0     1.0     
 10     0     1.0     1.0     
+11     1     0.99     1.0     
+12     2     0.99     1.0     
+13     3     0.99     1.0     
+14     4     0.99     1.0     
+15     5     0.99     1.0     
+16     6     0.99     1.0     
+17     7     0.99     1.0     
+18     8     0.99     1.0     
+19     9     0.99     1.0     
+20     0     0.99     1.0     
+21     1     0.98     1.0     
+22     2     0.98     1.0     
+23     3     0.98     1.0     
+24     4     0.98     1.0     
+25     5     0.98     1.0     
+26     6     0.98     1.0     
+27     7     0.98     1.0     
+28     8     0.98     1.0     
+29     9     0.98     1.0     
+30     0     0.98     1.0     
 
 ===================================================
 trace    
@@ -1283,17 +2083,37 @@ Trace Statistics:
 041. FIRST_VALUE single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-fv_1    
-name_10     
-name_10     
-name_10     
-name_10     
-name_10     
-name_10     
-name_10     
-name_10     
-name_10     
-name_10     
+id    val    fv_1    
+10     0     name_10     
+20     0     name_10     
+30     0     name_10     
+40     0     name_10     
+50     0     name_10     
+60     0     name_10     
+70     0     name_10     
+80     0     name_10     
+90     0     name_10     
+100     0     name_10     
+110     0     name_10     
+120     0     name_10     
+130     0     name_10     
+140     0     name_10     
+150     0     name_10     
+160     0     name_10     
+170     0     name_10     
+180     0     name_10     
+190     0     name_10     
+200     0     name_10     
+210     0     name_10     
+220     0     name_10     
+230     0     name_10     
+240     0     name_10     
+250     0     name_10     
+260     0     name_10     
+270     0     name_10     
+280     0     name_10     
+290     0     name_10     
+300     0     name_10     
 
 ===================================================
 trace    
@@ -1301,7 +2121,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
 
-  rewritten query: select first_value([dba.test_table].[name]) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, first_value([dba.test_table].[name]) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -1325,6 +2145,26 @@ id    val    fv_1    fv_2
 8     8     name_8     name_8     
 9     9     name_9     name_9     
 10     0     name_10     name_10     
+11     1     name_1     name_11     
+12     2     name_2     name_12     
+13     3     name_3     name_13     
+14     4     name_4     name_14     
+15     5     name_5     name_15     
+16     6     name_6     name_16     
+17     7     name_7     name_17     
+18     8     name_8     name_18     
+19     9     name_9     name_19     
+20     0     name_10     name_20     
+21     1     name_1     name_21     
+22     2     name_2     name_22     
+23     3     name_3     name_23     
+24     4     name_4     name_24     
+25     5     name_5     name_25     
+26     6     name_6     name_26     
+27     7     name_7     name_27     
+28     8     name_8     name_28     
+29     9     name_9     name_29     
+30     0     name_10     name_30     
 
 ===================================================
 trace    
@@ -1357,6 +2197,26 @@ id    val    fv_2    fv_1
 8     8     name_8     name_8     
 9     9     name_9     name_9     
 10     0     name_10     name_10     
+11     1     name_11     name_1     
+12     2     name_12     name_2     
+13     3     name_13     name_3     
+14     4     name_14     name_4     
+15     5     name_15     name_5     
+16     6     name_16     name_6     
+17     7     name_17     name_7     
+18     8     name_18     name_8     
+19     9     name_19     name_9     
+20     0     name_20     name_10     
+21     1     name_21     name_1     
+22     2     name_22     name_2     
+23     3     name_23     name_3     
+24     4     name_24     name_4     
+25     5     name_25     name_5     
+26     6     name_26     name_6     
+27     7     name_27     name_7     
+28     8     name_28     name_8     
+29     9     name_29     name_9     
+30     0     name_30     name_10     
 
 ===================================================
 trace    
@@ -1389,6 +2249,26 @@ id    val    fv_1    fv_2
 8     8     name_998     name_8     
 9     9     name_999     name_9     
 10     0     name_1000     name_10     
+11     1     name_991     name_11     
+12     2     name_992     name_12     
+13     3     name_993     name_13     
+14     4     name_994     name_14     
+15     5     name_995     name_15     
+16     6     name_996     name_16     
+17     7     name_997     name_17     
+18     8     name_998     name_18     
+19     9     name_999     name_19     
+20     0     name_1000     name_20     
+21     1     name_991     name_21     
+22     2     name_992     name_22     
+23     3     name_993     name_23     
+24     4     name_994     name_24     
+25     5     name_995     name_25     
+26     6     name_996     name_26     
+27     7     name_997     name_27     
+28     8     name_998     name_28     
+29     9     name_999     name_29     
+30     0     name_1000     name_30     
 
 ===================================================
 trace    
@@ -1410,17 +2290,37 @@ Trace Statistics:
 045. LAG single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-lg_1    
-null     
-name_10     
-name_20     
-name_30     
-name_40     
-name_50     
-name_60     
-name_70     
-name_80     
-name_90     
+id    val    lg_1    
+10     0     null     
+20     0     name_10     
+30     0     name_20     
+40     0     name_30     
+50     0     name_40     
+60     0     name_50     
+70     0     name_60     
+80     0     name_70     
+90     0     name_80     
+100     0     name_90     
+110     0     name_100     
+120     0     name_110     
+130     0     name_120     
+140     0     name_130     
+150     0     name_140     
+160     0     name_150     
+170     0     name_160     
+180     0     name_170     
+190     0     name_180     
+200     0     name_190     
+210     0     name_200     
+220     0     name_210     
+230     0     name_220     
+240     0     name_230     
+250     0     name_240     
+260     0     name_250     
+270     0     name_260     
+280     0     name_270     
+290     0     name_280     
+300     0     name_290     
 
 ===================================================
 trace    
@@ -1428,7 +2328,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
 
-  rewritten query: select lag([dba.test_table].[name], ?, null) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, lag([dba.test_table].[name], ?, null) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -1452,6 +2352,26 @@ id    val    lg_1    lg_2
 8     8     null     null     
 9     9     null     null     
 10     0     null     null     
+11     1     name_1     null     
+12     2     name_2     null     
+13     3     name_3     null     
+14     4     name_4     null     
+15     5     name_5     null     
+16     6     name_6     null     
+17     7     name_7     null     
+18     8     name_8     null     
+19     9     name_9     null     
+20     0     name_10     null     
+21     1     name_11     null     
+22     2     name_12     null     
+23     3     name_13     null     
+24     4     name_14     null     
+25     5     name_15     null     
+26     6     name_16     null     
+27     7     name_17     null     
+28     8     name_18     null     
+29     9     name_19     null     
+30     0     name_20     null     
 
 ===================================================
 trace    
@@ -1484,6 +2404,26 @@ id    val    lg_2    lg_1
 8     8     null     null     
 9     9     null     null     
 10     0     null     null     
+11     1     null     name_1     
+12     2     null     name_2     
+13     3     null     name_3     
+14     4     null     name_4     
+15     5     null     name_5     
+16     6     null     name_6     
+17     7     null     name_7     
+18     8     null     name_8     
+19     9     null     name_9     
+20     0     null     name_10     
+21     1     null     name_11     
+22     2     null     name_12     
+23     3     null     name_13     
+24     4     null     name_14     
+25     5     null     name_15     
+26     6     null     name_16     
+27     7     null     name_17     
+28     8     null     name_18     
+29     9     null     name_19     
+30     0     null     name_20     
 
 ===================================================
 trace    
@@ -1516,6 +2456,26 @@ id    val    lg_1    lg_2
 8     8     name_18     null     
 9     9     name_19     null     
 10     0     name_20     null     
+11     1     name_21     null     
+12     2     name_22     null     
+13     3     name_23     null     
+14     4     name_24     null     
+15     5     name_25     null     
+16     6     name_26     null     
+17     7     name_27     null     
+18     8     name_28     null     
+19     9     name_29     null     
+20     0     name_30     null     
+21     1     name_31     null     
+22     2     name_32     null     
+23     3     name_33     null     
+24     4     name_34     null     
+25     5     name_35     null     
+26     6     name_36     null     
+27     7     name_37     null     
+28     8     name_38     null     
+29     9     name_39     null     
+30     0     name_40     null     
 
 ===================================================
 trace    
@@ -1537,17 +2497,37 @@ Trace Statistics:
 049. LAST_VALUE single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-lv_1    
-name_10     
-name_20     
-name_30     
-name_40     
-name_50     
-name_60     
-name_70     
-name_80     
-name_90     
-name_100     
+id    val    lv_1    
+10     0     name_10     
+20     0     name_20     
+30     0     name_30     
+40     0     name_40     
+50     0     name_50     
+60     0     name_60     
+70     0     name_70     
+80     0     name_80     
+90     0     name_90     
+100     0     name_100     
+110     0     name_110     
+120     0     name_120     
+130     0     name_130     
+140     0     name_140     
+150     0     name_150     
+160     0     name_160     
+170     0     name_170     
+180     0     name_180     
+190     0     name_190     
+200     0     name_200     
+210     0     name_210     
+220     0     name_220     
+230     0     name_230     
+240     0     name_240     
+250     0     name_250     
+260     0     name_260     
+270     0     name_270     
+280     0     name_280     
+290     0     name_290     
+300     0     name_300     
 
 ===================================================
 trace    
@@ -1555,7 +2535,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
 
-  rewritten query: select last_value([dba.test_table].[name]) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, last_value([dba.test_table].[name]) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -1579,6 +2559,26 @@ id    val    lv_1    lv_2
 8     8     name_8     name_8     
 9     9     name_9     name_9     
 10     0     name_10     name_10     
+11     1     name_11     name_11     
+12     2     name_12     name_12     
+13     3     name_13     name_13     
+14     4     name_14     name_14     
+15     5     name_15     name_15     
+16     6     name_16     name_16     
+17     7     name_17     name_17     
+18     8     name_18     name_18     
+19     9     name_19     name_19     
+20     0     name_20     name_20     
+21     1     name_21     name_21     
+22     2     name_22     name_22     
+23     3     name_23     name_23     
+24     4     name_24     name_24     
+25     5     name_25     name_25     
+26     6     name_26     name_26     
+27     7     name_27     name_27     
+28     8     name_28     name_28     
+29     9     name_29     name_29     
+30     0     name_30     name_30     
 
 ===================================================
 trace    
@@ -1611,6 +2611,26 @@ id    val    lv_2    lv_1
 8     8     name_8     name_8     
 9     9     name_9     name_9     
 10     0     name_10     name_10     
+11     1     name_11     name_11     
+12     2     name_12     name_12     
+13     3     name_13     name_13     
+14     4     name_14     name_14     
+15     5     name_15     name_15     
+16     6     name_16     name_16     
+17     7     name_17     name_17     
+18     8     name_18     name_18     
+19     9     name_19     name_19     
+20     0     name_20     name_20     
+21     1     name_21     name_21     
+22     2     name_22     name_22     
+23     3     name_23     name_23     
+24     4     name_24     name_24     
+25     5     name_25     name_25     
+26     6     name_26     name_26     
+27     7     name_27     name_27     
+28     8     name_28     name_28     
+29     9     name_29     name_29     
+30     0     name_30     name_30     
 
 ===================================================
 trace    
@@ -1643,6 +2663,26 @@ id    val    lv_1    lv_2
 8     8     name_8     name_8     
 9     9     name_9     name_9     
 10     0     name_10     name_10     
+11     1     name_11     name_11     
+12     2     name_12     name_12     
+13     3     name_13     name_13     
+14     4     name_14     name_14     
+15     5     name_15     name_15     
+16     6     name_16     name_16     
+17     7     name_17     name_17     
+18     8     name_18     name_18     
+19     9     name_19     name_19     
+20     0     name_20     name_20     
+21     1     name_21     name_21     
+22     2     name_22     name_22     
+23     3     name_23     name_23     
+24     4     name_24     name_24     
+25     5     name_25     name_25     
+26     6     name_26     name_26     
+27     7     name_27     name_27     
+28     8     name_28     name_28     
+29     9     name_29     name_29     
+30     0     name_30     name_30     
 
 ===================================================
 trace    
@@ -1664,17 +2704,37 @@ Trace Statistics:
 053. LEAD single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-ld_1    
-name_20     
-name_30     
-name_40     
-name_50     
-name_60     
-name_70     
-name_80     
-name_90     
-name_100     
-name_110     
+id    val    ld_1    
+10     0     name_20     
+20     0     name_30     
+30     0     name_40     
+40     0     name_50     
+50     0     name_60     
+60     0     name_70     
+70     0     name_80     
+80     0     name_90     
+90     0     name_100     
+100     0     name_110     
+110     0     name_120     
+120     0     name_130     
+130     0     name_140     
+140     0     name_150     
+150     0     name_160     
+160     0     name_170     
+170     0     name_180     
+180     0     name_190     
+190     0     name_200     
+200     0     name_210     
+210     0     name_220     
+220     0     name_230     
+230     0     name_240     
+240     0     name_250     
+250     0     name_260     
+260     0     name_270     
+270     0     name_280     
+280     0     name_290     
+290     0     name_300     
+300     0     name_310     
 
 ===================================================
 trace    
@@ -1682,7 +2742,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
 
-  rewritten query: select lead([dba.test_table].[name], ?, null) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, lead([dba.test_table].[name], ?, null) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -1706,6 +2766,26 @@ id    val    ld_1    ld_2
 8     8     name_18     null     
 9     9     name_19     null     
 10     0     name_20     null     
+11     1     name_21     null     
+12     2     name_22     null     
+13     3     name_23     null     
+14     4     name_24     null     
+15     5     name_25     null     
+16     6     name_26     null     
+17     7     name_27     null     
+18     8     name_28     null     
+19     9     name_29     null     
+20     0     name_30     null     
+21     1     name_31     null     
+22     2     name_32     null     
+23     3     name_33     null     
+24     4     name_34     null     
+25     5     name_35     null     
+26     6     name_36     null     
+27     7     name_37     null     
+28     8     name_38     null     
+29     9     name_39     null     
+30     0     name_40     null     
 
 ===================================================
 trace    
@@ -1738,6 +2818,26 @@ id    val    ld_2    ld_1
 8     8     null     name_18     
 9     9     null     name_19     
 10     0     null     name_20     
+11     1     null     name_21     
+12     2     null     name_22     
+13     3     null     name_23     
+14     4     null     name_24     
+15     5     null     name_25     
+16     6     null     name_26     
+17     7     null     name_27     
+18     8     null     name_28     
+19     9     null     name_29     
+20     0     null     name_30     
+21     1     null     name_31     
+22     2     null     name_32     
+23     3     null     name_33     
+24     4     null     name_34     
+25     5     null     name_35     
+26     6     null     name_36     
+27     7     null     name_37     
+28     8     null     name_38     
+29     9     null     name_39     
+30     0     null     name_40     
 
 ===================================================
 trace    
@@ -1770,6 +2870,26 @@ id    val    ld_1    ld_2
 8     8     null     null     
 9     9     null     null     
 10     0     null     null     
+11     1     name_1     null     
+12     2     name_2     null     
+13     3     name_3     null     
+14     4     name_4     null     
+15     5     name_5     null     
+16     6     name_6     null     
+17     7     name_7     null     
+18     8     name_8     null     
+19     9     name_9     null     
+20     0     name_10     null     
+21     1     name_11     null     
+22     2     name_12     null     
+23     3     name_13     null     
+24     4     name_14     null     
+25     5     name_15     null     
+26     6     name_16     null     
+27     7     name_17     null     
+28     8     name_18     null     
+29     9     name_19     null     
+30     0     name_20     null     
 
 ===================================================
 trace    
@@ -1791,17 +2911,37 @@ Trace Statistics:
 057. MAX single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-mx_1    
-10     
-20     
-30     
-40     
-50     
-60     
-70     
-80     
-90     
-100     
+id    val    mx_1    
+10     0     10     
+20     0     20     
+30     0     30     
+40     0     40     
+50     0     50     
+60     0     60     
+70     0     70     
+80     0     80     
+90     0     90     
+100     0     100     
+110     0     110     
+120     0     120     
+130     0     130     
+140     0     140     
+150     0     150     
+160     0     160     
+170     0     170     
+180     0     180     
+190     0     190     
+200     0     200     
+210     0     210     
+220     0     220     
+230     0     230     
+240     0     240     
+250     0     250     
+260     0     260     
+270     0     270     
+280     0     280     
+290     0     290     
+300     0     300     
 
 ===================================================
 trace    
@@ -1809,7 +2949,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
 
-  rewritten query: select max([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, max([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -1833,6 +2973,26 @@ id    val    mx_1    mx_2
 8     8     8     8     
 9     9     9     9     
 10     0     10     0     
+11     1     11     1     
+12     2     12     2     
+13     3     13     3     
+14     4     14     4     
+15     5     15     5     
+16     6     16     6     
+17     7     17     7     
+18     8     18     8     
+19     9     19     9     
+20     0     20     0     
+21     1     21     1     
+22     2     22     2     
+23     3     23     3     
+24     4     24     4     
+25     5     25     5     
+26     6     26     6     
+27     7     27     7     
+28     8     28     8     
+29     9     29     9     
+30     0     30     0     
 
 ===================================================
 trace    
@@ -1865,6 +3025,26 @@ id    val    mx_2    mx_1
 8     8     8     8     
 9     9     9     9     
 10     0     0     10     
+11     1     1     11     
+12     2     2     12     
+13     3     3     13     
+14     4     4     14     
+15     5     5     15     
+16     6     6     16     
+17     7     7     17     
+18     8     8     18     
+19     9     9     19     
+20     0     0     20     
+21     1     1     21     
+22     2     2     22     
+23     3     3     23     
+24     4     4     24     
+25     5     5     25     
+26     6     6     26     
+27     7     7     27     
+28     8     8     28     
+29     9     9     29     
+30     0     0     30     
 
 ===================================================
 trace    
@@ -1897,6 +3077,26 @@ id    val    mx_1    mx_2
 8     8     998     8     
 9     9     999     9     
 10     0     1000     0     
+11     1     991     1     
+12     2     992     2     
+13     3     993     3     
+14     4     994     4     
+15     5     995     5     
+16     6     996     6     
+17     7     997     7     
+18     8     998     8     
+19     9     999     9     
+20     0     1000     0     
+21     1     991     1     
+22     2     992     2     
+23     3     993     3     
+24     4     994     4     
+25     5     995     5     
+26     6     996     6     
+27     7     997     7     
+28     8     998     8     
+29     9     999     9     
+30     0     1000     0     
 
 ===================================================
 trace    
@@ -1918,17 +3118,37 @@ Trace Statistics:
 061. MIN single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-mn_1    
-10     
-10     
-10     
-10     
-10     
-10     
-10     
-10     
-10     
-10     
+id    val    mn_1    
+10     0     10     
+20     0     10     
+30     0     10     
+40     0     10     
+50     0     10     
+60     0     10     
+70     0     10     
+80     0     10     
+90     0     10     
+100     0     10     
+110     0     10     
+120     0     10     
+130     0     10     
+140     0     10     
+150     0     10     
+160     0     10     
+170     0     10     
+180     0     10     
+190     0     10     
+200     0     10     
+210     0     10     
+220     0     10     
+230     0     10     
+240     0     10     
+250     0     10     
+260     0     10     
+270     0     10     
+280     0     10     
+290     0     10     
+300     0     10     
 
 ===================================================
 trace    
@@ -1936,7 +3156,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
 
-  rewritten query: select min([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, min([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -1960,6 +3180,26 @@ id    val    mn_1    mn_2
 8     8     8     8     
 9     9     9     9     
 10     0     10     0     
+11     1     1     1     
+12     2     2     2     
+13     3     3     3     
+14     4     4     4     
+15     5     5     5     
+16     6     6     6     
+17     7     7     7     
+18     8     8     8     
+19     9     9     9     
+20     0     10     0     
+21     1     1     1     
+22     2     2     2     
+23     3     3     3     
+24     4     4     4     
+25     5     5     5     
+26     6     6     6     
+27     7     7     7     
+28     8     8     8     
+29     9     9     9     
+30     0     10     0     
 
 ===================================================
 trace    
@@ -1992,6 +3232,26 @@ id    val    mn_2    mn_1
 8     8     8     8     
 9     9     9     9     
 10     0     0     10     
+11     1     1     1     
+12     2     2     2     
+13     3     3     3     
+14     4     4     4     
+15     5     5     5     
+16     6     6     6     
+17     7     7     7     
+18     8     8     8     
+19     9     9     9     
+20     0     0     10     
+21     1     1     1     
+22     2     2     2     
+23     3     3     3     
+24     4     4     4     
+25     5     5     5     
+26     6     6     6     
+27     7     7     7     
+28     8     8     8     
+29     9     9     9     
+30     0     0     10     
 
 ===================================================
 trace    
@@ -2024,6 +3284,26 @@ id    val    mn_1    mn_2
 8     8     8     8     
 9     9     9     9     
 10     0     10     0     
+11     1     11     1     
+12     2     12     2     
+13     3     13     3     
+14     4     14     4     
+15     5     15     5     
+16     6     16     6     
+17     7     17     7     
+18     8     18     8     
+19     9     19     9     
+20     0     20     0     
+21     1     21     1     
+22     2     22     2     
+23     3     23     3     
+24     4     24     4     
+25     5     25     5     
+26     6     26     6     
+27     7     27     7     
+28     8     28     8     
+29     9     29     9     
+30     0     30     0     
 
 ===================================================
 trace    
@@ -2045,17 +3325,37 @@ Trace Statistics:
 065. NTH_VALUE single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-nv_1    
-null     
-null     
-null     
-null     
-null     
-null     
-null     
-null     
-null     
-name_100     
+id    val    nv_1    
+10     0     null     
+20     0     null     
+30     0     null     
+40     0     null     
+50     0     null     
+60     0     null     
+70     0     null     
+80     0     null     
+90     0     null     
+100     0     name_100     
+110     0     name_100     
+120     0     name_100     
+130     0     name_100     
+140     0     name_100     
+150     0     name_100     
+160     0     name_100     
+170     0     name_100     
+180     0     name_100     
+190     0     name_100     
+200     0     name_100     
+210     0     name_100     
+220     0     name_100     
+230     0     name_100     
+240     0     name_100     
+250     0     name_100     
+260     0     name_100     
+270     0     name_100     
+280     0     name_100     
+290     0     name_100     
+300     0     name_100     
 
 ===================================================
 trace    
@@ -2063,7 +3363,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ))
 
-  rewritten query: select nth_value([dba.test_table].[name], ?) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, nth_value([dba.test_table].[name], ?) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -2087,6 +3387,26 @@ id    val    nv_1    nv_2
 8     8     null     null     
 9     9     null     null     
 10     0     null     null     
+11     1     null     null     
+12     2     null     null     
+13     3     null     null     
+14     4     null     null     
+15     5     null     null     
+16     6     null     null     
+17     7     null     null     
+18     8     null     null     
+19     9     null     null     
+20     0     null     null     
+21     1     null     null     
+22     2     null     null     
+23     3     null     null     
+24     4     null     null     
+25     5     null     null     
+26     6     null     null     
+27     7     null     null     
+28     8     null     null     
+29     9     null     null     
+30     0     null     null     
 
 ===================================================
 trace    
@@ -2119,6 +3439,26 @@ id    val    nv_2    nv_1
 8     8     null     null     
 9     9     null     null     
 10     0     null     null     
+11     1     null     null     
+12     2     null     null     
+13     3     null     null     
+14     4     null     null     
+15     5     null     null     
+16     6     null     null     
+17     7     null     null     
+18     8     null     null     
+19     9     null     null     
+20     0     null     null     
+21     1     null     null     
+22     2     null     null     
+23     3     null     null     
+24     4     null     null     
+25     5     null     null     
+26     6     null     null     
+27     7     null     null     
+28     8     null     null     
+29     9     null     null     
+30     0     null     null     
 
 ===================================================
 trace    
@@ -2151,6 +3491,26 @@ id    val    nv_1    nv_2
 8     8     name_908     null     
 9     9     name_909     null     
 10     0     name_910     null     
+11     1     name_901     null     
+12     2     name_902     null     
+13     3     name_903     null     
+14     4     name_904     null     
+15     5     name_905     null     
+16     6     name_906     null     
+17     7     name_907     null     
+18     8     name_908     null     
+19     9     name_909     null     
+20     0     name_910     null     
+21     1     name_901     null     
+22     2     name_902     null     
+23     3     name_903     null     
+24     4     name_904     null     
+25     5     name_905     null     
+26     6     name_906     null     
+27     7     name_907     null     
+28     8     name_908     null     
+29     9     name_909     null     
+30     0     name_910     null     
 
 ===================================================
 trace    
@@ -2172,17 +3532,37 @@ Trace Statistics:
 069. PERCENT_RANK single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-pr_1    
-0.0     
-0.010101010101010102     
-0.020202020202020204     
-0.030303030303030304     
-0.04040404040404041     
-0.050505050505050504     
-0.06060606060606061     
-0.0707070707070707     
-0.08080808080808081     
-0.09090909090909091     
+id    val    pr_1    
+10     0     0.0     
+20     0     0.010101010101010102     
+30     0     0.020202020202020204     
+40     0     0.030303030303030304     
+50     0     0.04040404040404041     
+60     0     0.050505050505050504     
+70     0     0.06060606060606061     
+80     0     0.0707070707070707     
+90     0     0.08080808080808081     
+100     0     0.09090909090909091     
+110     0     0.10101010101010101     
+120     0     0.1111111111111111     
+130     0     0.12121212121212122     
+140     0     0.13131313131313133     
+150     0     0.1414141414141414     
+160     0     0.15151515151515152     
+170     0     0.16161616161616163     
+180     0     0.1717171717171717     
+190     0     0.18181818181818182     
+200     0     0.1919191919191919     
+210     0     0.20202020202020202     
+220     0     0.21212121212121213     
+230     0     0.2222222222222222     
+240     0     0.23232323232323232     
+250     0     0.24242424242424243     
+260     0     0.25252525252525254     
+270     0     0.26262626262626265     
+280     0     0.2727272727272727     
+290     0     0.2828282828282828     
+300     0     0.29292929292929293     
 
 ===================================================
 trace    
@@ -2190,7 +3570,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
 
-  rewritten query: select percent_rank() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, percent_rank() over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -2214,6 +3594,26 @@ id    val    pr_1    pr_2
 8     8     0.0     0.0     
 9     9     0.0     0.0     
 10     0     0.0     0.0     
+11     1     0.010101010101010102     0.0     
+12     2     0.010101010101010102     0.0     
+13     3     0.010101010101010102     0.0     
+14     4     0.010101010101010102     0.0     
+15     5     0.010101010101010102     0.0     
+16     6     0.010101010101010102     0.0     
+17     7     0.010101010101010102     0.0     
+18     8     0.010101010101010102     0.0     
+19     9     0.010101010101010102     0.0     
+20     0     0.010101010101010102     0.0     
+21     1     0.020202020202020204     0.0     
+22     2     0.020202020202020204     0.0     
+23     3     0.020202020202020204     0.0     
+24     4     0.020202020202020204     0.0     
+25     5     0.020202020202020204     0.0     
+26     6     0.020202020202020204     0.0     
+27     7     0.020202020202020204     0.0     
+28     8     0.020202020202020204     0.0     
+29     9     0.020202020202020204     0.0     
+30     0     0.020202020202020204     0.0     
 
 ===================================================
 trace    
@@ -2246,6 +3646,26 @@ id    val    pr_2    pr_1
 8     8     0.0     0.0     
 9     9     0.0     0.0     
 10     0     0.0     0.0     
+11     1     0.0     0.010101010101010102     
+12     2     0.0     0.010101010101010102     
+13     3     0.0     0.010101010101010102     
+14     4     0.0     0.010101010101010102     
+15     5     0.0     0.010101010101010102     
+16     6     0.0     0.010101010101010102     
+17     7     0.0     0.010101010101010102     
+18     8     0.0     0.010101010101010102     
+19     9     0.0     0.010101010101010102     
+20     0     0.0     0.010101010101010102     
+21     1     0.0     0.020202020202020204     
+22     2     0.0     0.020202020202020204     
+23     3     0.0     0.020202020202020204     
+24     4     0.0     0.020202020202020204     
+25     5     0.0     0.020202020202020204     
+26     6     0.0     0.020202020202020204     
+27     7     0.0     0.020202020202020204     
+28     8     0.0     0.020202020202020204     
+29     9     0.0     0.020202020202020204     
+30     0     0.0     0.020202020202020204     
 
 ===================================================
 trace    
@@ -2278,6 +3698,26 @@ id    val    pr_1    pr_2
 8     8     1.0     0.0     
 9     9     1.0     0.0     
 10     0     1.0     0.0     
+11     1     0.98989898989899     0.0     
+12     2     0.98989898989899     0.0     
+13     3     0.98989898989899     0.0     
+14     4     0.98989898989899     0.0     
+15     5     0.98989898989899     0.0     
+16     6     0.98989898989899     0.0     
+17     7     0.98989898989899     0.0     
+18     8     0.98989898989899     0.0     
+19     9     0.98989898989899     0.0     
+20     0     0.98989898989899     0.0     
+21     1     0.9797979797979798     0.0     
+22     2     0.9797979797979798     0.0     
+23     3     0.9797979797979798     0.0     
+24     4     0.9797979797979798     0.0     
+25     5     0.9797979797979798     0.0     
+26     6     0.9797979797979798     0.0     
+27     7     0.9797979797979798     0.0     
+28     8     0.9797979797979798     0.0     
+29     9     0.9797979797979798     0.0     
+30     0     0.9797979797979798     0.0     
 
 ===================================================
 trace    
@@ -2299,17 +3739,37 @@ Trace Statistics:
 073. STDDEV_POP single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-sp_1    
-0.0     
-5.0     
-8.16496580927726     
-11.180339887498949     
-14.142135623730951     
-17.07825127659933     
-20.0     
-22.9128784747792     
-25.81988897471611     
-28.722813232690143     
+id    val    sp_1    
+10     0     0.0     
+20     0     5.0     
+30     0     8.16496580927726     
+40     0     11.180339887498949     
+50     0     14.142135623730951     
+60     0     17.07825127659933     
+70     0     20.0     
+80     0     22.9128784747792     
+90     0     25.81988897471611     
+100     0     28.722813232690143     
+110     0     31.622776601683793     
+120     0     34.52052529534664     
+130     0     37.416573867739416     
+140     0     40.311288741492746     
+150     0     43.204937989385726     
+160     0     46.09772228646444     
+170     0     48.98979485566356     
+180     0     51.881274720911264     
+190     0     54.772255750516614     
+200     0     57.66281297335398     
+210     0     60.55300708194983     
+220     0     63.4428877022476     
+230     0     66.332495807108     
+240     0     69.2218655243173     
+250     0     72.11102550927978     
+260     0     75.0     
+270     0     77.88880963698615     
+280     0     80.77747210701756     
+290     0     83.66600265340756     
+300     0     86.5544144839919     
 
 ===================================================
 trace    
@@ -2317,7 +3777,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
 
-  rewritten query: select stddev_pop([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, stddev_pop([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -2341,6 +3801,26 @@ id    val    sp_1    sp_2
 8     8     0.0     0.0     
 9     9     0.0     0.0     
 10     0     0.0     0.0     
+11     1     5.0     0.0     
+12     2     5.0     0.0     
+13     3     5.0     0.0     
+14     4     5.0     0.0     
+15     5     5.0     0.0     
+16     6     5.0     0.0     
+17     7     5.0     0.0     
+18     8     5.0     0.0     
+19     9     5.0     0.0     
+20     0     5.0     0.0     
+21     1     8.164965809277259     0.0     
+22     2     8.164965809277259     0.0     
+23     3     8.164965809277259     0.0     
+24     4     8.16496580927726     0.0     
+25     5     8.16496580927726     0.0     
+26     6     8.16496580927726     0.0     
+27     7     8.16496580927726     0.0     
+28     8     8.16496580927726     0.0     
+29     9     8.16496580927726     0.0     
+30     0     8.16496580927726     0.0     
 
 ===================================================
 trace    
@@ -2373,6 +3853,26 @@ id    val    sp_2    sp_1
 8     8     0.0     0.0     
 9     9     0.0     0.0     
 10     0     0.0     0.0     
+11     1     0.0     5.0     
+12     2     0.0     5.0     
+13     3     0.0     5.0     
+14     4     0.0     5.0     
+15     5     0.0     5.0     
+16     6     0.0     5.0     
+17     7     0.0     5.0     
+18     8     0.0     5.0     
+19     9     0.0     5.0     
+20     0     0.0     5.0     
+21     1     0.0     8.164965809277259     
+22     2     0.0     8.164965809277259     
+23     3     0.0     8.164965809277259     
+24     4     0.0     8.16496580927726     
+25     5     0.0     8.16496580927726     
+26     6     0.0     8.16496580927726     
+27     7     0.0     8.16496580927726     
+28     8     0.0     8.16496580927726     
+29     9     0.0     8.16496580927726     
+30     0     0.0     8.16496580927726     
 
 ===================================================
 trace    
@@ -2405,6 +3905,26 @@ id    val    sp_1    sp_2
 8     8     288.66070047722116     0.0     
 9     9     288.66070047722116     0.0     
 10     0     288.66070047722116     0.0     
+11     1     285.77380332470415     0.0     
+12     2     285.77380332470415     0.0     
+13     3     285.77380332470415     0.0     
+14     4     285.77380332470415     0.0     
+15     5     285.77380332470415     0.0     
+16     6     285.77380332470415     0.0     
+17     7     285.77380332470415     0.0     
+18     8     285.77380332470415     0.0     
+19     9     285.77380332470415     0.0     
+20     0     285.77380332470415     0.0     
+21     1     282.8869031963127     0.0     
+22     2     282.8869031963127     0.0     
+23     3     282.8869031963127     0.0     
+24     4     282.8869031963127     0.0     
+25     5     282.8869031963127     0.0     
+26     6     282.8869031963127     0.0     
+27     7     282.8869031963127     0.0     
+28     8     282.8869031963127     0.0     
+29     9     282.8869031963127     0.0     
+30     0     282.8869031963127     0.0     
 
 ===================================================
 trace    
@@ -2426,17 +3946,37 @@ Trace Statistics:
 077. STDDEV_SAMP single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-ss_1    
-null     
-7.0710678118654755     
-10.0     
-12.909944487358056     
-15.811388300841896     
-18.708286933869708     
-21.602468994692874     
-24.49489742783178     
-27.386127875258307     
-30.276503540974907     
+id    val    ss_1    
+10     0     null     
+20     0     7.0710678118654755     
+30     0     10.0     
+40     0     12.909944487358056     
+50     0     15.811388300841896     
+60     0     18.708286933869708     
+70     0     21.602468994692874     
+80     0     24.49489742783178     
+90     0     27.386127875258307     
+100     0     30.276503540974907     
+110     0     33.166247903554     
+120     0     36.05551275463989     
+130     0     38.94440481849308     
+140     0     41.83300132670378     
+150     0     44.721359549995796     
+160     0     47.60952285695234     
+170     0     50.49752469181039     
+180     0     53.38539126015655     
+190     0     56.27314338711377     
+200     0     59.16079783099616     
+210     0     62.048368229954285     
+220     0     64.9358657959272     
+230     0     67.8232998312527     
+240     0     70.71067811865474     
+250     0     73.59800721939874     
+260     0     76.48529270389177     
+270     0     79.37253933193772     
+280     0     82.25975119502043     
+290     0     85.14693182963201     
+300     0     88.03408430829505     
 
 ===================================================
 trace    
@@ -2444,7 +3984,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
 
-  rewritten query: select stddev_samp([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, stddev_samp([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -2468,6 +4008,26 @@ id    val    ss_1    ss_2
 8     8     null     null     
 9     9     null     null     
 10     0     null     null     
+11     1     7.0710678118654755     null     
+12     2     7.0710678118654755     null     
+13     3     7.0710678118654755     null     
+14     4     7.0710678118654755     null     
+15     5     7.0710678118654755     null     
+16     6     7.0710678118654755     null     
+17     7     7.0710678118654755     null     
+18     8     7.0710678118654755     null     
+19     9     7.0710678118654755     null     
+20     0     7.0710678118654755     null     
+21     1     10.0     null     
+22     2     10.0     null     
+23     3     10.0     null     
+24     4     10.0     null     
+25     5     10.0     null     
+26     6     10.0     null     
+27     7     10.0     null     
+28     8     10.0     null     
+29     9     10.0     null     
+30     0     10.0     null     
 
 ===================================================
 trace    
@@ -2500,6 +4060,26 @@ id    val    ss_2    ss_1
 8     8     null     null     
 9     9     null     null     
 10     0     null     null     
+11     1     null     7.0710678118654755     
+12     2     null     7.0710678118654755     
+13     3     null     7.0710678118654755     
+14     4     null     7.0710678118654755     
+15     5     null     7.0710678118654755     
+16     6     null     7.0710678118654755     
+17     7     null     7.0710678118654755     
+18     8     null     7.0710678118654755     
+19     9     null     7.0710678118654755     
+20     0     null     7.0710678118654755     
+21     1     null     10.0     
+22     2     null     10.0     
+23     3     null     10.0     
+24     4     null     10.0     
+25     5     null     10.0     
+26     6     null     10.0     
+27     7     null     10.0     
+28     8     null     10.0     
+29     9     null     10.0     
+30     0     null     10.0     
 
 ===================================================
 trace    
@@ -2532,6 +4112,26 @@ id    val    ss_1    ss_2
 8     8     290.1149197588202     null     
 9     9     290.1149197588202     null     
 10     0     290.1149197588202     null     
+11     1     287.22813232690146     null     
+12     2     287.22813232690146     null     
+13     3     287.2281323269014     null     
+14     4     287.22813232690146     null     
+15     5     287.2281323269014     null     
+16     6     287.22813232690146     null     
+17     7     287.22813232690146     null     
+18     8     287.22813232690146     null     
+19     9     287.22813232690146     null     
+20     0     287.2281323269015     null     
+21     1     284.34134416225857     null     
+22     2     284.34134416225874     null     
+23     3     284.34134416225874     null     
+24     4     284.3413441622586     null     
+25     5     284.3413441622586     null     
+26     6     284.34134416225874     null     
+27     7     284.3413441622586     null     
+28     8     284.34134416225874     null     
+29     9     284.3413441622586     null     
+30     0     284.3413441622586     null     
 
 ===================================================
 trace    
@@ -2553,17 +4153,37 @@ Trace Statistics:
 081. SUM single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-sm_1    
-10     
-30     
-60     
-100     
-150     
-210     
-280     
-360     
-450     
-550     
+id    val    sm_1    
+10     0     10     
+20     0     30     
+30     0     60     
+40     0     100     
+50     0     150     
+60     0     210     
+70     0     280     
+80     0     360     
+90     0     450     
+100     0     550     
+110     0     660     
+120     0     780     
+130     0     910     
+140     0     1050     
+150     0     1200     
+160     0     1360     
+170     0     1530     
+180     0     1710     
+190     0     1900     
+200     0     2100     
+210     0     2310     
+220     0     2530     
+230     0     2760     
+240     0     3000     
+250     0     3250     
+260     0     3510     
+270     0     3780     
+280     0     4060     
+290     0     4350     
+300     0     4650     
 
 ===================================================
 trace    
@@ -2571,7 +4191,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
 
-  rewritten query: select sum([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, sum([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -2595,6 +4215,26 @@ id    val    sm_1    sm_2
 8     8     8     8     
 9     9     9     9     
 10     0     10     0     
+11     1     12     1     
+12     2     14     2     
+13     3     16     3     
+14     4     18     4     
+15     5     20     5     
+16     6     22     6     
+17     7     24     7     
+18     8     26     8     
+19     9     28     9     
+20     0     30     0     
+21     1     33     1     
+22     2     36     2     
+23     3     39     3     
+24     4     42     4     
+25     5     45     5     
+26     6     48     6     
+27     7     51     7     
+28     8     54     8     
+29     9     57     9     
+30     0     60     0     
 
 ===================================================
 trace    
@@ -2627,6 +4267,26 @@ id    val    sm_2    sm_1
 8     8     8     8     
 9     9     9     9     
 10     0     0     10     
+11     1     1     12     
+12     2     2     14     
+13     3     3     16     
+14     4     4     18     
+15     5     5     20     
+16     6     6     22     
+17     7     7     24     
+18     8     8     26     
+19     9     9     28     
+20     0     0     30     
+21     1     1     33     
+22     2     2     36     
+23     3     3     39     
+24     4     4     42     
+25     5     5     45     
+26     6     6     48     
+27     7     7     51     
+28     8     8     54     
+29     9     9     57     
+30     0     0     60     
 
 ===================================================
 trace    
@@ -2659,6 +4319,26 @@ id    val    sm_1    sm_2
 8     8     50300     8     
 9     9     50400     9     
 10     0     50500     0     
+11     1     49599     1     
+12     2     49698     2     
+13     3     49797     3     
+14     4     49896     4     
+15     5     49995     5     
+16     6     50094     6     
+17     7     50193     7     
+18     8     50292     8     
+19     9     50391     9     
+20     0     50490     0     
+21     1     49588     1     
+22     2     49686     2     
+23     3     49784     3     
+24     4     49882     4     
+25     5     49980     5     
+26     6     50078     6     
+27     7     50176     7     
+28     8     50274     8     
+29     9     50372     9     
+30     0     50470     0     
 
 ===================================================
 trace    
@@ -2680,17 +4360,37 @@ Trace Statistics:
 085. VAR_POP single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-vp_1    
-0.0     
-25.0     
-66.66666666666669     
-125.0     
-200.0     
-291.66666666666674     
-400.0     
-525.0     
-666.6666666666665     
-825.0     
+id    val    vp_1    
+10     0     0.0     
+20     0     25.0     
+30     0     66.66666666666669     
+40     0     125.0     
+50     0     200.0     
+60     0     291.66666666666674     
+70     0     400.0     
+80     0     525.0     
+90     0     666.6666666666665     
+100     0     825.0     
+110     0     1000.0     
+120     0     1191.666666666667     
+130     0     1400.0     
+140     0     1625.0     
+150     0     1866.666666666666     
+160     0     2125.0     
+170     0     2400.0     
+180     0     2691.666666666666     
+190     0     3000.0     
+200     0     3325.0     
+210     0     3666.666666666666     
+220     0     4025.0     
+230     0     4400.0     
+240     0     4791.666666666668     
+250     0     5200.0     
+260     0     5625.0     
+270     0     6066.666666666668     
+280     0     6525.0     
+290     0     7000.0     
+300     0     7491.666666666668     
 
 ===================================================
 trace    
@@ -2698,7 +4398,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
 
-  rewritten query: select var_pop([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, var_pop([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -2722,6 +4422,26 @@ id    val    vp_1    vp_2
 8     8     0.0     0.0     
 9     9     0.0     0.0     
 10     0     0.0     0.0     
+11     1     25.0     0.0     
+12     2     25.0     0.0     
+13     3     25.0     0.0     
+14     4     25.0     0.0     
+15     5     25.0     0.0     
+16     6     25.0     0.0     
+17     7     25.0     0.0     
+18     8     25.0     0.0     
+19     9     25.0     0.0     
+20     0     25.0     0.0     
+21     1     66.66666666666666     0.0     
+22     2     66.66666666666666     0.0     
+23     3     66.66666666666666     0.0     
+24     4     66.66666666666669     0.0     
+25     5     66.66666666666669     0.0     
+26     6     66.66666666666669     0.0     
+27     7     66.66666666666669     0.0     
+28     8     66.66666666666669     0.0     
+29     9     66.66666666666669     0.0     
+30     0     66.66666666666669     0.0     
 
 ===================================================
 trace    
@@ -2754,6 +4474,26 @@ id    val    vp_2    vp_1
 8     8     0.0     0.0     
 9     9     0.0     0.0     
 10     0     0.0     0.0     
+11     1     0.0     25.0     
+12     2     0.0     25.0     
+13     3     0.0     25.0     
+14     4     0.0     25.0     
+15     5     0.0     25.0     
+16     6     0.0     25.0     
+17     7     0.0     25.0     
+18     8     0.0     25.0     
+19     9     0.0     25.0     
+20     0     0.0     25.0     
+21     1     0.0     66.66666666666666     
+22     2     0.0     66.66666666666666     
+23     3     0.0     66.66666666666666     
+24     4     0.0     66.66666666666669     
+25     5     0.0     66.66666666666669     
+26     6     0.0     66.66666666666669     
+27     7     0.0     66.66666666666669     
+28     8     0.0     66.66666666666669     
+29     9     0.0     66.66666666666669     
+30     0     0.0     66.66666666666669     
 
 ===================================================
 trace    
@@ -2786,6 +4526,26 @@ id    val    vp_1    vp_2
 8     8     83325.0     0.0     
 9     9     83325.0     0.0     
 10     0     83325.0     0.0     
+11     1     81666.66666666669     0.0     
+12     2     81666.66666666669     0.0     
+13     3     81666.66666666669     0.0     
+14     4     81666.66666666669     0.0     
+15     5     81666.66666666669     0.0     
+16     6     81666.66666666669     0.0     
+17     7     81666.66666666669     0.0     
+18     8     81666.66666666669     0.0     
+19     9     81666.66666666669     0.0     
+20     0     81666.66666666669     0.0     
+21     1     80025.0     0.0     
+22     2     80025.0     0.0     
+23     3     80025.0     0.0     
+24     4     80025.0     0.0     
+25     5     80025.0     0.0     
+26     6     80025.0     0.0     
+27     7     80025.0     0.0     
+28     8     80025.0     0.0     
+29     9     80025.0     0.0     
+30     0     80025.0     0.0     
 
 ===================================================
 trace    
@@ -2807,17 +4567,37 @@ Trace Statistics:
 089. VAR_SAMP single analytic - OVER matches midx_01(val,id), sort skipped     
 
 ===================================================
-vs_1    
-null     
-50.0     
-100.0     
-166.66666666666663     
-250.0     
-350.0     
-466.66666666666697     
-600.0     
-750.0     
-916.6666666666661     
+id    val    vs_1    
+10     0     null     
+20     0     50.0     
+30     0     100.0     
+40     0     166.66666666666663     
+50     0     250.0     
+60     0     350.0     
+70     0     466.66666666666697     
+80     0     600.0     
+90     0     750.0     
+100     0     916.6666666666661     
+110     0     1100.0     
+120     0     1300.0     
+130     0     1516.666666666667     
+140     0     1750.0     
+150     0     2000.0     
+160     0     2266.666666666667     
+170     0     2550.0     
+180     0     2850.0     
+190     0     3166.666666666666     
+200     0     3500.0     
+210     0     3850.0     
+220     0     4216.666666666668     
+230     0     4600.000000000002     
+240     0     4999.999999999998     
+250     0     5416.666666666668     
+260     0     5850.0     
+270     0     6300.0     
+280     0     6766.666666666664     
+290     0     7250.0     
+300     0     7750.0     
 
 ===================================================
 trace    
@@ -2825,7 +4605,7 @@ trace
 Query Plan:
   INDEX SCAN (dba.test_table.midx_?) (key range: ([dba.test_table].val>= ?:? ), covered: true)
 
-  rewritten query: select var_samp([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
+  rewritten query: select [dba.test_table].id, [dba.test_table].val, var_samp([dba.test_table].id) over (partition by ? order by ?) from [dba.test_table] [dba.test_table] where ([dba.test_table].val>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table].midx_?(+)
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
@@ -2849,6 +4629,26 @@ id    val    vs_1    vs_2
 8     8     null     null     
 9     9     null     null     
 10     0     null     null     
+11     1     50.0     null     
+12     2     50.0     null     
+13     3     50.0     null     
+14     4     50.0     null     
+15     5     50.0     null     
+16     6     50.0     null     
+17     7     50.0     null     
+18     8     50.0     null     
+19     9     50.0     null     
+20     0     50.0     null     
+21     1     100.0     null     
+22     2     100.0     null     
+23     3     100.0     null     
+24     4     100.0     null     
+25     5     100.0     null     
+26     6     100.0     null     
+27     7     100.0     null     
+28     8     100.0     null     
+29     9     100.0     null     
+30     0     100.0     null     
 
 ===================================================
 trace    
@@ -2881,6 +4681,26 @@ id    val    vs_2    vs_1
 8     8     null     null     
 9     9     null     null     
 10     0     null     null     
+11     1     null     50.0     
+12     2     null     50.0     
+13     3     null     50.0     
+14     4     null     50.0     
+15     5     null     50.0     
+16     6     null     50.0     
+17     7     null     50.0     
+18     8     null     50.0     
+19     9     null     50.0     
+20     0     null     50.0     
+21     1     null     100.0     
+22     2     null     100.0     
+23     3     null     100.0     
+24     4     null     100.0     
+25     5     null     100.0     
+26     6     null     100.0     
+27     7     null     100.0     
+28     8     null     100.0     
+29     9     null     100.0     
+30     0     null     100.0     
 
 ===================================================
 trace    
@@ -2913,6 +4733,26 @@ id    val    vs_1    vs_2
 8     8     84166.66666666666     null     
 9     9     84166.66666666669     null     
 10     0     84166.66666666669     null     
+11     1     82500.00000000003     null     
+12     2     82500.0     null     
+13     3     82499.99999999997     null     
+14     4     82500.0     null     
+15     5     82499.99999999997     null     
+16     6     82500.00000000003     null     
+17     7     82500.00000000003     null     
+18     8     82500.00000000003     null     
+19     9     82500.00000000003     null     
+20     0     82500.00000000006     null     
+21     1     80849.99999999997     null     
+22     2     80850.00000000006     null     
+23     3     80850.00000000006     null     
+24     4     80850.0     null     
+25     5     80850.0     null     
+26     6     80850.00000000006     null     
+27     7     80850.0     null     
+28     8     80850.00000000006     null     
+29     9     80850.0     null     
+30     0     80850.0     null     
 
 ===================================================
 trace    
@@ -2945,6 +4785,26 @@ id    val    n_2    n_1
 8     8     1     5     
 9     9     1     5     
 10     0     1     5     
+11     1     1     5     
+12     2     1     5     
+13     3     1     5     
+14     4     1     5     
+15     5     1     5     
+16     6     1     5     
+17     7     1     5     
+18     8     1     5     
+19     9     1     5     
+20     0     1     5     
+21     1     1     5     
+22     2     1     5     
+23     3     1     5     
+24     4     1     5     
+25     5     1     5     
+26     6     1     5     
+27     7     1     5     
+28     8     1     5     
+29     9     1     5     
+30     0     1     5     
 
 ===================================================
 trace    
@@ -2991,6 +4851,26 @@ c1    c2    c3    c4    a1    a2
 0     0     0     840     8     8     
 0     0     0     945     9     9     
 0     0     1     70     1     10     
+0     0     1     175     2     11     
+0     0     1     280     3     12     
+0     0     1     385     4     13     
+0     0     1     490     5     14     
+0     0     1     595     6     15     
+0     0     1     700     7     16     
+0     0     1     805     8     17     
+0     0     1     910     9     18     
+0     0     2     35     1     19     
+0     0     2     140     2     20     
+0     0     2     245     3     21     
+0     0     2     350     4     22     
+0     0     2     455     5     23     
+0     0     2     560     6     24     
+0     0     2     665     7     25     
+0     0     2     770     8     26     
+0     0     2     875     9     27     
+0     0     2     980     10     28     
+0     1     0     15     1     29     
+0     1     0     120     2     30     
 
 ===================================================
 trace    
@@ -3036,6 +4916,26 @@ c1    c2    c3    rn
 0     c2_0     c3_0     8     
 0     c2_0     c3_0     9     
 0     c2_0     c3_0     10     
+1     c2_1     c3_1     1     
+1     c2_1     c3_1     2     
+1     c2_1     c3_1     3     
+1     c2_1     c3_1     4     
+1     c2_1     c3_1     5     
+1     c2_1     c3_1     6     
+1     c2_1     c3_1     7     
+1     c2_1     c3_1     8     
+1     c2_1     c3_1     9     
+1     c2_1     c3_1     10     
+2     c2_2     c3_2     1     
+2     c2_2     c3_2     2     
+2     c2_2     c3_2     3     
+2     c2_2     c3_2     4     
+2     c2_2     c3_2     5     
+2     c2_2     c3_2     6     
+2     c2_2     c3_2     7     
+2     c2_2     c3_2     8     
+2     c2_2     c3_2     9     
+2     c2_2     c3_2     10     
 
 ===================================================
 trace    
@@ -3067,6 +4967,26 @@ c1    c2    c3    rn
 0     c2_0     c3_0     8     
 0     c2_0     c3_0     9     
 0     c2_0     c3_0     10     
+1     c2_1     c3_1     1     
+1     c2_1     c3_1     2     
+1     c2_1     c3_1     3     
+1     c2_1     c3_1     4     
+1     c2_1     c3_1     5     
+1     c2_1     c3_1     6     
+1     c2_1     c3_1     7     
+1     c2_1     c3_1     8     
+1     c2_1     c3_1     9     
+1     c2_1     c3_1     10     
+2     c2_2     c3_2     1     
+2     c2_2     c3_2     2     
+2     c2_2     c3_2     3     
+2     c2_2     c3_2     4     
+2     c2_2     c3_2     5     
+2     c2_2     c3_2     6     
+2     c2_2     c3_2     7     
+2     c2_2     c3_2     8     
+2     c2_2     c3_2     9     
+2     c2_2     c3_2     10     
 
 ===================================================
 trace    
@@ -3098,6 +5018,26 @@ c1    c2    c3    rn
 0     c2_0     c3_0     8     
 0     c2_0     c3_0     9     
 0     c2_0     c3_0     10     
+1     c2_1     c3_1     1     
+1     c2_1     c3_1     2     
+1     c2_1     c3_1     3     
+1     c2_1     c3_1     4     
+1     c2_1     c3_1     5     
+1     c2_1     c3_1     6     
+1     c2_1     c3_1     7     
+1     c2_1     c3_1     8     
+1     c2_1     c3_1     9     
+1     c2_1     c3_1     10     
+2     c2_2     c3_2     1     
+2     c2_2     c3_2     2     
+2     c2_2     c3_2     3     
+2     c2_2     c3_2     4     
+2     c2_2     c3_2     5     
+2     c2_2     c3_2     6     
+2     c2_2     c3_2     7     
+2     c2_2     c3_2     8     
+2     c2_2     c3_2     9     
+2     c2_2     c3_2     10     
 
 ===================================================
 trace    
@@ -3129,6 +5069,26 @@ c1    c2    c3    rn
 0     c2_0     c3_0     8     
 0     c2_0     c3_0     9     
 0     c2_0     c3_0     10     
+1     c2_1     c3_1     1     
+1     c2_1     c3_1     2     
+1     c2_1     c3_1     3     
+1     c2_1     c3_1     4     
+1     c2_1     c3_1     5     
+1     c2_1     c3_1     6     
+1     c2_1     c3_1     7     
+1     c2_1     c3_1     8     
+1     c2_1     c3_1     9     
+1     c2_1     c3_1     10     
+2     c2_2     c3_2     1     
+2     c2_2     c3_2     2     
+2     c2_2     c3_2     3     
+2     c2_2     c3_2     4     
+2     c2_2     c3_2     5     
+2     c2_2     c3_2     6     
+2     c2_2     c3_2     7     
+2     c2_2     c3_2     8     
+2     c2_2     c3_2     9     
+2     c2_2     c3_2     10     
 
 ===================================================
 trace    
@@ -3160,6 +5120,26 @@ c1    c2    c3    rn
 99     c2_9     c3_9     8     
 99     c2_9     c3_9     9     
 99     c2_9     c3_9     10     
+98     c2_8     c3_8     1     
+98     c2_8     c3_8     2     
+98     c2_8     c3_8     3     
+98     c2_8     c3_8     4     
+98     c2_8     c3_8     5     
+98     c2_8     c3_8     6     
+98     c2_8     c3_8     7     
+98     c2_8     c3_8     8     
+98     c2_8     c3_8     9     
+98     c2_8     c3_8     10     
+97     c2_7     c3_7     1     
+97     c2_7     c3_7     2     
+97     c2_7     c3_7     3     
+97     c2_7     c3_7     4     
+97     c2_7     c3_7     5     
+97     c2_7     c3_7     6     
+97     c2_7     c3_7     7     
+97     c2_7     c3_7     8     
+97     c2_7     c3_7     9     
+97     c2_7     c3_7     10     
 
 ===================================================
 trace    

--- a/sql/_36_guava/cbrd_26473/answers/cbrd_26473.answer
+++ b/sql/_36_guava/cbrd_26473/answers/cbrd_26473.answer
@@ -5159,3 +5159,188 @@ Trace Statistics:
 0
 ===================================================
 0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+1000
+===================================================
+0
+===================================================
+    
+100. ORDER BY mod(c4,10) - function-based index column that varies inside the partition, sort skipped     
+
+===================================================
+c1    c2    c3    m    rn    
+0     c2_0     c3_0     0     1     
+0     c2_0     c3_0     0     2     
+0     c2_0     c3_0     0     3     
+0     c2_0     c3_0     0     4     
+0     c2_0     c3_0     1     5     
+0     c2_0     c3_0     1     6     
+0     c2_0     c3_0     1     7     
+0     c2_0     c3_0     1     8     
+0     c2_0     c3_0     1     9     
+0     c2_0     c3_0     2     10     
+0     c2_0     c3_0     2     11     
+0     c2_0     c3_0     2     12     
+0     c2_0     c3_0     2     13     
+0     c2_0     c3_0     2     14     
+0     c2_0     c3_0     3     15     
+0     c2_0     c3_0     3     16     
+0     c2_0     c3_0     3     17     
+0     c2_0     c3_0     3     18     
+0     c2_0     c3_0     3     19     
+0     c2_0     c3_0     4     20     
+0     c2_0     c3_0     4     21     
+0     c2_0     c3_0     4     22     
+0     c2_0     c3_0     4     23     
+0     c2_0     c3_0     4     24     
+0     c2_0     c3_0     5     25     
+0     c2_0     c3_0     5     26     
+0     c2_0     c3_0     5     27     
+0     c2_0     c3_0     5     28     
+0     c2_0     c3_0     5     29     
+0     c2_0     c3_0     6     30     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table_?.midx_?) (key range: ([dba.test_table_?].c?>= ?:? ))
+
+  rewritten query: select [dba.test_table_?].c?, [dba.test_table_?].c?, [dba.test_table_?].c?,  mod([dba.test_table_?].c?, ?), row_number() over (partition by ?, ?, ? order by ?) from [dba.test_table_?] [dba.test_table_?] where ([dba.test_table_?].c?>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table_?].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table_?.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: skip, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+101. same query forced onto a sequential scan - sort required, result block must be identical to the skipped one     
+
+===================================================
+c1    c2    c3    m    rn    
+0     c2_0     c3_0     0     1     
+0     c2_0     c3_0     0     2     
+0     c2_0     c3_0     0     3     
+0     c2_0     c3_0     0     4     
+0     c2_0     c3_0     1     5     
+0     c2_0     c3_0     1     6     
+0     c2_0     c3_0     1     7     
+0     c2_0     c3_0     1     8     
+0     c2_0     c3_0     1     9     
+0     c2_0     c3_0     2     10     
+0     c2_0     c3_0     2     11     
+0     c2_0     c3_0     2     12     
+0     c2_0     c3_0     2     13     
+0     c2_0     c3_0     2     14     
+0     c2_0     c3_0     3     15     
+0     c2_0     c3_0     3     16     
+0     c2_0     c3_0     3     17     
+0     c2_0     c3_0     3     18     
+0     c2_0     c3_0     3     19     
+0     c2_0     c3_0     4     20     
+0     c2_0     c3_0     4     21     
+0     c2_0     c3_0     4     22     
+0     c2_0     c3_0     4     23     
+0     c2_0     c3_0     4     24     
+0     c2_0     c3_0     5     25     
+0     c2_0     c3_0     5     26     
+0     c2_0     c3_0     5     27     
+0     c2_0     c3_0     5     28     
+0     c2_0     c3_0     5     29     
+0     c2_0     c3_0     6     30     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.test_table_?)
+
+  rewritten query: select [dba.test_table_?].c?, [dba.test_table_?].c?, [dba.test_table_?].c?,  mod([dba.test_table_?].c?, ?), row_number() over (partition by ?, ?, ? order by ?) from [dba.test_table_?] [dba.test_table_?] where ([dba.test_table_?].c?>= ?:? ) and (inst_num()<= ?:? ) using index none
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.test_table_?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+    
+102. control - ORDER BY c4 itself, which is not an index column expression - sort required and the numbering differs from the mod(c4,10) ordering     
+
+===================================================
+c1    c2    c3    m    rn    
+0     c2_0     c3_0     1     1     
+0     c2_0     c3_0     2     2     
+0     c2_0     c3_0     3     3     
+0     c2_0     c3_0     4     4     
+0     c2_0     c3_0     5     5     
+0     c2_0     c3_0     6     6     
+0     c2_0     c3_0     7     7     
+0     c2_0     c3_0     8     8     
+0     c2_0     c3_0     9     9     
+0     c2_0     c3_0     0     10     
+0     c2_0     c3_0     1     11     
+0     c2_0     c3_0     2     12     
+0     c2_0     c3_0     3     13     
+0     c2_0     c3_0     4     14     
+0     c2_0     c3_0     5     15     
+0     c2_0     c3_0     6     16     
+0     c2_0     c3_0     7     17     
+0     c2_0     c3_0     8     18     
+0     c2_0     c3_0     9     19     
+0     c2_0     c3_0     0     20     
+0     c2_0     c3_0     1     21     
+0     c2_0     c3_0     2     22     
+0     c2_0     c3_0     3     23     
+0     c2_0     c3_0     4     24     
+0     c2_0     c3_0     5     25     
+0     c2_0     c3_0     6     26     
+0     c2_0     c3_0     7     27     
+0     c2_0     c3_0     8     28     
+0     c2_0     c3_0     9     29     
+0     c2_0     c3_0     0     30     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.test_table_?.midx_?) (key range: ([dba.test_table_?].c?>= ?:? ))
+
+  rewritten query: select [dba.test_table_?].c?, [dba.test_table_?].c?, [dba.test_table_?].c?,  mod([dba.test_table_?].c?, ?), row_number() over (partition by ?, ?, ? order by ?) from [dba.test_table_?] [dba.test_table_?] where ([dba.test_table_?].c?>= ?:? ) and (inst_num()<= ?:? ) using index [dba.test_table_?].midx_?(+)
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (index: dba.test_table_?.midx_?), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+     
+
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+1000
+===================================================
+    
+103. merged analytics vs the same analytics computed one per query - values must match (expect joined_cnt 1000, bad_a1 0, bad_a2 0)     
+
+===================================================
+joined_cnt    bad_a1    bad_a2    
+1000     0     0     
+
+===================================================
+0

--- a/sql/_36_guava/cbrd_26473/cases/cbrd_26473.sql
+++ b/sql/_36_guava/cbrd_26473/cases/cbrd_26473.sql
@@ -43,11 +43,18 @@
  *       plus one case where the index-compatible-but-unskippable (DESC) analytic
  *       is written SECOND, so the execution-order promotion is observable in the
  *       final row order rather than being a no-op
- *    5. Sort-group merging - analytics sharing a sort key collapse into a single
- *       ANALYTIC #N group (trace prints per sort group, not per function)
+ *    5. Sort-group merging - two analytics whose sort keys normalize to the same
+ *       key collapse into a single ANALYTIC #N group (the trace prints one line
+ *       per sort group, not per function)
  *    6. Index edge cases - partition on leading index columns, ORDER BY on a
- *       non-index column, ORDER BY on a function-based index column, and
- *       descending index scan (use_desc_idx)
+ *       non-index column, ORDER BY on a function-based index column that is
+ *       CONSTANT inside the partition (a degenerate ordering), and descending
+ *       index scan (use_desc_idx)
+ *    7. Function-based index column that VARIES inside the partition, with the
+ *       same query forced onto a sequential scan as the value oracle
+ *    8. Value equivalence - the sort-skip path must return the same analytic
+ *       values as paths where the sort cannot be skipped or the merge cannot
+ *       happen (oracle-independent: it compares the engine against itself)
  */
 
 drop table if exists test_table;
@@ -747,6 +754,16 @@ select /*+ recompile */ c1, c2, c3, c4,
 from t_group where c1 >= 0 using index gidx(+) limit 30;
 show trace;
 
+
+-- todo: a three-analytic merge scenario (three families on one shared key)
+--       and a merge-plus-promotion scenario are still missing here. Both were
+--       drafted and run, and both come back with WRONG analytic values on the
+--       sort-skip path: with three or more analytics in one query the engine
+--       loses one analytic's PARTITION BY (a running sum returns the global
+--       total, and a row_number numbers over a wider group). Two analytics are
+--       unaffected. Add these scenarios once that defect is fixed - recording
+--       the current output would bake the wrong values into the answer.
+
 set trace off;
 drop table t_group;
 
@@ -809,3 +826,103 @@ show trace;
 
 set trace off;
 drop table test_table_2;
+
+--
+-- 7. Function-based index column that VARIES inside the partition.
+--    In section 6 the ordering expression mod(c1,10) is a function of the
+--    partition key, so it is CONSTANT inside a partition: ordering by it is a
+--    no-op and its sort: skip does not prove the function-based index column
+--    was matched. Here mod(c4,10) is independent of the partition key, so the
+--    skipped path must also produce the CORRECT row_number values.
+--    c1 = n%7 and c2/c3 = n%3 are coprime, so a (c1,c2,c3) partition is n mod 21
+--    - 21 partitions of ~47 rows - and limit 30 stays inside the first one.
+--    For n = r + 21k, mod(c4,10) = (r + k) mod 10, which varies with k.
+--    Rows tied on mod(c4,10) print identically (c1,c2,c3 are constant in the
+--    partition, c4 itself is NOT projected, rn is emitted in visit order), so
+--    the block is order-invariant. Do not project c4.
+--
+drop table if exists test_table_3;
+create table test_table_3 (c1 int, c2 varchar, c3 varchar, c4 int);
+create index midx_03 on test_table_3 (c1, c2, c3, mod(c4, 10));
+
+insert into test_table_3
+with recursive cte (n) as (
+  select 1
+  union all
+  select n + 1 from cte where n < 1000
+)
+select n % 7, 'c2_' || (n % 3), 'c3_' || (n % 3), n from cte;
+
+set trace on;
+
+evaluate '100. ORDER BY mod(c4,10) - function-based index column that varies inside the partition, sort skipped';
+select /*+ recompile */ c1, c2, c3, mod(c4, 10) as m,
+  row_number() over (partition by c1, c2, c3 order by mod(c4, 10)) as rn
+from test_table_3 where c1 >= 0 using index midx_03(+) limit 30;
+show trace;
+
+-- Value oracle for the scenario above: the SAME query forced onto a sequential
+-- scan cannot skip the sort, so it must still print an identical result block.
+evaluate '101. same query forced onto a sequential scan - sort required, result block must be identical to the skipped one';
+select /*+ recompile */ c1, c2, c3, mod(c4, 10) as m,
+  row_number() over (partition by c1, c2, c3 order by mod(c4, 10)) as rn
+from test_table_3 where c1 >= 0 using index none limit 30;
+show trace;
+
+evaluate '102. control - ORDER BY c4 itself, which is not an index column expression - sort required and the numbering differs from the mod(c4,10) ordering';
+select /*+ recompile */ c1, c2, c3, mod(c4, 10) as m,
+  row_number() over (partition by c1, c2, c3 order by c4) as rn
+from test_table_3 where c1 >= 0 using index midx_03(+) limit 30;
+show trace;
+
+set trace off;
+drop table test_table_3;
+
+--
+-- 8. Value equivalence: analytic values produced with the sort skipped must
+--    match the same values produced where merging cannot happen. This is an
+--    oracle-independent check - it compares the engine against itself, so a
+--    wrong value cannot pass merely by having been recorded in the answer.
+--    The merged query computes two analytics with DIFFERENT sort keys in one
+--    statement; each is then recomputed alone, where no merge is possible.
+--    nvl() sentinels are required so a NULL on one side cannot make the
+--    comparison UNKNOWN and silently drop a mismatch, and joined_cnt guards
+--    against rows going missing entirely. The result is a single scalar row,
+--    so it needs no ORDER BY, and no LIMIT is used - a LIMIT would truncate
+--    the comparison.
+-- todo: a differential scenario (the same analytics via an index scan and via
+--       a forced sequential scan, asserting 0 mismatches) was drafted and run,
+--       but reports 900 mismatches out of 1000 today: when two analytics that
+--       SHARE a sort key are merged inside a joined inline view, the two
+--       branches disagree on row_number. The same two analytics are correct as
+--       a top-level query, and analytics with different sort keys are correct
+--       even inside inline views (the scenario below). Add the differential
+--       scenario once that defect is fixed.
+--
+drop table if exists test_table;
+create table test_table (id int auto_increment, name varchar, val int, primary key (id));
+create index midx_01 on test_table (val, id);
+
+insert into test_table (name, val)
+with recursive cte (n) as (
+  select 1
+  union all
+  select n + 1 from cte where n < 1000
+)
+select 'name_' || n, n % 10 from cte;
+
+evaluate '103. merged analytics vs the same analytics computed one per query - values must match (expect joined_cnt 1000, bad_a1 0, bad_a2 0)';
+select count(*) as joined_cnt,
+  sum(case when nvl(m.a1, -1) <> nvl(s1.a1, -1) then 1 else 0 end) as bad_a1,
+  sum(case when nvl(m.a2, -1) <> nvl(s2.a2, -1) then 1 else 0 end) as bad_a2
+from (select id,
+        row_number() over (partition by val order by id) as a1,
+        row_number() over (partition by id order by val) as a2
+      from test_table where val >= 0 using index midx_01(+)) m,
+     (select id, row_number() over (partition by val order by id) as a1
+      from test_table where val >= 0 using index none) s1,
+     (select id, row_number() over (partition by id order by val) as a2
+      from test_table where val >= 0 using index none) s2
+where m.id = s1.id and m.id = s2.id;
+
+drop table test_table;

--- a/sql/_36_guava/cbrd_26473/cases/cbrd_26473.sql
+++ b/sql/_36_guava/cbrd_26473/cases/cbrd_26473.sql
@@ -17,11 +17,18 @@
  *  "sort: true"). Determinism instead comes from the forced index scan order and
  *  the deterministic fresh CTP load: single-analytic results follow the index
  *  stream; multi-analytic results follow the engine's final sort order, whose
- *  trailing column is unique (id in sections 1-4, c4 in section 5). Section 6's
- *  row_number ties within a partition (all rows
- *  share the full index key) are broken by the deterministic load. Volatile
- *  trace counters (time, page, ioread, fetch) are masked to '?' by the CTP
- *  trace normalizer.
+ *  trailing column is unique (id in sections 1-4, c4 in section 5).
+ *  Section 6 makes NO assumption about intra-partition row order: the 10 rows of
+ *  a (c1,c2,c3) partition share the full index key, so their relative order is
+ *  not guaranteed. Those queries therefore project only c1, c2, c3 - constant
+ *  inside a partition - plus rn, which is emitted in assignment order, so the
+ *  printed block is identical however the tied rows are visited.
+ *  Every scenario uses limit 30 rather than limit 10: with limit 10 each returned
+ *  row is the FIRST row of its own partition, so a partition-by-val analytic
+ *  prints its first-row value on every row and never exercises accumulation
+ *  inside a partition; 30 rows cross partition boundaries and expose both the
+ *  running value and the reset. Volatile trace counters (time, page, ioread,
+ *  fetch) are masked to '?' by the CTP trace normalizer.
  *
  *  Coverage (each analytic in sections 1-4 is checked in four scenarios:
  *  single-analytic skip, two analytics with the index-compatible one written
@@ -62,616 +69,652 @@ set trace on;
 -- 1. NTILE
 --
 evaluate '001. NTILE single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ ntile(5) over (partition by val order by id) as ntile_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  ntile(5) over (partition by val order by id) as ntile_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '002. NTILE two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   ntile(5) over (partition by val order by id) as ntile_1,
   ntile(5) over (partition by id order by val) as ntile_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '003. NTILE two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   ntile(5) over (partition by id order by val) as ntile_2,
   ntile(5) over (partition by val order by id) as ntile_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '004. NTILE conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   ntile(5) over (partition by val order by id desc) as ntile_1,
   ntile(5) over (partition by id order by val) as ntile_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 --
 -- 2. Interpolation functions (MEDIAN, PERCENTILE_CONT, PERCENTILE_DISC)
 --
 evaluate '005. MEDIAN single analytic - OVER(partition by val) covered by midx_01 leading column, sort skipped';
-select /*+ recompile */ median(id) over (partition by val) as md_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  median(id) over (partition by val) as md_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '006. MEDIAN two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   median(id) over (partition by val) as md_1,
   median(val) over (partition by id) as md_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '007. MEDIAN two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   median(val) over (partition by id) as md_2,
   median(id) over (partition by val) as md_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '008. MEDIAN partition column not in the index (val, name) - sort required';
 select /*+ recompile */ id, val,
   median(id) over (partition by val, name) as md_1,
   median(val) over (partition by id) as md_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '009. PERCENTILE_CONT single analytic - within group(order by id) over(partition by val) covered by midx_01, sort skipped';
-select /*+ recompile */ percentile_cont(0.5) within group (order by id) over (partition by val) as pc_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  percentile_cont(0.5) within group (order by id) over (partition by val) as pc_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '010. PERCENTILE_CONT two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   percentile_cont(0.5) within group (order by id) over (partition by val) as pc_1,
   percentile_cont(0.5) within group (order by val) over (partition by id) as pc_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '011. PERCENTILE_CONT two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   percentile_cont(0.5) within group (order by val) over (partition by id) as pc_2,
   percentile_cont(0.5) within group (order by id) over (partition by val) as pc_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '012. PERCENTILE_CONT conflicting DESC order (order by id desc) - sort required';
 select /*+ recompile */ id, val,
   percentile_cont(0.5) within group (order by id desc) over (partition by val) as pc_1,
   percentile_cont(0.5) within group (order by val) over (partition by id) as pc_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '013. PERCENTILE_DISC single analytic - within group(order by id) over(partition by val) covered by midx_01, sort skipped';
-select /*+ recompile */ percentile_disc(0.5) within group (order by id) over (partition by val) as pd_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  percentile_disc(0.5) within group (order by id) over (partition by val) as pd_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '014. PERCENTILE_DISC two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   percentile_disc(0.5) within group (order by id) over (partition by val) as pd_1,
   percentile_disc(0.5) within group (order by val) over (partition by id) as pd_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '015. PERCENTILE_DISC two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   percentile_disc(0.5) within group (order by val) over (partition by id) as pd_2,
   percentile_disc(0.5) within group (order by id) over (partition by val) as pd_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '016. PERCENTILE_DISC conflicting DESC order (order by id desc) - sort required';
 select /*+ recompile */ id, val,
   percentile_disc(0.5) within group (order by id desc) over (partition by val) as pd_1,
   percentile_disc(0.5) within group (order by val) over (partition by id) as pd_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 --
 -- 3. Ranking family (ROW_NUMBER, RANK, DENSE_RANK)
 --
 evaluate '017. ROW_NUMBER single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ row_number() over (partition by val order by id) as rn_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  row_number() over (partition by val order by id) as rn_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '018. ROW_NUMBER two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   row_number() over (partition by val order by id) as rn_1,
   row_number() over (partition by id order by val) as rn_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '019. ROW_NUMBER two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   row_number() over (partition by id order by val) as rn_2,
   row_number() over (partition by val order by id) as rn_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '020. ROW_NUMBER conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   row_number() over (partition by val order by id desc) as rn_1,
   row_number() over (partition by id order by val) as rn_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '021. RANK single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ rank() over (partition by val order by id) as rk_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  rank() over (partition by val order by id) as rk_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '022. RANK two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   rank() over (partition by val order by id) as rk_1,
   rank() over (partition by id order by val) as rk_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '023. RANK two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   rank() over (partition by id order by val) as rk_2,
   rank() over (partition by val order by id) as rk_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '024. RANK conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   rank() over (partition by val order by id desc) as rk_1,
   rank() over (partition by id order by val) as rk_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '025. DENSE_RANK single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ dense_rank() over (partition by val order by id) as dr_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  dense_rank() over (partition by val order by id) as dr_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '026. DENSE_RANK two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   dense_rank() over (partition by val order by id) as dr_1,
   dense_rank() over (partition by id order by val) as dr_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '027. DENSE_RANK two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   dense_rank() over (partition by id order by val) as dr_2,
   dense_rank() over (partition by val order by id) as dr_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '028. DENSE_RANK conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   dense_rank() over (partition by val order by id desc) as dr_1,
   dense_rank() over (partition by id order by val) as dr_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 --
 -- 4. Aggregate / navigation / distribution window functions
 --
 evaluate '029. AVG single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ avg(id) over (partition by val order by id) as av_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  avg(id) over (partition by val order by id) as av_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '030. AVG two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   avg(id) over (partition by val order by id) as av_1,
   avg(val) over (partition by id order by val) as av_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '031. AVG two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   avg(val) over (partition by id order by val) as av_2,
   avg(id) over (partition by val order by id) as av_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '032. AVG conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   avg(id) over (partition by val order by id desc) as av_1,
   avg(val) over (partition by id order by val) as av_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '033. COUNT single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ count(id) over (partition by val order by id) as cnt_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  count(id) over (partition by val order by id) as cnt_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '034. COUNT two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   count(id) over (partition by val order by id) as cnt_1,
   count(val) over (partition by id order by val) as cnt_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '035. COUNT two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   count(val) over (partition by id order by val) as cnt_2,
   count(id) over (partition by val order by id) as cnt_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '036. COUNT conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   count(id) over (partition by val order by id desc) as cnt_1,
   count(val) over (partition by id order by val) as cnt_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '037. CUME_DIST single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ cume_dist() over (partition by val order by id) as cd_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  cume_dist() over (partition by val order by id) as cd_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '038. CUME_DIST two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   cume_dist() over (partition by val order by id) as cd_1,
   cume_dist() over (partition by id order by val) as cd_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '039. CUME_DIST two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   cume_dist() over (partition by id order by val) as cd_2,
   cume_dist() over (partition by val order by id) as cd_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '040. CUME_DIST conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   cume_dist() over (partition by val order by id desc) as cd_1,
   cume_dist() over (partition by id order by val) as cd_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '041. FIRST_VALUE single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ first_value(name) over (partition by val order by id) as fv_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  first_value(name) over (partition by val order by id) as fv_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '042. FIRST_VALUE two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   first_value(name) over (partition by val order by id) as fv_1,
   first_value(name) over (partition by id order by val) as fv_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '043. FIRST_VALUE two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   first_value(name) over (partition by id order by val) as fv_2,
   first_value(name) over (partition by val order by id) as fv_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '044. FIRST_VALUE conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   first_value(name) over (partition by val order by id desc) as fv_1,
   first_value(name) over (partition by id order by val) as fv_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '045. LAG single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ lag(name, 1) over (partition by val order by id) as lg_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  lag(name, 1) over (partition by val order by id) as lg_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '046. LAG two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   lag(name, 1) over (partition by val order by id) as lg_1,
   lag(name, 1) over (partition by id order by val) as lg_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '047. LAG two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   lag(name, 1) over (partition by id order by val) as lg_2,
   lag(name, 1) over (partition by val order by id) as lg_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '048. LAG conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   lag(name, 1) over (partition by val order by id desc) as lg_1,
   lag(name, 1) over (partition by id order by val) as lg_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '049. LAST_VALUE single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ last_value(name) over (partition by val order by id) as lv_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  last_value(name) over (partition by val order by id) as lv_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '050. LAST_VALUE two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   last_value(name) over (partition by val order by id) as lv_1,
   last_value(name) over (partition by id order by val) as lv_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '051. LAST_VALUE two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   last_value(name) over (partition by id order by val) as lv_2,
   last_value(name) over (partition by val order by id) as lv_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '052. LAST_VALUE conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   last_value(name) over (partition by val order by id desc) as lv_1,
   last_value(name) over (partition by id order by val) as lv_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '053. LEAD single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ lead(name, 1) over (partition by val order by id) as ld_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  lead(name, 1) over (partition by val order by id) as ld_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '054. LEAD two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   lead(name, 1) over (partition by val order by id) as ld_1,
   lead(name, 1) over (partition by id order by val) as ld_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '055. LEAD two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   lead(name, 1) over (partition by id order by val) as ld_2,
   lead(name, 1) over (partition by val order by id) as ld_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '056. LEAD conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   lead(name, 1) over (partition by val order by id desc) as ld_1,
   lead(name, 1) over (partition by id order by val) as ld_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '057. MAX single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ max(id) over (partition by val order by id) as mx_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  max(id) over (partition by val order by id) as mx_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '058. MAX two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   max(id) over (partition by val order by id) as mx_1,
   max(val) over (partition by id order by val) as mx_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '059. MAX two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   max(val) over (partition by id order by val) as mx_2,
   max(id) over (partition by val order by id) as mx_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '060. MAX conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   max(id) over (partition by val order by id desc) as mx_1,
   max(val) over (partition by id order by val) as mx_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '061. MIN single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ min(id) over (partition by val order by id) as mn_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  min(id) over (partition by val order by id) as mn_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '062. MIN two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   min(id) over (partition by val order by id) as mn_1,
   min(val) over (partition by id order by val) as mn_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '063. MIN two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   min(val) over (partition by id order by val) as mn_2,
   min(id) over (partition by val order by id) as mn_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '064. MIN conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   min(id) over (partition by val order by id desc) as mn_1,
   min(val) over (partition by id order by val) as mn_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '065. NTH_VALUE single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ nth_value(name, 10) over (partition by val order by id) as nv_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  nth_value(name, 10) over (partition by val order by id) as nv_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '066. NTH_VALUE two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   nth_value(name, 10) over (partition by val order by id) as nv_1,
   nth_value(name, 10) over (partition by id order by val) as nv_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '067. NTH_VALUE two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   nth_value(name, 10) over (partition by id order by val) as nv_2,
   nth_value(name, 10) over (partition by val order by id) as nv_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '068. NTH_VALUE conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   nth_value(name, 10) over (partition by val order by id desc) as nv_1,
   nth_value(name, 10) over (partition by id order by val) as nv_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '069. PERCENT_RANK single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ percent_rank() over (partition by val order by id) as pr_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  percent_rank() over (partition by val order by id) as pr_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '070. PERCENT_RANK two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   percent_rank() over (partition by val order by id) as pr_1,
   percent_rank() over (partition by id order by val) as pr_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '071. PERCENT_RANK two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   percent_rank() over (partition by id order by val) as pr_2,
   percent_rank() over (partition by val order by id) as pr_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '072. PERCENT_RANK conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   percent_rank() over (partition by val order by id desc) as pr_1,
   percent_rank() over (partition by id order by val) as pr_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '073. STDDEV_POP single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ stddev_pop(id) over (partition by val order by id) as sp_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  stddev_pop(id) over (partition by val order by id) as sp_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '074. STDDEV_POP two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   stddev_pop(id) over (partition by val order by id) as sp_1,
   stddev_pop(val) over (partition by id order by val) as sp_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '075. STDDEV_POP two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   stddev_pop(val) over (partition by id order by val) as sp_2,
   stddev_pop(id) over (partition by val order by id) as sp_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '076. STDDEV_POP conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   stddev_pop(id) over (partition by val order by id desc) as sp_1,
   stddev_pop(val) over (partition by id order by val) as sp_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '077. STDDEV_SAMP single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ stddev_samp(id) over (partition by val order by id) as ss_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  stddev_samp(id) over (partition by val order by id) as ss_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '078. STDDEV_SAMP two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   stddev_samp(id) over (partition by val order by id) as ss_1,
   stddev_samp(val) over (partition by id order by val) as ss_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '079. STDDEV_SAMP two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   stddev_samp(val) over (partition by id order by val) as ss_2,
   stddev_samp(id) over (partition by val order by id) as ss_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '080. STDDEV_SAMP conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   stddev_samp(id) over (partition by val order by id desc) as ss_1,
   stddev_samp(val) over (partition by id order by val) as ss_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '081. SUM single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ sum(id) over (partition by val order by id) as sm_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  sum(id) over (partition by val order by id) as sm_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '082. SUM two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   sum(id) over (partition by val order by id) as sm_1,
   sum(val) over (partition by id order by val) as sm_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '083. SUM two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   sum(val) over (partition by id order by val) as sm_2,
   sum(id) over (partition by val order by id) as sm_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '084. SUM conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   sum(id) over (partition by val order by id desc) as sm_1,
   sum(val) over (partition by id order by val) as sm_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '085. VAR_POP single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ var_pop(id) over (partition by val order by id) as vp_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  var_pop(id) over (partition by val order by id) as vp_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '086. VAR_POP two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   var_pop(id) over (partition by val order by id) as vp_1,
   var_pop(val) over (partition by id order by val) as vp_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '087. VAR_POP two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   var_pop(val) over (partition by id order by val) as vp_2,
   var_pop(id) over (partition by val order by id) as vp_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '088. VAR_POP conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   var_pop(id) over (partition by val order by id desc) as vp_1,
   var_pop(val) over (partition by id order by val) as vp_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '089. VAR_SAMP single analytic - OVER matches midx_01(val,id), sort skipped';
-select /*+ recompile */ var_samp(id) over (partition by val order by id) as vs_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+select /*+ recompile */ id, val,
+  var_samp(id) over (partition by val order by id) as vs_1
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '090. VAR_SAMP two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
   var_samp(id) over (partition by val order by id) as vs_1,
   var_samp(val) over (partition by id order by val) as vs_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '091. VAR_SAMP two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
   var_samp(val) over (partition by id order by val) as vs_2,
   var_samp(id) over (partition by val order by id) as vs_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '092. VAR_SAMP conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
   var_samp(id) over (partition by val order by id desc) as vs_1,
   var_samp(val) over (partition by id order by val) as vs_2
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
+
+--
+-- 4-1. Execution-order promotion observable in the final row order
+--      (index-compatible but unskippable DESC analytic written second).
+--      Both ANALYTIC lines report "sort: true" here, exactly as in 004, so
+--      the sort flag alone cannot distinguish this case - the proof is which
+--      rows survive the LIMIT and in what order. Written second, the
+--      (val, id desc) analytic is still promoted to run first, so the LAST
+--      sort applied is (id, val) and the result starts at id 1. Without the
+--      promotion the last sort would be (val, id desc) and the first rows
+--      would be val = 0 / id = 1000, 990, ... instead. Do not remove this
+--      scenario as a duplicate of 004, and do not remove its show trace.
+--
 evaluate '093. NTILE index-compatible DESC analytic written second - promoted ahead of the incompatible one (final row order reveals the execution order)';
 select /*+ recompile */ id, val,
   ntile(5) over (partition by id order by val) as n_2,
   ntile(5) over (partition by val order by id desc) as n_1
-from test_table where val >= 0 using index midx_01(+) limit 10;
+from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 set trace off;
@@ -701,7 +744,7 @@ evaluate '094. Two analytics share the sort key (c1,c2,c3,c4) - they merge into 
 select /*+ recompile */ c1, c2, c3, c4,
   row_number() over (partition by c1, c2, c3 order by c4) as a1,
   row_number() over (partition by c1, c2 order by c3, c4) as a2
-from t_group where c1 >= 0 using index gidx(+) limit 10;
+from t_group where c1 >= 0 using index gidx(+) limit 30;
 show trace;
 
 set trace off;
@@ -711,10 +754,14 @@ drop table t_group;
 -- 6. Index edge cases found in code review
 --    (function-based index column, descending index scan, non-index column)
 -- note: no outer ORDER BY (it would suppress the analytic sort-skip).
---    Every (c1,c2,c3) partition shares the full index key
---    (c1,c2,c3,mod(c1,10)); the returned partition's rows and their
---    row_number values are fixed by the deterministic fresh CTP load
---    (index/insertion order), independent of the sort:skip/true signal.
+--    Every (c1,c2,c3) partition holds 10 rows sharing the FULL index key
+--    (c1,c2,c3,mod(c1,10)) - mod(c1,10) is determined by c1 - so their
+--    relative order is NOT guaranteed and is not relied on here. The
+--    distinguishing column c4 is deliberately not projected: c1, c2, c3 are
+--    constant inside a partition and rn is emitted in assignment order, so
+--    the block is identical however the tied rows are visited. limit 30
+--    spans three partitions, so rn resetting at each boundary is what
+--    proves the analytic partitions at all.
 --
 drop table if exists test_table_2;
 create table test_table_2 (c1 int, c2 varchar, c3 varchar, c4 int);
@@ -733,31 +780,31 @@ set trace on;
 evaluate '095. Partition on leading index columns (c1, c2, c3), no ORDER BY - sort skipped';
 select /*+ recompile */ c1, c2, c3,
   row_number() over (partition by c1, c2, c3) as rn
-from test_table_2 where c1 >= 0 using index midx_02(+) limit 10;
+from test_table_2 where c1 >= 0 using index midx_02(+) limit 30;
 show trace;
 
 evaluate '096. ORDER BY c4 (not an index column) - sort required';
 select /*+ recompile */ c1, c2, c3,
   row_number() over (partition by c1, c2, c3 order by c4) as rn
-from test_table_2 where c1 >= 0 using index midx_02(+) limit 10;
+from test_table_2 where c1 >= 0 using index midx_02(+) limit 30;
 show trace;
 
 evaluate '097. ORDER BY mod(c1, 10) (the function-based 4th index column) - sort skipped';
 select /*+ recompile */ c1, c2, c3,
   row_number() over (partition by c1, c2, c3 order by mod(c1, 10)) as rn
-from test_table_2 where c1 >= 0 using index midx_02(+) limit 10;
+from test_table_2 where c1 >= 0 using index midx_02(+) limit 30;
 show trace;
 
 evaluate '098. use_desc_idx with ascending OVER order - descending scan conflicts, sort required';
 select /*+ recompile use_desc_idx */ c1, c2, c3,
   row_number() over (partition by c1, c2, c3 order by mod(c1, 10)) as rn
-from test_table_2 where c1 >= 0 using index midx_02(+) limit 10;
+from test_table_2 where c1 >= 0 using index midx_02(+) limit 30;
 show trace;
 
 evaluate '099. use_desc_idx with all-descending OVER order - matches descending scan, sort skipped';
 select /*+ recompile use_desc_idx */ c1, c2, c3,
   row_number() over (partition by c1 desc, c2 desc, c3 desc order by mod(c1, 10) desc) as rn
-from test_table_2 where c1 >= 0 using index midx_02(+) limit 10;
+from test_table_2 where c1 >= 0 using index midx_02(+) limit 30;
 show trace;
 
 set trace off;

--- a/sql/_36_guava/cbrd_26473/cases/cbrd_26473.sql
+++ b/sql/_36_guava/cbrd_26473/cases/cbrd_26473.sql
@@ -55,6 +55,9 @@
  *    8. Value equivalence - the sort-skip path must return the same analytic
  *       values as paths where the sort cannot be skipped or the merge cannot
  *       happen (oracle-independent: it compares the engine against itself)
+ *    9. OVER (ORDER BY ...) with no PARTITION BY - order key as an index prefix,
+ *       as the full index key, a mixed ASC/DESC key, and NULLS FIRST/LAST both
+ *       matching and opposing the index default
  */
 
 drop table if exists test_table;
@@ -925,4 +928,85 @@ from (select id,
       from test_table where val >= 0 using index none) s2
 where m.id = s1.id and m.id = s2.id;
 
+drop table test_table;
+
+--
+-- 9. OVER (ORDER BY ...) with NO PARTITION BY - the whole result is one
+--    partition, a separate path from the partitioned scenarios above.
+--    Covers an order key that is a prefix of the index, one that is the full
+--    index key, a mixed ASC/DESC key the ASC index cannot supply, and NULLS
+--    ordering both matching and opposing the index default (a CUBRID ASC
+--    index stores NULLs first).
+--    Rows tied on the order key print identically - the order column is
+--    constant inside a tie group and rn is emitted in assignment order - so
+--    each block is invariant under any permutation of tied rows.
+--
+drop table if exists test_table;
+create table test_table (id int auto_increment, name varchar, val int, primary key (id));
+create index midx_01 on test_table (val, id);
+
+insert into test_table (name, val)
+with recursive cte (n) as (
+  select 1
+  union all
+  select n + 1 from cte where n < 1000
+)
+select 'name_' || n, n % 10 from cte;
+
+drop table if exists test_table_null;
+create table test_table_null (id int, val int);
+create index nidx_01 on test_table_null (val, id);
+
+-- val is NULL on every 10th row (100 NULLs), otherwise n % 10.
+insert into test_table_null (id, val)
+with recursive cte (n) as (
+  select 1
+  union all
+  select n + 1 from cte where n < 1000
+)
+select n, case when n % 10 = 0 then null else n % 10 end from cte;
+
+set trace on;
+
+evaluate '104. ORDER BY only, order key is a prefix of midx_01(val,id) - sort skipped';
+select /*+ recompile */ val,
+  row_number() over (order by val) as rn
+from test_table where val >= 0 using index midx_01(+) limit 30;
+show trace;
+
+evaluate '105. ORDER BY only, order key is the full index key (val, id) - sort skipped';
+select /*+ recompile */ val, id,
+  row_number() over (order by val, id) as rn
+from test_table where val >= 0 using index midx_01(+) limit 30;
+show trace;
+
+evaluate '106. ORDER BY only, mixed ASC/DESC key (val, id desc) the ASC index cannot supply - sort required';
+select /*+ recompile */ val, id,
+  row_number() over (order by val, id desc) as rn
+from test_table where val >= 0 using index midx_01(+) limit 30;
+show trace;
+
+-- The NULLS cases need a scan that starts at the very beginning of the
+-- index, where NULLs are stored. A range predicate on val cannot get there
+-- (val >= 0 and val < 100 both DROP the NULL rows - the comparison is
+-- UNKNOWN), and a forced index hint without an indexable predicate falls
+-- back to a table scan (verified). An index skip scan driven by a predicate
+-- on the SECOND index column delivers full index order including NULL keys.
+evaluate '107. ORDER BY only, NULLS FIRST matches the ASC index default (NULLs stored first) - sort skipped';
+select /*+ recompile index_ss */ val,
+  row_number() over (order by val nulls first) as rn
+from test_table_null where id >= 1 using index nidx_01(+) limit 30;
+show trace;
+
+-- todo: the NULLS LAST counterpart is missing. It was drafted and run, and
+--       the sort-skip path returns WRONG ROW ORDER: with NULLS LAST the
+--       engine treats the index NULLs-first order as compatible, reports
+--       sort: skip and returns the NULL rows FIRST. The same analytic is
+--       correct on a table scan and under using index none, and plain
+--       (non-analytic) ORDER BY ... NULLS LAST is correct too. Add the
+--       scenario once that defect is fixed - recording the current output
+--       would bake a wrong ordering into the answer.
+
+set trace off;
+drop table test_table_null;
 drop table test_table;

--- a/sql/_36_guava/cbrd_26473/cases/cbrd_26473.sql
+++ b/sql/_36_guava/cbrd_26473/cases/cbrd_26473.sql
@@ -758,14 +758,14 @@ from t_group where c1 >= 0 using index gidx(+) limit 30;
 show trace;
 
 
--- todo: a three-analytic merge scenario (three families on one shared key)
---       and a merge-plus-promotion scenario are still missing here. Both were
---       drafted and run, and both come back with WRONG analytic values on the
---       sort-skip path: with three or more analytics in one query the engine
---       loses one analytic's PARTITION BY (a running sum returns the global
---       total, and a row_number numbers over a wider group). Two analytics are
---       unaffected. Add these scenarios once that defect is fixed - recording
---       the current output would bake the wrong values into the answer.
+-- todo: three scenarios are missing here because the sort-skip path
+--       returns WRONG analytic values for them - recording the current
+--       output would bake wrong values into the answer. Add each once its
+--       issue is fixed; details and repros are in the issues:
+--         three families on one shared sort key, and merge-plus-promotion
+--           -> CBRD-27125
+--         sort keys using the same columns in a DIFFERENT order
+--           -> CBRD-27123
 
 set trace off;
 drop table t_group;
@@ -893,14 +893,10 @@ drop table test_table_3;
 --    against rows going missing entirely. The result is a single scalar row,
 --    so it needs no ORDER BY, and no LIMIT is used - a LIMIT would truncate
 --    the comparison.
--- todo: a differential scenario (the same analytics via an index scan and via
---       a forced sequential scan, asserting 0 mismatches) was drafted and run,
---       but reports 900 mismatches out of 1000 today: when two analytics that
---       SHARE a sort key are merged inside a joined inline view, the two
---       branches disagree on row_number. The same two analytics are correct as
---       a top-level query, and analytics with different sort keys are correct
---       even inside inline views (the scenario below). Add the differential
---       scenario once that defect is fixed.
+-- todo: the differential half of this check is missing - the same
+--       analytics via an index scan vs a forced sequential scan, expecting
+--       0 mismatches. Merged analytics inside a joined inline view disagree
+--       today (900 of 1000 rows) -> CBRD-27125. Add once fixed.
 --
 drop table if exists test_table;
 create table test_table (id int auto_increment, name varchar, val int, primary key (id));
@@ -998,14 +994,10 @@ select /*+ recompile index_ss */ val,
 from test_table_null where id >= 1 using index nidx_01(+) limit 30;
 show trace;
 
--- todo: the NULLS LAST counterpart is missing. It was drafted and run, and
---       the sort-skip path returns WRONG ROW ORDER: with NULLS LAST the
---       engine treats the index NULLs-first order as compatible, reports
---       sort: skip and returns the NULL rows FIRST. The same analytic is
---       correct on a table scan and under using index none, and plain
---       (non-analytic) ORDER BY ... NULLS LAST is correct too. Add the
---       scenario once that defect is fixed - recording the current output
---       would bake a wrong ordering into the answer.
+-- todo: the NULLS LAST counterpart is missing - the sort-skip path
+--       reports sort: skip and returns the NULL rows FIRST, so the current
+--       output would bake a wrong ordering into the answer
+--       -> CBRD-27145. Add once fixed.
 
 set trace off;
 drop table test_table_null;

--- a/sql/_36_guava/cbrd_26473/cases/cbrd_26473.sql
+++ b/sql/_36_guava/cbrd_26473/cases/cbrd_26473.sql
@@ -33,6 +33,9 @@
  *    4. Aggregate / navigation / distribution - AVG, COUNT, CUME_DIST,
  *       FIRST_VALUE, LAG, LAST_VALUE, LEAD, MAX, MIN, NTH_VALUE, PERCENT_RANK,
  *       STDDEV_POP, STDDEV_SAMP, SUM, VAR_POP, VAR_SAMP
+ *       plus one case where the index-compatible-but-unskippable (DESC) analytic
+ *       is written SECOND, so the execution-order promotion is observable in the
+ *       final row order rather than being a no-op
  *    5. Sort-group merging - analytics sharing a sort key collapse into a single
  *       ANALYTIC #N group (trace prints per sort group, not per function)
  *    6. Index edge cases - partition on leading index columns, ORDER BY on a
@@ -664,6 +667,12 @@ select /*+ recompile */ id, val,
   var_samp(val) over (partition by id order by val) as vs_2
 from test_table where val >= 0 using index midx_01(+) limit 10;
 show trace;
+evaluate '093. NTILE index-compatible DESC analytic written second - promoted ahead of the incompatible one (final row order reveals the execution order)';
+select /*+ recompile */ id, val,
+  ntile(5) over (partition by id order by val) as n_2,
+  ntile(5) over (partition by val order by id desc) as n_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
 
 set trace off;
 drop table test_table;
@@ -688,7 +697,7 @@ select n % 5, n % 7, n % 3, n from cte;
 
 set trace on;
 
-evaluate '093. Two analytics share the sort key (c1,c2,c3,c4) - they merge into a single ANALYTIC # group (sort skipped); the trace prints one line per sort group, not per function';
+evaluate '094. Two analytics share the sort key (c1,c2,c3,c4) - they merge into a single ANALYTIC # group (sort skipped); the trace prints one line per sort group, not per function';
 select /*+ recompile */ c1, c2, c3, c4,
   row_number() over (partition by c1, c2, c3 order by c4) as a1,
   row_number() over (partition by c1, c2 order by c3, c4) as a2
@@ -721,31 +730,31 @@ select n % 100, 'c2_' || (n % 10), 'c3_' || (n % 10), n from cte;
 
 set trace on;
 
-evaluate '094. Partition on leading index columns (c1, c2, c3), no ORDER BY - sort skipped';
+evaluate '095. Partition on leading index columns (c1, c2, c3), no ORDER BY - sort skipped';
 select /*+ recompile */ c1, c2, c3,
   row_number() over (partition by c1, c2, c3) as rn
 from test_table_2 where c1 >= 0 using index midx_02(+) limit 10;
 show trace;
 
-evaluate '095. ORDER BY c4 (not an index column) - sort required';
+evaluate '096. ORDER BY c4 (not an index column) - sort required';
 select /*+ recompile */ c1, c2, c3,
   row_number() over (partition by c1, c2, c3 order by c4) as rn
 from test_table_2 where c1 >= 0 using index midx_02(+) limit 10;
 show trace;
 
-evaluate '096. ORDER BY mod(c1, 10) (the function-based 4th index column) - sort skipped';
+evaluate '097. ORDER BY mod(c1, 10) (the function-based 4th index column) - sort skipped';
 select /*+ recompile */ c1, c2, c3,
   row_number() over (partition by c1, c2, c3 order by mod(c1, 10)) as rn
 from test_table_2 where c1 >= 0 using index midx_02(+) limit 10;
 show trace;
 
-evaluate '097. use_desc_idx with ascending OVER order - descending scan conflicts, sort required';
+evaluate '098. use_desc_idx with ascending OVER order - descending scan conflicts, sort required';
 select /*+ recompile use_desc_idx */ c1, c2, c3,
   row_number() over (partition by c1, c2, c3 order by mod(c1, 10)) as rn
 from test_table_2 where c1 >= 0 using index midx_02(+) limit 10;
 show trace;
 
-evaluate '098. use_desc_idx with all-descending OVER order - matches descending scan, sort skipped';
+evaluate '099. use_desc_idx with all-descending OVER order - matches descending scan, sort skipped';
 select /*+ recompile use_desc_idx */ c1, c2, c3,
   row_number() over (partition by c1 desc, c2 desc, c3 desc order by mod(c1, 10) desc) as rn
 from test_table_2 where c1 >= 0 using index midx_02(+) limit 10;

--- a/sql/_36_guava/cbrd_26473/cases/cbrd_26473.sql
+++ b/sql/_36_guava/cbrd_26473/cases/cbrd_26473.sql
@@ -5,15 +5,17 @@
  *  before it is evaluated. When an index scan already delivers rows in a
  *  compatible order, the engine reorders the index-compatible analytic functions
  *  to run first and skips (or reduces) their sort. Each analytic sort group is
- *  reported in the query trace as "sort: skip" (order provided by the index) or
- *  "sort: true" (a sort was still required); the ANALYTIC #N lines were also
+ *  reported in the query trace as "sort: false" (no sort needed - the index
+ *  already provided the order) or "sort: true" (a sort was still required); the
+ *  marker was spelled "sort: skip" until CBRD-26795 normalised it. The
+ *  ANALYTIC #N lines were also
  *  newly added to the trace output by this change, and are emitted once per
  *  distinct sort group (analytics that share a sort key are merged into one #N).
  *
  *  These are trace cases: the feature is asserted from the "show trace" output,
  *  so the scans are pinned with USING INDEX (+) / hints. No outer ORDER BY is
  *  used - an outer sort becomes the top plan node and suppresses the analytic
- *  sort-skip being tested (verified: adding one flips every "sort: skip" to
+ *  sort-skip being tested (verified: adding one flips every "sort: false" to
  *  "sort: true"). Determinism instead comes from the forced index scan order and
  *  the deterministic fresh CTP load: single-analytic results follow the index
  *  stream; multi-analytic results follow the engine's final sort order, whose
@@ -28,7 +30,14 @@
  *  prints its first-row value on every row and never exercises accumulation
  *  inside a partition; 30 rows cross partition boundaries and expose both the
  *  running value and the reset. Volatile trace counters (time, page, ioread,
- *  fetch) are masked to '?' by the CTP trace normalizer.
+ *  fetch) are masked to '?' by the CTP trace normalizer, and "(stopkey)" marks
+ *  the read-only-what-is-needed path added by CBRD-26524.
+ *
+ *  Regression guards for the three defects found while building this suite,
+ *  all introduced by CBRD-26473 and since fixed: CBRD-27125 and CBRD-27123
+ *  (merged analytics losing their window boundaries, fixed together) in
+ *  sections 5 and 8, and CBRD-27145 (NULLS LAST wrongly judged index-
+ *  compatible) in section 9.
  *
  *  Coverage (each analytic in sections 1-4 is checked in four scenarios:
  *  single-analytic skip, two analytics with the index-compatible one written
@@ -43,9 +52,11 @@
  *       plus one case where the index-compatible-but-unskippable (DESC) analytic
  *       is written SECOND, so the execution-order promotion is observable in the
  *       final row order rather than being a no-op
- *    5. Sort-group merging - two analytics whose sort keys normalize to the same
- *       key collapse into a single ANALYTIC #N group (the trace prints one line
- *       per sort group, not per function)
+ *    5. Sort-group merging - analytics whose sort keys normalize to the same key
+ *       collapse into a single ANALYTIC #N group (the trace prints one line per
+ *       sort group, not per function), three families on one key, merge plus
+ *       promotion, and the same columns in a different key order (CBRD-27125,
+ *       CBRD-27123)
  *    6. Index edge cases - partition on leading index columns, ORDER BY on a
  *       non-index column, and descending index scan (use_desc_idx) with an OVER
  *       order that conflicts with the scan direction and one that matches it
@@ -772,14 +783,50 @@ from t_group where c1 >= 0 using index gidx(+) limit 30;
 show trace;
 
 
--- todo: three scenarios are missing here because the sort-skip path
---       returns WRONG analytic values for them - recording the current
---       output would bake wrong values into the answer. Add each once its
---       issue is fixed; details and repros are in the issues:
---         three families on one shared sort key, and merge-plus-promotion
---           -> CBRD-27125
---         sort keys using the same columns in a DIFFERENT order
---           -> CBRD-27123
+--
+-- Fixed by CBRD-27125 (https://github.com/CUBRID/cubrid/pull/7581): when several
+-- analytics merged into one sort group and the sort was skipped, every function
+-- after the first stopped detecting partition/order-key changes. These three
+-- scenarios are the regression guards for it and for CBRD-27123.
+--
+evaluate '095. CBRD-27125 - three analytics of DIFFERENT families share one sort key (c1,c2,c3 order by c4): they collapse into a single ANALYTIC # group and every one must still see the partition boundary';
+select /*+ recompile */ c1, c2, c3, c4,
+  row_number() over (partition by c1, c2, c3 order by c4) as a1,
+  sum(c4)      over (partition by c1, c2, c3 order by c4) as a2,
+  lag(c4, 1)   over (partition by c1, c2, c3 order by c4) as a3
+from t_group where c1 >= 0 using index gidx(+) limit 30;
+show trace;
+
+--
+-- CBRD-27125: merging and promotion together. a0 is NOT index-compatible (its
+-- leading partition column c2 is not the index leading column) while a1 and a2
+-- normalize to the SAME key (c1,c2,c3,c4), so a1+a2 merge into one skipped group
+-- and are promoted ahead of a0. a0 therefore runs last and its sort (c2,c4) fixes
+-- the row order. a1 and a2 must keep DIFFERENT numbering despite sharing a group.
+--
+evaluate '096. CBRD-27125 - merge plus promotion: incompatible analytic written FIRST, the two mergeable ones after (2 ANALYTIC lines, the merged group first)';
+select /*+ recompile */ c1, c2, c3, c4,
+  row_number() over (partition by c2 order by c4)          as a0,
+  row_number() over (partition by c1, c2, c3 order by c4)  as a1,
+  row_number() over (partition by c1, c2 order by c3, c4)  as a2
+from t_group where c1 >= 0 using index gidx(+) limit 30;
+show trace;
+
+--
+-- CBRD-27123 (same root cause, same fix as CBRD-27125): sort keys built from the
+-- SAME columns in a DIFFERENT order. (c1,c2,c3) and (c3,c2,c1) describe the very
+-- same partitioning, so with the same ORDER BY the two row_numbers are
+-- semantically IDENTICAL and must agree on every row. Before the fix one of them
+-- was numbered against the other's partition (it returned 10 where 1 was due).
+-- Counted over all 1000 rows rather than a 30-row window so no mismatch can hide
+-- outside the LIMIT; the result is a single scalar row, so it needs no ORDER BY.
+--
+evaluate '097. CBRD-27123 - same columns in a different sort-key order describe the same partitioning, so the two row_numbers must agree on every row (expect total 1000, mismatch 0)';
+select count(*) as total,
+  sum(case when a1 <> a3 then 1 else 0 end) as mismatch
+from (select row_number() over (partition by c1, c2, c3 order by c4) as a1,
+             row_number() over (partition by c3, c2, c1 order by c4) as a3
+      from t_group where c1 >= 0 using index gidx(+)) t;
 
 set trace off;
 drop table t_group;
@@ -822,25 +869,25 @@ select n % 100, 'c2_' || (n % 10), 'c3_' || (n % 10), n from cte;
 
 set trace on;
 
-evaluate '095. Partition on leading index columns (c1, c2, c3), no ORDER BY - sort skipped';
+evaluate '098. Partition on leading index columns (c1, c2, c3), no ORDER BY - sort skipped';
 select /*+ recompile */ c1, c2, c3,
   row_number() over (partition by c1, c2, c3) as rn
 from test_table_2 where c1 >= 0 using index midx_02(+) limit 30;
 show trace;
 
-evaluate '096. ORDER BY c4 (not an index column) - sort required';
+evaluate '099. ORDER BY c4 (not an index column) - sort required';
 select /*+ recompile */ c1, c2, c3,
   row_number() over (partition by c1, c2, c3 order by c4) as rn
 from test_table_2 where c1 >= 0 using index midx_02(+) limit 30;
 show trace;
 
-evaluate '097. use_desc_idx with ascending OVER order - descending scan conflicts, sort required';
+evaluate '100. use_desc_idx with ascending OVER order - descending scan conflicts, sort required';
 select /*+ recompile use_desc_idx */ c1, c2, c3,
   row_number() over (partition by c1, c2, c3 order by mod(c1, 10)) as rn
 from test_table_2 where c1 >= 0 using index midx_02(+) limit 30;
 show trace;
 
-evaluate '098. use_desc_idx with all-descending OVER order - matches descending scan, sort skipped';
+evaluate '101. use_desc_idx with all-descending OVER order - matches descending scan, sort skipped';
 select /*+ recompile use_desc_idx */ c1, c2, c3,
   row_number() over (partition by c1 desc, c2 desc, c3 desc order by mod(c1, 10) desc) as rn
 from test_table_2 where c1 >= 0 using index midx_02(+) limit 30;
@@ -879,7 +926,7 @@ select n % 7, 'c2_' || (n % 3), 'c3_' || (n % 3), n from cte;
 
 set trace on;
 
-evaluate '099. ORDER BY mod(c4,10) - function-based index column that varies inside the partition, sort skipped';
+evaluate '102. ORDER BY mod(c4,10) - function-based index column that varies inside the partition, sort skipped';
 select /*+ recompile */ c1, c2, c3, mod(c4, 10) as m,
   row_number() over (partition by c1, c2, c3 order by mod(c4, 10)) as rn
 from test_table_3 where c1 >= 0 using index midx_03(+) limit 30;
@@ -887,13 +934,13 @@ show trace;
 
 -- Value oracle for the scenario above: the SAME query forced onto a sequential
 -- scan cannot skip the sort, so it must still print an identical result block.
-evaluate '100. same query forced onto a sequential scan - sort required, result block must be identical to the skipped one';
+evaluate '103. same query forced onto a sequential scan - sort required, result block must be identical to the skipped one';
 select /*+ recompile */ c1, c2, c3, mod(c4, 10) as m,
   row_number() over (partition by c1, c2, c3 order by mod(c4, 10)) as rn
 from test_table_3 where c1 >= 0 using index none limit 30;
 show trace;
 
-evaluate '101. control - ORDER BY c4 itself, which is not an index column expression - sort required and the numbering differs from the mod(c4,10) ordering';
+evaluate '104. control - ORDER BY c4 itself, which is not an index column expression - sort required and the numbering differs from the mod(c4,10) ordering';
 select /*+ recompile */ c1, c2, c3, mod(c4, 10) as m,
   row_number() over (partition by c1, c2, c3 order by c4) as rn
 from test_table_3 where c1 >= 0 using index midx_03(+) limit 30;
@@ -914,10 +961,13 @@ drop table test_table_3;
 --    against rows going missing entirely. The result is a single scalar row,
 --    so it needs no ORDER BY, and no LIMIT is used - a LIMIT would truncate
 --    the comparison.
--- todo: the differential half of this check is missing - the same
---       analytics via an index scan vs a forced sequential scan, expecting
---       0 mismatches. Merged analytics inside a joined inline view disagree
---       today (900 of 1000 rows) -> CBRD-27125. Add once fixed.
+-- The differential half: the same analytics down an index scan (sort skipped)
+-- and down a forced sequential scan (sort performed) must agree on every row.
+-- Restored after CBRD-27125 was fixed - before that fix the two branches
+-- disagreed on 900 of 1000 rows. nvl() sentinels are required because lag() is
+-- NULL on the first row of each partition and a bare <> would evaluate to
+-- UNKNOWN and silently drop the mismatch; joined_cnt guards against rows going
+-- missing entirely. No LIMIT - a LIMIT would truncate the comparison.
 --
 drop table if exists test_table;
 create table test_table (id int auto_increment, name varchar, val int, primary key (id));
@@ -931,7 +981,31 @@ with recursive cte (n) as (
 )
 select 'name_' || n, n % 10 from cte;
 
-evaluate '102. merged analytics vs the same analytics computed one per query - values must match (expect joined_cnt 1000, bad_a1 0, bad_a2 0)';
+evaluate '105. CBRD-27125 - sort-skip path vs forced-sort path: analytic values must be identical (expect joined_cnt 1000, mismatch_cnt 0)';
+select count(*) as joined_cnt,
+  sum(case when nvl(a.rn, -1) <> nvl(b.rn, -1)
+             or nvl(a.rk, -1) <> nvl(b.rk, -1)
+             or nvl(a.sm, -1) <> nvl(b.sm, -1)
+             or nvl(a.fv, '~') <> nvl(b.fv, '~')
+             or nvl(a.lg, -1) <> nvl(b.lg, -1)
+           then 1 else 0 end) as mismatch_cnt
+from (select id,
+        row_number() over (partition by val order by id) as rn,
+        rank()       over (partition by val order by id) as rk,
+        sum(id)      over (partition by val order by id) as sm,
+        first_value(name) over (partition by val order by id) as fv,
+        lag(id, 1)   over (partition by val order by id) as lg
+      from test_table where val >= 0 using index midx_01(+)) a,
+     (select id,
+        row_number() over (partition by val order by id) as rn,
+        rank()       over (partition by val order by id) as rk,
+        sum(id)      over (partition by val order by id) as sm,
+        first_value(name) over (partition by val order by id) as fv,
+        lag(id, 1)   over (partition by val order by id) as lg
+      from test_table where val >= 0 using index none) b
+where a.id = b.id;
+
+evaluate '106. merged analytics vs the same analytics computed one per query - values must match (expect joined_cnt 1000, bad_a1 0, bad_a2 0)';
 select count(*) as joined_cnt,
   sum(case when nvl(m.a1, -1) <> nvl(s1.a1, -1) then 1 else 0 end) as bad_a1,
   sum(case when nvl(m.a2, -1) <> nvl(s2.a2, -1) then 1 else 0 end) as bad_a2
@@ -985,19 +1059,19 @@ select n, case when n % 10 = 0 then null else n % 10 end from cte;
 
 set trace on;
 
-evaluate '103. ORDER BY only, order key is a prefix of midx_01(val,id) - sort skipped';
+evaluate '107. ORDER BY only, order key is a prefix of midx_01(val,id) - sort skipped';
 select /*+ recompile */ val,
   row_number() over (order by val) as rn
 from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
-evaluate '104. ORDER BY only, order key is the full index key (val, id) - sort skipped';
+evaluate '108. ORDER BY only, order key is the full index key (val, id) - sort skipped';
 select /*+ recompile */ val, id,
   row_number() over (order by val, id) as rn
 from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
-evaluate '105. ORDER BY only, mixed ASC/DESC key (val, id desc) the ASC index cannot supply - sort required';
+evaluate '109. ORDER BY only, mixed ASC/DESC key (val, id desc) the ASC index cannot supply - sort required';
 select /*+ recompile */ val, id,
   row_number() over (order by val, id desc) as rn
 from test_table where val >= 0 using index midx_01(+) limit 30;
@@ -1009,16 +1083,22 @@ show trace;
 -- UNKNOWN), and a forced index hint without an indexable predicate falls
 -- back to a table scan (verified). An index skip scan driven by a predicate
 -- on the SECOND index column delivers full index order including NULL keys.
-evaluate '106. ORDER BY only, NULLS FIRST matches the ASC index default (NULLs stored first) - sort skipped';
+evaluate '110. ORDER BY only, NULLS FIRST matches the ASC index default (NULLs stored first) - sort skipped';
 select /*+ recompile index_ss */ val,
   row_number() over (order by val nulls first) as rn
 from test_table_null where id >= 1 using index nidx_01(+) limit 30;
 show trace;
 
--- todo: the NULLS LAST counterpart is missing - the sort-skip path
---       reports sort: skip and returns the NULL rows FIRST, so the current
---       output would bake a wrong ordering into the answer
---       -> CBRD-27145. Add once fixed.
+-- Fixed by CBRD-27145 (https://github.com/CUBRID/cubrid/pull/7586): the
+-- sort-skip path treated the index NULLs-first order as compatible with
+-- NULLS LAST, reported the sort as skipped and returned the NULL rows FIRST.
+-- NULLS LAST opposes the ASC index default, so the sort must be performed and
+-- the non-NULL rows must come first.
+evaluate '111. CBRD-27145 - ORDER BY only, NULLS LAST opposes the ASC index default: the sort must be performed and the NULL rows must come last';
+select /*+ recompile index_ss */ val,
+  row_number() over (order by val nulls last) as rn
+from test_table_null where id >= 1 using index nidx_01(+) limit 30;
+show trace;
 
 set trace off;
 drop table test_table_null;

--- a/sql/_36_guava/cbrd_26473/cases/cbrd_26473.sql
+++ b/sql/_36_guava/cbrd_26473/cases/cbrd_26473.sql
@@ -1,0 +1,755 @@
+/**
+ *  This test case verifies CBRD-26473 : Skip sorting for analytic functions when index order matches.
+ *
+ *  An analytic function sorts its input by OVER (PARTITION BY ..., ORDER BY ...)
+ *  before it is evaluated. When an index scan already delivers rows in a
+ *  compatible order, the engine reorders the index-compatible analytic functions
+ *  to run first and skips (or reduces) their sort. Each analytic sort group is
+ *  reported in the query trace as "sort: skip" (order provided by the index) or
+ *  "sort: true" (a sort was still required); the ANALYTIC #N lines were also
+ *  newly added to the trace output by this change, and are emitted once per
+ *  distinct sort group (analytics that share a sort key are merged into one #N).
+ *
+ *  These are trace cases: the feature is asserted from the "show trace" output,
+ *  so the scans are pinned with USING INDEX (+) / hints. No outer ORDER BY is
+ *  used - an outer sort becomes the top plan node and suppresses the analytic
+ *  sort-skip being tested (verified: adding one flips every "sort: skip" to
+ *  "sort: true"). Determinism instead comes from the forced index scan order and
+ *  the deterministic fresh CTP load: single-analytic results follow the index
+ *  stream; multi-analytic results follow the engine's final sort order, whose
+ *  trailing column is unique (id in sections 1-4, c4 in section 5). Section 6's
+ *  row_number ties within a partition (all rows
+ *  share the full index key) are broken by the deterministic load. Volatile
+ *  trace counters (time, page, ioread, fetch) are masked to '?' by the CTP
+ *  trace normalizer.
+ *
+ *  Coverage (each analytic in sections 1-4 is checked in four scenarios:
+ *  single-analytic skip, two analytics with the index-compatible one written
+ *  first, the same two written in reverse to prove execution-order is swapped,
+ *  and a DESC/incompatible order that still requires a sort):
+ *    1. NTILE
+ *    2. Interpolation functions - MEDIAN, PERCENTILE_CONT, PERCENTILE_DISC
+ *    3. Ranking family - ROW_NUMBER, RANK, DENSE_RANK
+ *    4. Aggregate / navigation / distribution - AVG, COUNT, CUME_DIST,
+ *       FIRST_VALUE, LAG, LAST_VALUE, LEAD, MAX, MIN, NTH_VALUE, PERCENT_RANK,
+ *       STDDEV_POP, STDDEV_SAMP, SUM, VAR_POP, VAR_SAMP
+ *    5. Sort-group merging - analytics sharing a sort key collapse into a single
+ *       ANALYTIC #N group (trace prints per sort group, not per function)
+ *    6. Index edge cases - partition on leading index columns, ORDER BY on a
+ *       non-index column, ORDER BY on a function-based index column, and
+ *       descending index scan (use_desc_idx)
+ */
+
+drop table if exists test_table;
+create table test_table (id int auto_increment, name varchar, val int, primary key (id));
+create index midx_01 on test_table (val, id);
+
+-- 1000 deterministic, environment-independent rows: id = 1..1000, val = id % 10.
+insert into test_table (name, val)
+with recursive cte (n) as (
+  select 1
+  union all
+  select n + 1 from cte where n < 1000
+)
+select 'name_' || n, n % 10 from cte;
+
+set trace on;
+
+--
+-- 1. NTILE
+--
+evaluate '001. NTILE single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ ntile(5) over (partition by val order by id) as ntile_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '002. NTILE two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  ntile(5) over (partition by val order by id) as ntile_1,
+  ntile(5) over (partition by id order by val) as ntile_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '003. NTILE two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  ntile(5) over (partition by id order by val) as ntile_2,
+  ntile(5) over (partition by val order by id) as ntile_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '004. NTILE conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  ntile(5) over (partition by val order by id desc) as ntile_1,
+  ntile(5) over (partition by id order by val) as ntile_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+--
+-- 2. Interpolation functions (MEDIAN, PERCENTILE_CONT, PERCENTILE_DISC)
+--
+evaluate '005. MEDIAN single analytic - OVER(partition by val) covered by midx_01 leading column, sort skipped';
+select /*+ recompile */ median(id) over (partition by val) as md_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '006. MEDIAN two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  median(id) over (partition by val) as md_1,
+  median(val) over (partition by id) as md_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '007. MEDIAN two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  median(val) over (partition by id) as md_2,
+  median(id) over (partition by val) as md_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '008. MEDIAN partition column not in the index (val, name) - sort required';
+select /*+ recompile */ id, val,
+  median(id) over (partition by val, name) as md_1,
+  median(val) over (partition by id) as md_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '009. PERCENTILE_CONT single analytic - within group(order by id) over(partition by val) covered by midx_01, sort skipped';
+select /*+ recompile */ percentile_cont(0.5) within group (order by id) over (partition by val) as pc_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '010. PERCENTILE_CONT two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  percentile_cont(0.5) within group (order by id) over (partition by val) as pc_1,
+  percentile_cont(0.5) within group (order by val) over (partition by id) as pc_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '011. PERCENTILE_CONT two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  percentile_cont(0.5) within group (order by val) over (partition by id) as pc_2,
+  percentile_cont(0.5) within group (order by id) over (partition by val) as pc_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '012. PERCENTILE_CONT conflicting DESC order (order by id desc) - sort required';
+select /*+ recompile */ id, val,
+  percentile_cont(0.5) within group (order by id desc) over (partition by val) as pc_1,
+  percentile_cont(0.5) within group (order by val) over (partition by id) as pc_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '013. PERCENTILE_DISC single analytic - within group(order by id) over(partition by val) covered by midx_01, sort skipped';
+select /*+ recompile */ percentile_disc(0.5) within group (order by id) over (partition by val) as pd_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '014. PERCENTILE_DISC two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  percentile_disc(0.5) within group (order by id) over (partition by val) as pd_1,
+  percentile_disc(0.5) within group (order by val) over (partition by id) as pd_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '015. PERCENTILE_DISC two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  percentile_disc(0.5) within group (order by val) over (partition by id) as pd_2,
+  percentile_disc(0.5) within group (order by id) over (partition by val) as pd_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '016. PERCENTILE_DISC conflicting DESC order (order by id desc) - sort required';
+select /*+ recompile */ id, val,
+  percentile_disc(0.5) within group (order by id desc) over (partition by val) as pd_1,
+  percentile_disc(0.5) within group (order by val) over (partition by id) as pd_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+--
+-- 3. Ranking family (ROW_NUMBER, RANK, DENSE_RANK)
+--
+evaluate '017. ROW_NUMBER single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ row_number() over (partition by val order by id) as rn_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '018. ROW_NUMBER two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  row_number() over (partition by val order by id) as rn_1,
+  row_number() over (partition by id order by val) as rn_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '019. ROW_NUMBER two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  row_number() over (partition by id order by val) as rn_2,
+  row_number() over (partition by val order by id) as rn_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '020. ROW_NUMBER conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  row_number() over (partition by val order by id desc) as rn_1,
+  row_number() over (partition by id order by val) as rn_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '021. RANK single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ rank() over (partition by val order by id) as rk_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '022. RANK two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  rank() over (partition by val order by id) as rk_1,
+  rank() over (partition by id order by val) as rk_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '023. RANK two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  rank() over (partition by id order by val) as rk_2,
+  rank() over (partition by val order by id) as rk_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '024. RANK conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  rank() over (partition by val order by id desc) as rk_1,
+  rank() over (partition by id order by val) as rk_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '025. DENSE_RANK single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ dense_rank() over (partition by val order by id) as dr_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '026. DENSE_RANK two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  dense_rank() over (partition by val order by id) as dr_1,
+  dense_rank() over (partition by id order by val) as dr_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '027. DENSE_RANK two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  dense_rank() over (partition by id order by val) as dr_2,
+  dense_rank() over (partition by val order by id) as dr_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '028. DENSE_RANK conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  dense_rank() over (partition by val order by id desc) as dr_1,
+  dense_rank() over (partition by id order by val) as dr_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+--
+-- 4. Aggregate / navigation / distribution window functions
+--
+evaluate '029. AVG single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ avg(id) over (partition by val order by id) as av_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '030. AVG two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  avg(id) over (partition by val order by id) as av_1,
+  avg(val) over (partition by id order by val) as av_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '031. AVG two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  avg(val) over (partition by id order by val) as av_2,
+  avg(id) over (partition by val order by id) as av_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '032. AVG conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  avg(id) over (partition by val order by id desc) as av_1,
+  avg(val) over (partition by id order by val) as av_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '033. COUNT single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ count(id) over (partition by val order by id) as cnt_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '034. COUNT two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  count(id) over (partition by val order by id) as cnt_1,
+  count(val) over (partition by id order by val) as cnt_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '035. COUNT two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  count(val) over (partition by id order by val) as cnt_2,
+  count(id) over (partition by val order by id) as cnt_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '036. COUNT conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  count(id) over (partition by val order by id desc) as cnt_1,
+  count(val) over (partition by id order by val) as cnt_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '037. CUME_DIST single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ cume_dist() over (partition by val order by id) as cd_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '038. CUME_DIST two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  cume_dist() over (partition by val order by id) as cd_1,
+  cume_dist() over (partition by id order by val) as cd_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '039. CUME_DIST two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  cume_dist() over (partition by id order by val) as cd_2,
+  cume_dist() over (partition by val order by id) as cd_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '040. CUME_DIST conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  cume_dist() over (partition by val order by id desc) as cd_1,
+  cume_dist() over (partition by id order by val) as cd_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '041. FIRST_VALUE single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ first_value(name) over (partition by val order by id) as fv_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '042. FIRST_VALUE two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  first_value(name) over (partition by val order by id) as fv_1,
+  first_value(name) over (partition by id order by val) as fv_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '043. FIRST_VALUE two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  first_value(name) over (partition by id order by val) as fv_2,
+  first_value(name) over (partition by val order by id) as fv_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '044. FIRST_VALUE conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  first_value(name) over (partition by val order by id desc) as fv_1,
+  first_value(name) over (partition by id order by val) as fv_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '045. LAG single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ lag(name, 1) over (partition by val order by id) as lg_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '046. LAG two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  lag(name, 1) over (partition by val order by id) as lg_1,
+  lag(name, 1) over (partition by id order by val) as lg_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '047. LAG two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  lag(name, 1) over (partition by id order by val) as lg_2,
+  lag(name, 1) over (partition by val order by id) as lg_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '048. LAG conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  lag(name, 1) over (partition by val order by id desc) as lg_1,
+  lag(name, 1) over (partition by id order by val) as lg_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '049. LAST_VALUE single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ last_value(name) over (partition by val order by id) as lv_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '050. LAST_VALUE two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  last_value(name) over (partition by val order by id) as lv_1,
+  last_value(name) over (partition by id order by val) as lv_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '051. LAST_VALUE two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  last_value(name) over (partition by id order by val) as lv_2,
+  last_value(name) over (partition by val order by id) as lv_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '052. LAST_VALUE conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  last_value(name) over (partition by val order by id desc) as lv_1,
+  last_value(name) over (partition by id order by val) as lv_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '053. LEAD single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ lead(name, 1) over (partition by val order by id) as ld_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '054. LEAD two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  lead(name, 1) over (partition by val order by id) as ld_1,
+  lead(name, 1) over (partition by id order by val) as ld_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '055. LEAD two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  lead(name, 1) over (partition by id order by val) as ld_2,
+  lead(name, 1) over (partition by val order by id) as ld_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '056. LEAD conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  lead(name, 1) over (partition by val order by id desc) as ld_1,
+  lead(name, 1) over (partition by id order by val) as ld_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '057. MAX single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ max(id) over (partition by val order by id) as mx_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '058. MAX two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  max(id) over (partition by val order by id) as mx_1,
+  max(val) over (partition by id order by val) as mx_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '059. MAX two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  max(val) over (partition by id order by val) as mx_2,
+  max(id) over (partition by val order by id) as mx_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '060. MAX conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  max(id) over (partition by val order by id desc) as mx_1,
+  max(val) over (partition by id order by val) as mx_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '061. MIN single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ min(id) over (partition by val order by id) as mn_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '062. MIN two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  min(id) over (partition by val order by id) as mn_1,
+  min(val) over (partition by id order by val) as mn_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '063. MIN two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  min(val) over (partition by id order by val) as mn_2,
+  min(id) over (partition by val order by id) as mn_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '064. MIN conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  min(id) over (partition by val order by id desc) as mn_1,
+  min(val) over (partition by id order by val) as mn_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '065. NTH_VALUE single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ nth_value(name, 10) over (partition by val order by id) as nv_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '066. NTH_VALUE two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  nth_value(name, 10) over (partition by val order by id) as nv_1,
+  nth_value(name, 10) over (partition by id order by val) as nv_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '067. NTH_VALUE two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  nth_value(name, 10) over (partition by id order by val) as nv_2,
+  nth_value(name, 10) over (partition by val order by id) as nv_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '068. NTH_VALUE conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  nth_value(name, 10) over (partition by val order by id desc) as nv_1,
+  nth_value(name, 10) over (partition by id order by val) as nv_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '069. PERCENT_RANK single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ percent_rank() over (partition by val order by id) as pr_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '070. PERCENT_RANK two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  percent_rank() over (partition by val order by id) as pr_1,
+  percent_rank() over (partition by id order by val) as pr_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '071. PERCENT_RANK two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  percent_rank() over (partition by id order by val) as pr_2,
+  percent_rank() over (partition by val order by id) as pr_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '072. PERCENT_RANK conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  percent_rank() over (partition by val order by id desc) as pr_1,
+  percent_rank() over (partition by id order by val) as pr_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '073. STDDEV_POP single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ stddev_pop(id) over (partition by val order by id) as sp_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '074. STDDEV_POP two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  stddev_pop(id) over (partition by val order by id) as sp_1,
+  stddev_pop(val) over (partition by id order by val) as sp_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '075. STDDEV_POP two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  stddev_pop(val) over (partition by id order by val) as sp_2,
+  stddev_pop(id) over (partition by val order by id) as sp_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '076. STDDEV_POP conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  stddev_pop(id) over (partition by val order by id desc) as sp_1,
+  stddev_pop(val) over (partition by id order by val) as sp_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '077. STDDEV_SAMP single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ stddev_samp(id) over (partition by val order by id) as ss_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '078. STDDEV_SAMP two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  stddev_samp(id) over (partition by val order by id) as ss_1,
+  stddev_samp(val) over (partition by id order by val) as ss_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '079. STDDEV_SAMP two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  stddev_samp(val) over (partition by id order by val) as ss_2,
+  stddev_samp(id) over (partition by val order by id) as ss_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '080. STDDEV_SAMP conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  stddev_samp(id) over (partition by val order by id desc) as ss_1,
+  stddev_samp(val) over (partition by id order by val) as ss_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '081. SUM single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ sum(id) over (partition by val order by id) as sm_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '082. SUM two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  sum(id) over (partition by val order by id) as sm_1,
+  sum(val) over (partition by id order by val) as sm_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '083. SUM two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  sum(val) over (partition by id order by val) as sm_2,
+  sum(id) over (partition by val order by id) as sm_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '084. SUM conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  sum(id) over (partition by val order by id desc) as sm_1,
+  sum(val) over (partition by id order by val) as sm_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '085. VAR_POP single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ var_pop(id) over (partition by val order by id) as vp_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '086. VAR_POP two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  var_pop(id) over (partition by val order by id) as vp_1,
+  var_pop(val) over (partition by id order by val) as vp_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '087. VAR_POP two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  var_pop(val) over (partition by id order by val) as vp_2,
+  var_pop(id) over (partition by val order by id) as vp_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '088. VAR_POP conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  var_pop(id) over (partition by val order by id desc) as vp_1,
+  var_pop(val) over (partition by id order by val) as vp_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '089. VAR_SAMP single analytic - OVER matches midx_01(val,id), sort skipped';
+select /*+ recompile */ var_samp(id) over (partition by val order by id) as vs_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '090. VAR_SAMP two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
+select /*+ recompile */ id, val,
+  var_samp(id) over (partition by val order by id) as vs_1,
+  var_samp(val) over (partition by id order by val) as vs_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '091. VAR_SAMP two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
+select /*+ recompile */ id, val,
+  var_samp(val) over (partition by id order by val) as vs_2,
+  var_samp(id) over (partition by val order by id) as vs_1
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+evaluate '092. VAR_SAMP conflicting DESC order on the ASC index - sort required';
+select /*+ recompile */ id, val,
+  var_samp(id) over (partition by val order by id desc) as vs_1,
+  var_samp(val) over (partition by id order by val) as vs_2
+from test_table where val >= 0 using index midx_01(+) limit 10;
+show trace;
+
+set trace off;
+drop table test_table;
+
+--
+-- 5. Sort-group merging: two analytics that share a sort key are
+--    reported as a single ANALYTIC #N group (JIRA comment 2026-03-19).
+--
+drop table if exists t_group;
+create table t_group (c1 int, c2 int, c3 int, c4 int);
+create index gidx on t_group (c1, c2, c3, c4);
+
+-- Independent columns (coprime moduli) so every (c1,c2,c3) partition
+-- holds several rows with distinct c4; c4 is unique overall.
+insert into t_group
+with recursive cte (n) as (
+  select 1
+  union all
+  select n + 1 from cte where n < 1000
+)
+select n % 5, n % 7, n % 3, n from cte;
+
+set trace on;
+
+evaluate '093. Two analytics share the sort key (c1,c2,c3,c4) - they merge into a single ANALYTIC # group (sort skipped); the trace prints one line per sort group, not per function';
+select /*+ recompile */ c1, c2, c3, c4,
+  row_number() over (partition by c1, c2, c3 order by c4) as a1,
+  row_number() over (partition by c1, c2 order by c3, c4) as a2
+from t_group where c1 >= 0 using index gidx(+) limit 10;
+show trace;
+
+set trace off;
+drop table t_group;
+
+--
+-- 6. Index edge cases found in code review
+--    (function-based index column, descending index scan, non-index column)
+-- note: no outer ORDER BY (it would suppress the analytic sort-skip).
+--    Every (c1,c2,c3) partition shares the full index key
+--    (c1,c2,c3,mod(c1,10)); the returned partition's rows and their
+--    row_number values are fixed by the deterministic fresh CTP load
+--    (index/insertion order), independent of the sort:skip/true signal.
+--
+drop table if exists test_table_2;
+create table test_table_2 (c1 int, c2 varchar, c3 varchar, c4 int);
+create index midx_02 on test_table_2 (c1, c2, c3, mod(c1, 10));
+
+insert into test_table_2
+with recursive cte (n) as (
+  select 1
+  union all
+  select n + 1 from cte where n < 1000
+)
+select n % 100, 'c2_' || (n % 10), 'c3_' || (n % 10), n from cte;
+
+set trace on;
+
+evaluate '094. Partition on leading index columns (c1, c2, c3), no ORDER BY - sort skipped';
+select /*+ recompile */ c1, c2, c3,
+  row_number() over (partition by c1, c2, c3) as rn
+from test_table_2 where c1 >= 0 using index midx_02(+) limit 10;
+show trace;
+
+evaluate '095. ORDER BY c4 (not an index column) - sort required';
+select /*+ recompile */ c1, c2, c3,
+  row_number() over (partition by c1, c2, c3 order by c4) as rn
+from test_table_2 where c1 >= 0 using index midx_02(+) limit 10;
+show trace;
+
+evaluate '096. ORDER BY mod(c1, 10) (the function-based 4th index column) - sort skipped';
+select /*+ recompile */ c1, c2, c3,
+  row_number() over (partition by c1, c2, c3 order by mod(c1, 10)) as rn
+from test_table_2 where c1 >= 0 using index midx_02(+) limit 10;
+show trace;
+
+evaluate '097. use_desc_idx with ascending OVER order - descending scan conflicts, sort required';
+select /*+ recompile use_desc_idx */ c1, c2, c3,
+  row_number() over (partition by c1, c2, c3 order by mod(c1, 10)) as rn
+from test_table_2 where c1 >= 0 using index midx_02(+) limit 10;
+show trace;
+
+evaluate '098. use_desc_idx with all-descending OVER order - matches descending scan, sort skipped';
+select /*+ recompile use_desc_idx */ c1, c2, c3,
+  row_number() over (partition by c1 desc, c2 desc, c3 desc order by mod(c1, 10) desc) as rn
+from test_table_2 where c1 >= 0 using index midx_02(+) limit 10;
+show trace;
+
+set trace off;
+drop table test_table_2;

--- a/sql/_36_guava/cbrd_26473/cases/cbrd_26473.sql
+++ b/sql/_36_guava/cbrd_26473/cases/cbrd_26473.sql
@@ -47,9 +47,8 @@
  *       key collapse into a single ANALYTIC #N group (the trace prints one line
  *       per sort group, not per function)
  *    6. Index edge cases - partition on leading index columns, ORDER BY on a
- *       non-index column, ORDER BY on a function-based index column that is
- *       CONSTANT inside the partition (a degenerate ordering), and descending
- *       index scan (use_desc_idx)
+ *       non-index column, and descending index scan (use_desc_idx) with an OVER
+ *       order that conflicts with the scan direction and one that matches it
  *    7. Function-based index column that VARIES inside the partition, with the
  *       same query forced onto a sequential scan as the value oracle
  *    8. Value equivalence - the sort-skip path must return the same analytic
@@ -77,31 +76,39 @@ set trace on;
 
 --
 -- 1. NTILE
+--    ntile(50) - not ntile(5) - because a val partition holds 100 rows: 50
+--    buckets put exactly 2 rows in each, so the bucket number VARIES across
+--    the 30 returned rows and therefore pins which partition positions came
+--    back. With ntile(5) the bucket boundaries sit every 20 positions, and
+--    the two-analytic scenarios return partition positions 1-3 only, so the
+--    bucket was a constant 1 that asserted nothing about the value. The
+--    bucket count is an argument, not part of the OVER sort key, so the
+--    sort: skip / sort: true verdicts are unaffected by this choice.
 --
 evaluate '001. NTILE single analytic - OVER matches midx_01(val,id), sort skipped';
 select /*+ recompile */ id, val,
-  ntile(5) over (partition by val order by id) as ntile_1
+  ntile(50) over (partition by val order by id) as ntile_1
 from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '002. NTILE two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
-  ntile(5) over (partition by val order by id) as ntile_1,
-  ntile(5) over (partition by id order by val) as ntile_2
+  ntile(50) over (partition by val order by id) as ntile_1,
+  ntile(50) over (partition by id order by val) as ntile_2
 from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '003. NTILE two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
-  ntile(5) over (partition by id order by val) as ntile_2,
-  ntile(5) over (partition by val order by id) as ntile_1
+  ntile(50) over (partition by id order by val) as ntile_2,
+  ntile(50) over (partition by val order by id) as ntile_1
 from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '004. NTILE conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
-  ntile(5) over (partition by val order by id desc) as ntile_1,
-  ntile(5) over (partition by id order by val) as ntile_2
+  ntile(50) over (partition by val order by id desc) as ntile_1,
+  ntile(50) over (partition by id order by val) as ntile_2
 from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
@@ -519,30 +526,37 @@ select /*+ recompile */ id, val,
 from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
+-- nth_value's default window frame is UNBOUNDED PRECEDING .. CURRENT ROW, so
+-- nth_value(name, N) is NULL until the frame has accumulated N rows. N = 2 is
+-- the smallest N > 1 that becomes non-NULL inside the returned window (the
+-- two-analytic scenarios return partition positions 1-3, so N = 10 was NULL on
+-- every row and asserted nothing). N = 1 is deliberately not used: it would
+-- duplicate FIRST_VALUE and leave no N > 1 positional coverage. Like ntile's
+-- bucket count, N is an argument and not part of the OVER sort key.
 evaluate '065. NTH_VALUE single analytic - OVER matches midx_01(val,id), sort skipped';
 select /*+ recompile */ id, val,
-  nth_value(name, 10) over (partition by val order by id) as nv_1
+  nth_value(name, 2) over (partition by val order by id) as nv_1
 from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '066. NTH_VALUE two analytics, index-compatible one listed first - #1 sort skipped, #2 sort required';
 select /*+ recompile */ id, val,
-  nth_value(name, 10) over (partition by val order by id) as nv_1,
-  nth_value(name, 10) over (partition by id order by val) as nv_2
+  nth_value(name, 2) over (partition by val order by id) as nv_1,
+  nth_value(name, 2) over (partition by id order by val) as nv_2
 from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '067. NTH_VALUE two analytics, index-compatible one listed second - reordered to run first, #1 sort skipped';
 select /*+ recompile */ id, val,
-  nth_value(name, 10) over (partition by id order by val) as nv_2,
-  nth_value(name, 10) over (partition by val order by id) as nv_1
+  nth_value(name, 2) over (partition by id order by val) as nv_2,
+  nth_value(name, 2) over (partition by val order by id) as nv_1
 from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
 evaluate '068. NTH_VALUE conflicting DESC order on the ASC index - sort required';
 select /*+ recompile */ id, val,
-  nth_value(name, 10) over (partition by val order by id desc) as nv_1,
-  nth_value(name, 10) over (partition by id order by val) as nv_2
+  nth_value(name, 2) over (partition by val order by id desc) as nv_1,
+  nth_value(name, 2) over (partition by id order by val) as nv_2
 from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
@@ -722,8 +736,8 @@ show trace;
 --
 evaluate '093. NTILE index-compatible DESC analytic written second - promoted ahead of the incompatible one (final row order reveals the execution order)';
 select /*+ recompile */ id, val,
-  ntile(5) over (partition by id order by val) as n_2,
-  ntile(5) over (partition by val order by id desc) as n_1
+  ntile(50) over (partition by id order by val) as n_2,
+  ntile(50) over (partition by val order by id desc) as n_1
 from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
@@ -782,6 +796,17 @@ drop table t_group;
 --    the block is identical however the tied rows are visited. limit 30
 --    spans three partitions, so rn resetting at each boundary is what
 --    proves the analytic partitions at all.
+--    There is deliberately NO standalone ascending "order by mod(c1, 10)"
+--    scenario here. mod(c1,10) is a function of the partition key c1, so it is
+--    CONSTANT inside every partition and ordering by it is a no-op: such a
+--    scenario printed a data block byte-identical to the partition-only one
+--    below and reported the same sort: skip, so it asserted nothing that the
+--    partition-only scenario did not already assert. The matching of a
+--    function-based index column is still covered - by the descending pair at
+--    the end of this section (which orders by mod(c1,10) and mod(c1,10) desc,
+--    one requiring a sort and one skipping it), and, with an ordering value
+--    that actually VARIES inside the partition plus a value oracle, by
+--    section 7.
 --
 drop table if exists test_table_2;
 create table test_table_2 (c1 int, c2 varchar, c3 varchar, c4 int);
@@ -809,19 +834,13 @@ select /*+ recompile */ c1, c2, c3,
 from test_table_2 where c1 >= 0 using index midx_02(+) limit 30;
 show trace;
 
-evaluate '097. ORDER BY mod(c1, 10) (the function-based 4th index column) - sort skipped';
-select /*+ recompile */ c1, c2, c3,
-  row_number() over (partition by c1, c2, c3 order by mod(c1, 10)) as rn
-from test_table_2 where c1 >= 0 using index midx_02(+) limit 30;
-show trace;
-
-evaluate '098. use_desc_idx with ascending OVER order - descending scan conflicts, sort required';
+evaluate '097. use_desc_idx with ascending OVER order - descending scan conflicts, sort required';
 select /*+ recompile use_desc_idx */ c1, c2, c3,
   row_number() over (partition by c1, c2, c3 order by mod(c1, 10)) as rn
 from test_table_2 where c1 >= 0 using index midx_02(+) limit 30;
 show trace;
 
-evaluate '099. use_desc_idx with all-descending OVER order - matches descending scan, sort skipped';
+evaluate '098. use_desc_idx with all-descending OVER order - matches descending scan, sort skipped';
 select /*+ recompile use_desc_idx */ c1, c2, c3,
   row_number() over (partition by c1 desc, c2 desc, c3 desc order by mod(c1, 10) desc) as rn
 from test_table_2 where c1 >= 0 using index midx_02(+) limit 30;
@@ -834,9 +853,11 @@ drop table test_table_2;
 -- 7. Function-based index column that VARIES inside the partition.
 --    In section 6 the ordering expression mod(c1,10) is a function of the
 --    partition key, so it is CONSTANT inside a partition: ordering by it is a
---    no-op and its sort: skip does not prove the function-based index column
---    was matched. Here mod(c4,10) is independent of the partition key, so the
---    skipped path must also produce the CORRECT row_number values.
+--    no-op, and a sort: skip on a no-op ordering does not prove the
+--    function-based index column was matched (which is why section 6 carries
+--    no standalone ascending case for it - it printed byte-identically to its
+--    partition-only scenario). Here mod(c4,10) is independent of the partition
+--    key, so the skipped path must also produce the CORRECT row_number values.
 --    c1 = n%7 and c2/c3 = n%3 are coprime, so a (c1,c2,c3) partition is n mod 21
 --    - 21 partitions of ~47 rows - and limit 30 stays inside the first one.
 --    For n = r + 21k, mod(c4,10) = (r + k) mod 10, which varies with k.
@@ -858,7 +879,7 @@ select n % 7, 'c2_' || (n % 3), 'c3_' || (n % 3), n from cte;
 
 set trace on;
 
-evaluate '100. ORDER BY mod(c4,10) - function-based index column that varies inside the partition, sort skipped';
+evaluate '099. ORDER BY mod(c4,10) - function-based index column that varies inside the partition, sort skipped';
 select /*+ recompile */ c1, c2, c3, mod(c4, 10) as m,
   row_number() over (partition by c1, c2, c3 order by mod(c4, 10)) as rn
 from test_table_3 where c1 >= 0 using index midx_03(+) limit 30;
@@ -866,13 +887,13 @@ show trace;
 
 -- Value oracle for the scenario above: the SAME query forced onto a sequential
 -- scan cannot skip the sort, so it must still print an identical result block.
-evaluate '101. same query forced onto a sequential scan - sort required, result block must be identical to the skipped one';
+evaluate '100. same query forced onto a sequential scan - sort required, result block must be identical to the skipped one';
 select /*+ recompile */ c1, c2, c3, mod(c4, 10) as m,
   row_number() over (partition by c1, c2, c3 order by mod(c4, 10)) as rn
 from test_table_3 where c1 >= 0 using index none limit 30;
 show trace;
 
-evaluate '102. control - ORDER BY c4 itself, which is not an index column expression - sort required and the numbering differs from the mod(c4,10) ordering';
+evaluate '101. control - ORDER BY c4 itself, which is not an index column expression - sort required and the numbering differs from the mod(c4,10) ordering';
 select /*+ recompile */ c1, c2, c3, mod(c4, 10) as m,
   row_number() over (partition by c1, c2, c3 order by c4) as rn
 from test_table_3 where c1 >= 0 using index midx_03(+) limit 30;
@@ -910,7 +931,7 @@ with recursive cte (n) as (
 )
 select 'name_' || n, n % 10 from cte;
 
-evaluate '103. merged analytics vs the same analytics computed one per query - values must match (expect joined_cnt 1000, bad_a1 0, bad_a2 0)';
+evaluate '102. merged analytics vs the same analytics computed one per query - values must match (expect joined_cnt 1000, bad_a1 0, bad_a2 0)';
 select count(*) as joined_cnt,
   sum(case when nvl(m.a1, -1) <> nvl(s1.a1, -1) then 1 else 0 end) as bad_a1,
   sum(case when nvl(m.a2, -1) <> nvl(s2.a2, -1) then 1 else 0 end) as bad_a2
@@ -964,19 +985,19 @@ select n, case when n % 10 = 0 then null else n % 10 end from cte;
 
 set trace on;
 
-evaluate '104. ORDER BY only, order key is a prefix of midx_01(val,id) - sort skipped';
+evaluate '103. ORDER BY only, order key is a prefix of midx_01(val,id) - sort skipped';
 select /*+ recompile */ val,
   row_number() over (order by val) as rn
 from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
-evaluate '105. ORDER BY only, order key is the full index key (val, id) - sort skipped';
+evaluate '104. ORDER BY only, order key is the full index key (val, id) - sort skipped';
 select /*+ recompile */ val, id,
   row_number() over (order by val, id) as rn
 from test_table where val >= 0 using index midx_01(+) limit 30;
 show trace;
 
-evaluate '106. ORDER BY only, mixed ASC/DESC key (val, id desc) the ASC index cannot supply - sort required';
+evaluate '105. ORDER BY only, mixed ASC/DESC key (val, id desc) the ASC index cannot supply - sort required';
 select /*+ recompile */ val, id,
   row_number() over (order by val, id desc) as rn
 from test_table where val >= 0 using index midx_01(+) limit 30;
@@ -988,7 +1009,7 @@ show trace;
 -- UNKNOWN), and a forced index hint without an indexable predicate falls
 -- back to a table scan (verified). An index skip scan driven by a predicate
 -- on the SECOND index column delivers full index order including NULL keys.
-evaluate '107. ORDER BY only, NULLS FIRST matches the ASC index default (NULLs stored first) - sort skipped';
+evaluate '106. ORDER BY only, NULLS FIRST matches the ASC index default (NULLs stored first) - sort skipped';
 select /*+ recompile index_ss */ val,
   row_number() over (order by val nulls first) as rn
 from test_table_null where id >= 1 using index nidx_01(+) limit 30;


### PR DESCRIPTION
Refer to: http://jira.cubrid.org/browse/CBRD-26473

## 개요
분석함수(analytic function)가 인덱스가 제공하는 정렬 순서를 활용해 정렬을 생략(sort: skip)하는 CBRD-26473 최적화를 검증하는 SQL 테스트 케이스입니다. OVER 절(PARTITION BY, ORDER BY)의 정렬 기준이 인덱스와 호환되면, 해당 분석함수를 먼저 실행하고 정렬을 생략하며 `show trace` 출력의 `ANALYTIC #N` 라인에 `sort: skip` / `sort: true`로 표시됩니다.

## 커버리지 (단일 파일, 99개 시나리오)
- **1~4. 23개 윈도우 함수 × 4개 시나리오**: 단일 분석함수 정렬 생략, 인덱스 호환 함수를 앞에 배치(앞 그룹 skip / 뒤 그룹 true), 뒤에 배치(재정렬로 여전히 앞 그룹 skip), DESC 충돌 시 정렬 수행(true).
  NTILE, MEDIAN, PERCENTILE_CONT, PERCENTILE_DISC, ROW_NUMBER, RANK, DENSE_RANK, AVG, COUNT, CUME_DIST, FIRST_VALUE, LAG, LAST_VALUE, LEAD, MAX, MIN, NTH_VALUE, PERCENT_RANK, STDDEV_POP, STDDEV_SAMP, SUM, VAR_POP, VAR_SAMP
- **실행 순서 승격**: 인덱스 선두 컬럼과 호환되지만 정렬을 생략할 수 없는(DESC) 분석함수를 select-list **두 번째**에 배치한 시나리오. 이 경우에만 승격이 no-op이 아니게 되어, 최종 행 순서(승격 시 id 순, 미승격 시 val=0/id=1000 시작)로 실행 순서 조정이 관찰됩니다.
- **5. 정렬 그룹 병합**: 동일한 정렬 기준을 가지는 두 분석함수가 하나의 `ANALYTIC #N` 그룹으로 병합되어, 함수 개수가 아닌 정렬 기준 개수만큼 trace에 출력되는 동작.
- **6. 인덱스 엣지 케이스**: 선두 인덱스 컬럼 파티션, 비인덱스 컬럼 ORDER BY, 함수 기반 인덱스 컬럼(`mod(c1,10)`) ORDER BY, `use_desc_idx` 역순 인덱스 스캔.

## 결정성 설계
- trace 테스트 특성상 외부 ORDER BY를 사용하지 않습니다. 외부 정렬이 상위 플랜 노드가 되어 분석함수의 sort 생략을 억제하기 때문입니다(외부 ORDER BY 추가 시 모든 `sort: skip`이 `sort: true`로 바뀌는 것을 확인).
- 결과 행은 강제 인덱스 스캔 순서와 결정적인 재귀 CTE 데이터로 고정됩니다.

## 배치
- `sql/_36_guava/cbrd_26473/cases/cbrd_26473.sql`
- `sql/_36_guava/cbrd_26473/answers/cbrd_26473.answer`

## 검증
pre-fix / post-fix 빌드로 검증했습니다.
- Verified: pre-fix `fe754e9` -> NOK / post-fix `1cdd023` -> OK
- pre-fix는 분석함수 trace(ANALYTIC 라인)가 없어 답지와 불일치하여 실패하고, post-fix에서 통과합니다.
- 99개 전 시나리오의 `sort: skip` / `sort: true` 라벨을 실제 trace와 대조하여 일치를 확인했습니다.
