### PR TITLE
[CUBRIDQA-1136] Modify the test case SQL statement to explicitly ensu…

### DIFF
--- a/sql/_27_banana_qa/issue_5765_timezone_support/_01_table_operations/_04_select/cases/_09_view_dt.sql
+++ b/sql/_27_banana_qa/issue_5765_timezone_support/_01_table_operations/_04_select/cases/_09_view_dt.sql
@@ -33,8 +33,9 @@ set timezone 'Asia/Seoul';
 select all * from v1 order by id;
 
 set timezone 'Europe/Bucharest';
-select distinct newt.col1 from (select id,col1 from v1 order by id) newt order by 1;
-select unique newt.col1, newt.col2 from (select id,col1,col2 from tz_test order by id) newt  order by 1;
+-- When dealing with data containing duplicate values, using `DISTINCT` or `UNIQUE` in a query does not explicitly guarantee the specific output. The query must be modified to ensure the output is explicitly guaranteed.
+select v1.col1 from v1 where v1.id = (select min(v2.id) from v1 v2 where v2.col1 = v1.col1) order by 1;
+select tz_test.col1, tz_test.col2 from tz_test where tz_test.id = (select min(t2.id) from tz_test t2 where t2.col1 = tz_test.col1 and t2.col2 = tz_test.col2) order by 1;
 
 --test: alter view
 alter view v1 as select * from tz_test where col1<datetimetz'1933-12-10 15:30:00.999 +8:59' and col2>datetimetz'1891-07-10 2:00:00.999';

--- a/sql/_27_banana_qa/issue_5765_timezone_support/_01_table_operations/_04_select/cases/_09_view_ts.sql
+++ b/sql/_27_banana_qa/issue_5765_timezone_support/_01_table_operations/_04_select/cases/_09_view_ts.sql
@@ -33,8 +33,9 @@ set timezone 'Asia/Seoul';
 select all * from v1 order by id;
 
 set timezone 'Europe/Bucharest';
-select distinct tv2.col1 from (select id,col1 from v1 order by 1) tv2 order by 1;
-select unique tv2.col1, tv2.col2 from (select id,col1,col2 from tz_test order by id) tv2 order by 1;
+-- When dealing with data containing duplicate values, using `DISTINCT` or `UNIQUE` in a query does not explicitly guarantee the specific output. The query must be modified to ensure the output is explicitly guaranteed.
+select v1.col1 from v1 where v1.id = (select min(tv2.id) from v1 tv2 where tv2.col1 = v1.col1) order by 1;
+select tz_test.col1, tz_test.col2 from tz_test where tz_test.id = (select min(t2.id) from tz_test t2 where t2.col1 = tz_test.col1 and t2.col2 = tz_test.col2) order by 1;
 
 --test: alter view
 alter view v1 as select * from tz_test where col1<timestamptz'2013-12-10 15:30:00 +8:59' and col2>timestamptz'1992-07-10 2:00:00';


### PR DESCRIPTION
…re output.

to refer : sql/_27_banana_qa/issue_5765_timezone_support/_01_table_operations/_04_select/cases/_09_view_dt.sql
sql/_27_banana_qa/issue_5765_timezone_support/_01_table_operations/_04_select/cases/_09_view_ts.sql

regression test 버전(11.5.0.2378-0dd8912 - 64bits - sql) 이후 부터 지속적으로 Failed 발생.
원인 : 컬럼의 데이터 중복 값이 있으며 이에 대해 select절에 distinct, unique를 사용하면서 order by절에 중복 컬럼을 사용함으로써 출력할 때는 어떤 값이 명시적으로 출력되는지 보장하지 않다보니 출력 결과와 답지가 상이하는 현상발생

- 실제 계산으로 확인해보니 id=1,3,4,5 총 4개

**1) v1 테이블의 col1 값 (1933-12-10 관련 5건)**
id  col1 표기	                              시간대 오프셋      UTC 환산
1  15:30:00.999 Asia/Seoul JST	      UTC+9	 15:30:00.999 − 9:00 = 06:30:00.999
2  15:30:30.999 +09:00	                      UTC+9	 15:30:30.999 − 9:00 = 06:30:30.999
3  03:00:00.999 -03:30	                      UTC−3:30    03:00:00.999 + 3:30 = 06:30:00.999
4  15:30:00.999 Asia/Tokyo JST	      UTC+9	 15:30:00.999 − 9:00 = 06:30:00.999
5  08:30:00.999 Europe/Bucharest EET  UTC+2	 08:30:00.999 − 2:00 = 06:30:00.999
id=1, 3, 4, 5 → 전부 1933-12-10 06:30:00.999 UTC로 동일합니다.

