### PR TITLE
[CBRD-27169] [Backport-11.3.6] Transitive propagation missed for ON clause terms

### DIFF
--- a/sql/_13_issues/_23_1h/answers/cbrd_24906_3.answer
+++ b/sql/_13_issues/_23_1h/answers/cbrd_24906_3.answer
@@ -25,17 +25,17 @@ Query Plan:
     TABLE SCAN (a)
     INDEX SCAN (b.pk_tbl_b_id) (key range: a.id=b.id)
 
-  rewritten query: select a.id, b.com from [dba.tbl_a] a, [dba.tbl_b] b where b.com= ?:?  and b.com= ?:?  and a.id=b.id
+  rewritten query: select a.id, b.com from [dba.tbl_a] a, [dba.tbl_b] b where a.id=b.id and b.com= ?:?  and b.com= ?:? 
 
   NESTED LOOPS (inner join)
     TABLE SCAN (a)
     INDEX SCAN (b.pk_tbl_b_id) (key range: a.id=b.id)
 
-  rewritten query: select a.id, b.com from [dba.tbl_a] a, [dba.tbl_b] b where b.com= ?:?  and b.com= ?:?  and a.id=b.id
+  rewritten query: select a.id, b.com from [dba.tbl_a] a, [dba.tbl_b] b where a.id=b.id and b.com= ?:?  and b.com= ?:? 
 
   TABLE SCAN (t)
 
-  rewritten query: select t.id, t.com from (select a.id, b.com from [dba.tbl_a] a, [dba.tbl_b] b where b.com= ?:?  and b.com= ?:?  and a.id=b.id union all select a.id, b.com from [dba.tbl_a] a, [dba.tbl_b] b where b.com= ?:?  and b.com= ?:?  and a.id=b.id) t (id, com)
+  rewritten query: select t.id, t.com from (select a.id, b.com from [dba.tbl_a] a, [dba.tbl_b] b where a.id=b.id and b.com= ?:?  and b.com= ?:?  union all select a.id, b.com from [dba.tbl_a] a, [dba.tbl_b] b where a.id=b.id and b.com= ?:?  and b.com= ?:? ) t (id, com)
 
 
 Trace Statistics:
@@ -62,17 +62,17 @@ Query Plan:
     TABLE SCAN (a)
     INDEX SCAN (b.pk_tbl_b_id) (key range: a.id=b.id)
 
-  rewritten query: select a.id, b.com from [dba.tbl_a] a, [dba.tbl_b] b where b.com= ?:?  and b.com= ?:?  and a.id=b.id
+  rewritten query: select a.id, b.com from [dba.tbl_a] a, [dba.tbl_b] b where a.id=b.id and b.com= ?:?  and b.com= ?:? 
 
   NESTED LOOPS (inner join)
     TABLE SCAN (a)
     INDEX SCAN (b.pk_tbl_b_id) (key range: a.id=b.id)
 
-  rewritten query: select a.id, b.com from [dba.tbl_a] a, [dba.tbl_b] b where b.com= ?:?  and b.com= ?:?  and a.id=b.id
+  rewritten query: select a.id, b.com from [dba.tbl_a] a, [dba.tbl_b] b where a.id=b.id and b.com= ?:?  and b.com= ?:? 
 
   TABLE SCAN (t)
 
-  rewritten query: select t.id, t.com from (select a.id, b.com from [dba.tbl_a] a, [dba.tbl_b] b where b.com= ?:?  and b.com= ?:?  and a.id=b.id union all select a.id, b.com from [dba.tbl_a] a, [dba.tbl_b] b where b.com= ?:?  and b.com= ?:?  and a.id=b.id) t (id, com)
+  rewritten query: select t.id, t.com from (select a.id, b.com from [dba.tbl_a] a, [dba.tbl_b] b where a.id=b.id and b.com= ?:?  and b.com= ?:?  union all select a.id, b.com from [dba.tbl_a] a, [dba.tbl_b] b where a.id=b.id and b.com= ?:?  and b.com= ?:? ) t (id, com)
 
 
 Trace Statistics:


### PR DESCRIPTION
Backport 수행입니다.
참고 : https://github.com/CUBRID/cubrid-testcases/pull/3198

http://jira.cubrid.org/browse/CBRD-27169

### Purpose

ANSI JOIN의 ON 절에 작성한 상수 조건이 조인 조건으로 이행되지 않습니다.
원인이 다른 두 가지 경우가 있습니다.

1. 상수 조건과 조인 조건을 서로 다른 ON 절에 작성한 경우.
2. 인라인뷰 내부 ON 절에 작성하고, 바깥 쿼리에 조건절이 있는 경우.

### Implementation

조건절 순서만 바뀌었고, 실행계획과 결과는 동일합니다.
ON 절에 위치한 조인 조건이 이행 검사 전에 WHERE 로 이동하게 되어, 상수 조건이 뒤쪽에 위치합니다. 

[sql/_13_issues/_23_1h/cases/cbrd_24906_3.sql](https://github.com/CUBRID/cubrid-testcases/blob/develop/sql/_13_issues/_23_1h/cases/cbrd_24906_3.sql) 의 첫 번째 SELECT 문을 예로 들겠습니다.

**[before]**  `where b.com= ?:?  and b.com= ?:?  and a.id=b.id`
**[after]**   `where a.id=b.id and b.com= ?:?  and b.com= ?:?`

조인 컬럼(`a.id`, `b.id`)에 상수 조건이 없어 이행으로 생성된 조건은 없습니다. `b.com= ?:?` 두 개는 원 쿼리의 `b.com='cubrid'` 와 바깥 `t.com='tibero'` 가 인라인뷰로 내려온 것(푸시다운)이며 before/after 동일합니다.

**조건절 순서가 다른 이유**
조건절 이행은 `WHERE` 절만 대상으로 하므로, `ON` 절 조건은 `WHERE`로 옮겨진 뒤에야 이행 대상이 됩니다.

조건절 이행 검사는 바깥 `SELECT` 처리 시 인라인뷰 안쪽까지 한꺼번에 하므로
인라인뷰 안쪽은 `ON` 절 조건이 빠진 상태로 이행 검사를 받았습니다. 또한 이행은 `SELECT` 문마다 한 번만 수행되어, 이후 `ON` 절 조건이 `WHERE` 로 합쳐져도 다시 시도되지 않았습니다.
그래서 `ON` 절에 이행 가능한 조건이 있어도 이행되지 않았습니다.

```sql
-- t2.b='X' 와 t2.b=t3.b 로부터 t3.b='X' 를 유도할 수 있으나 이행되지 않는 예
select ... from ( select ... from t1
  inner join t2 on t1.a = t2.a
  inner join t3 on t2.b = t3.b and t2.b = 'X' ) z where ... ;
```

따라서, 인라인뷰 안쪽 `SELECT` 의 처리 순서를 아래와 같이 변경했습니다.

**`[before]  이행 검사 →  푸시다운  →  ON 조건절을 WHERE 로 이동`**
**`[after]   ON 조건절을 WHERE 로 이동  →  이행 검사  →  푸시다운`**

두 번째 SELECT 문도 동일하게 조건절 순서만 변경되었습니다.