### PR TITLE
[CBRD-26976] Add missing readrows field to cbrd_26522 GROUPBY trace answer

### DIFF
--- a/sql/_36_guava/cbrd_26522/answers/cbrd_26522.answer
+++ b/sql/_36_guava/cbrd_26522/answers/cbrd_26522.answer
@@ -490,7 +490,7 @@ Trace Statistics:
     SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
          (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
       SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    GROUPBY (time: ?, hash: partial, sort: true, page: ?, ioread: ?, rows: ?)
+    GROUPBY (time: ?, hash: partial, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================
@@ -516,7 +516,7 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
-    GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
+    GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
      
 
 ===================================================


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26976

### Problem

`sql/_36_guava/cbrd_26522/cases/cbrd_26522.sql` fails on `develop` for every engine PR right now.

CUBRID/cubrid#7365 (merged 2026-08-06) added the `readrows` field to the GROUPBY trace line:

```
-    GROUPBY (time: ?, hash: partial, sort: true, page: ?, ioread: ?, rows: ?)
+    GROUPBY (time: ?, hash: partial, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
```

Its paired TC PR (#2981) updated every affected trace answer except `sql/_36_guava/cbrd_26522`, which was added later (#3095, 2026-07-29) and therefore was not in that patch set.

### Evidence

- CUBRID/cubrid#7619 (unrelated PR, base develop): test_sql fails with exactly this diff.
- CUBRID/cubrid#7625: same case fails with the same diff.

### Change

Answer updated to the current trace output (2 lines). Verified locally with CTP `sql`: the case passes after the update.