**2) 4건이 동일하고, 1건이 다른 이유에 대한 설명**
id=1(Seoul, UTC+9)과 id=4(Tokyo, UTC+9): 1933년 당시 한국은 일제강점기라 서울도 도쿄와 같은 일본 표준시(JST, UTC+9)를 썼기 때문에 표기(Asia/Seoul JST)는 다르지만 오프셋이 완전히 같습니다.
id=3(-03:30): 로컬 시각은 새벽 3시로 전혀 달라 보이지만, 오프셋이 -3:30이라 UTC로 환산하면 정확히 같은 순간이 됩니다.
id=5(Bucharest, UTC+2, 겨울철 EET): 로컬 08:30이지만 UTC+2라서 역시 06:30 UTC로 같아집니다.
id=2만 예외입니다: 초 단위가 :30.999로 30초 더 있어서 UTC로도 06:30:30.999가 되어 나머지 4개와 30초 차이가 나는, 진짜로 다른 순간입니다.
아마 "얼핏 비슷해 보이지만 실제로는 다른 값"을 걸러내는지 확인하려고 의도적으로 넣은 데이터임.

**해결 :** Failed가 발생하지 않도록 컬럼의 데이터 중복 값이 있더라도 명시적으로 데이터 출력이 보장되는 query문 수정

3) 컬럼의 타입을 datetime with time zone으로 했을 시 데이터의 UTC 환산 결과 값으로 비교하여 출력 된다.

4) datetimetz 타입의 값이 아래와 같다.(datetime까지 UTC 환산 결과 값)
   03:30:00.999 PM 12/10/1933 Asia/Seoul JST  -> UTC+9 환산 결과: 06:30:00.999
   03:00:00.999 AM 12/10/1933 -03:30              -> UTC+0 환산 결과: 06:30:00.999
   03:30:00.999 PM 12/10/1933 Asia/Tokyo JST -> UTC+9 환산 결과: 06:30:00.999
   08:30:00.999 Europe/Bucharest EET                -> UTC+2 환산 결과: 06:30:00.999

5) TZ 타입은 UTC 순간 기준으로 비교되므로 같은 순간이면 동일값 취급임으로 query문 수정
   5-1) v2.col1 = v1.col1 비교가 UTC 순간 기준 동등 비교이므로, 같은 순간을 나타내는 id=1,3,4,5 에서 MIN(id)=1인 행만 살아남고, 
그 행 자신의 col1 값(Asia/Seoul JST 표기)이 출력됨.
   5-2) 불확실성 없애고,  명시적으로 보장하기 위함입니다.
  - sql/_27_banana_qa/issue_5765_timezone_support/_01_table_operations/_04_select/cases/_09_view_dt.sql
    as - is : select distinct newt.col1 from (select id,col1 from v1 order by id) newt order by 1;
    to - be : select v1.col1 from v1 where v1.id = (select min(v2.id) from v1 v2 where v2.col1 = v1.col1) order by 1;
    as - is : select unique newt.col1, newt.col2 from (select id,col1,col2 from tz_test order by id) newt  order by 1;
    to - be : select tz_test.col1, tz_test.col2 from tz_test where tz_test.id = (select min(t2.id) from tz_test t2 where t2.col1 = tz_test.col1 and t2.col2 = tz_test.col2) order by 1;

 - sql/_27_banana_qa/issue_5765_timezone_support/_01_table_operations/_04_select/cases/_09_view_ts.sql
    as - is : select distinct tv2.col1 from (select id,col1 from v1 order by 1) tv2 order by 1;
    to - be : select v1.col1 from v1 where v1.id = (select min(tv2.id) from v1 tv2 where tv2.col1 = v1.col1) order by 1;
    as - is : select unique tv2.col1, tv2.col2 from (select id,col1,col2 from tz_test order by id) tv2 order by 1;
    to - be : select tz_test.col1, tz_test.col2 from tz_test where tz_test.id = (select min(t2.id) from tz_test t2 where t2.col1 = tz_test.col1 and t2.col2 = tz_test.col2) order by 1;

P.S) 실제 수행한 쿼리문 데이터 : select all * from v1 order by id;
id    col1                                                               col2
1     1933-12-10 15:30:00.999 Asia/Seoul JST     1933-12-10 15:30:00.999 Asia/Seoul JST
2     1933-12-10 15:30:30.999 +09:00                 1933-12-10 15:30:00.999 Asia/Seoul JST
3     1933-12-10 03:00:00.999 -03:30                  1933-12-10 15:30:00.999 Asia/Seoul JST
4     1933-12-10 15:30:00.999 Asia/Tokyo JST     1933-12-10 15:30:00.999 Asia/Seoul JST
5     1933-12-10 08:30:00.999 Europe/Bucharest EET     1933-12-10 15:30:00.999 Asia/Seoul JST
6     1891-07-10 02:00:00.999 Europe/Bucharest LMT     1891-07-10 08:43:28.999 Asia/Seoul LMT
7     1891-07-10 03:00:00.999 Europe/Bucharest LMT     1891-07-10 09:43:28.999 Asia/Seoul LMT
8     1891-07-10 02:00:00.999 +02:00                  1891-07-10 08:27:52.999 Asia/Seoul LMT