### PR TITLE
[CBRD-26866] update 6 answers

### DIFF
--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_constant.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_constant.answer
@@ -467,7 +467,7 @@ PRAGMA
 
 ===================================================
 Error:-1360
-Stored procedure compile error: mismatched input 'CONSTANT'
+Stored procedure compile error: mismatched input 'PRAGMA'
 
 ===================================================
 'RAISE'    

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_exception.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_exception.answer
@@ -478,7 +478,7 @@ PRAGMA
 
 ===================================================
 Error:-1360
-Stored procedure compile error: mismatched input 'EXCEPTION'
+Stored procedure compile error: mismatched input 'PRAGMA'
 
 ===================================================
 'RAISE'    

--- a/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_variable.answer
+++ b/sql/_05_plcsql/_01_testspec/_01_basic_structure/_01_create_procedure/_07_writing_rule/answers/01_01_07-08_bug_error_reserved_word_variable.answer
@@ -466,7 +466,7 @@ PRAGMA
 
 ===================================================
 Error:-1360
-Stored procedure compile error: mismatched input 'varchar'
+Stored procedure compile error: mismatched input 'PRAGMA'
 
 ===================================================
 'RAISE'    

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_05_autonomous_transaction/_01_basic/answers/02_05_01-02_error_in_local_proc.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_05_autonomous_transaction/_01_basic/answers/02_05_01-02_error_in_local_proc.answer
@@ -1,6 +1,6 @@
 ===================================================
 Error:-1360
-Stored procedure compile error: AUTONOMOUS_TRANSACTION can only be declared at the top level
+Stored procedure compile error: mismatched input 'pragma'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_05_autonomous_transaction/_01_basic/answers/02_05_01-03_error_in_block.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_05_autonomous_transaction/_01_basic/answers/02_05_01-03_error_in_block.answer
@@ -1,6 +1,6 @@
 ===================================================
 Error:-1360
-Stored procedure compile error: AUTONOMOUS_TRANSACTION can only be declared at the top level
+Stored procedure compile error: mismatched input 'pragma'
 
 ===================================================
 count(*)    

--- a/sql/_05_plcsql/_01_testspec/_02_declaration/_05_autonomous_transaction/_01_basic/answers/02_05_01-04_error_typo.answer
+++ b/sql/_05_plcsql/_01_testspec/_02_declaration/_05_autonomous_transaction/_01_basic/answers/02_05_01-04_error_typo.answer
@@ -4,5 +4,5 @@ Stored procedure compile error: no viable alternative at input 'PRAGMAA AUTONOMO
 
 ===================================================
 Error:-1360
-Stored procedure compile error: mismatched input 'AUTONOMOUS_TRANSACTIONS'
+Stored procedure compile error: extraneous input 'PRAGMA'
 


### PR DESCRIPTION
문법 체크만을 수행하는 함수를 추가하는 과정에서
pragma autonomous_transaction; 구문이 문법 에러를 내도록 문법을 수정해서 
답지 6건이 바뀌었습니다. 
develop 브랜치에서 검토하셨던 아래 PR과 유사합니다. 
https://github.com/CUBRID/cubrid-testcases/pull/3100