### PR TITLE
[CBRD-26959] Revise isolation answers for the UPDATE STATISTICS summary-line change

### DIFF
--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_01.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_01.answer
@@ -1,4 +1,5 @@
 | 6 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -32,6 +33,7 @@
 |    'c'    'CHAR(300)'    'YES'    ''    NULL    ''  
 |    'curdate'    'DATETIME'    'YES'    ''    NULL    ''  
 | 4 rows selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_02.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_02.answer
@@ -1,4 +1,5 @@
 | 6 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -24,6 +25,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_03.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_03.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_04.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_04.answer
@@ -1,4 +1,5 @@
 | 6 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -26,6 +27,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_06.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_06.answer
@@ -1,4 +1,5 @@
 | 6 rows affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -33,6 +34,7 @@
 |    'c'    'CHAR(10)'    'YES'    ''    NULL    ''  
 |    'd1'    'CHAR(4)'    'YES'    ''    'zzz '    ''  
 | 4 rows selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_07.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_07.answer
@@ -1,4 +1,5 @@
 | 6 rows affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -32,6 +33,7 @@
 |    'b'    'INTEGER'    'YES'    'MUL'    NULL    ''  
 |    'c'    'CHAR(10)'    'YES'    ''    NULL    ''  
 | 3 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_08.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_08.answer
@@ -1,4 +1,5 @@
 | 6 rows affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -8,6 +9,7 @@
 |    'd'    'CHAR(4)'    'YES'    ''    'zzz '    ''  
 | 4 rows selected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_10.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_10.answer
@@ -1,4 +1,5 @@
 | 6 rows affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -31,6 +32,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_11.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_11.answer
@@ -31,6 +31,7 @@
 |    'k'    'INTEGER'    'YES'    'MUL'    NULL    ''  
 |    'm'    'TIMESTAMP'    'YES'    ''    NULL    ''  
 | 4 rows selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_14.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/create_14.answer
@@ -31,6 +31,7 @@
 |    'k'    'INTEGER'    'YES'    'MUL'    NULL    ''  
 |    'm'    'TIMESTAMP'    'YES'    ''    NULL    'ON UPDATE CURRENT_TIMESTAMP'  
 | 4 rows selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/show_001.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/create_ddl/answer/show_001.answer
@@ -1,4 +1,5 @@
 | 6 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -14,6 +15,7 @@
 |    'public.t1'    0    'pk_t1_a'    1    'a'    'A'    6    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 | 3 rows selected
 | 1 row affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/create_multiple_index_01.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/create_multiple_index_01.answer
@@ -36,6 +36,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/create_multiple_index_02.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/create_multiple_index_02.answer
@@ -25,6 +25,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/delete_01.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/delete_01.answer
@@ -1,4 +1,5 @@
 | 3 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -23,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/delete_05_prepare.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/delete_05_prepare.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_01.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_01.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_01_rollback.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_01_rollback.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_02_rollback.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_02_rollback.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_03.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_03.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_04_rollback.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_04_rollback.answer
@@ -25,6 +25,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_05.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_05.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_delete_02.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_delete_02.answer
@@ -23,6 +23,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 1 column.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_delete_03.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/insert_delete_03.answer
@@ -23,6 +23,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 1 column.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/select_01.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/select_01.answer
@@ -42,6 +42,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/update_01.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/update_01.answer
@@ -41,6 +41,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/update_02.answer
+++ b/isolation/_01_ReadCommitted/cbrd_21506/unique_index/answer/update_02.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_22202_invisible_indexes/answer/invisible_index_02.answer
+++ b/isolation/_01_ReadCommitted/cbrd_22202_invisible_indexes/answer/invisible_index_02.answer
@@ -19,11 +19,13 @@
 |    5    'e '  
 |    6    'f '  
 | 6 rows selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
 |    'public.t1'    0    'i'    1    'b'    'A'    6    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'NO'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_22202_invisible_indexes/answer/invisible_index_05.answer
+++ b/isolation/_01_ReadCommitted/cbrd_22202_invisible_indexes/answer/invisible_index_05.answer
@@ -29,6 +29,7 @@
 |    5    'e '  
 |    6    'f '  
 | 6 rows selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/cbrd_22202_invisible_indexes/invisible_index_02.ctl
+++ b/isolation/_01_ReadCommitted/cbrd_22202_invisible_indexes/invisible_index_02.ctl
@@ -29,6 +29,7 @@ MC: wait until C2 ready;
 
 C1: update statistics on t1;
 C1: show index from t1;
+C1: COMMIT;
 MC: wait until C1 ready;
 
 C2: update statistics on t1;

--- a/isolation/_01_ReadCommitted/dml_ddl/answer/altertable_delete_04.answer
+++ b/isolation/_01_ReadCommitted/dml_ddl/answer/altertable_delete_04.answer
@@ -8,6 +8,7 @@
 |    1    'abc'    10  
 |    2    'efg'    11  
 | 2 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/dml_ddl/answer/altertable_delete_05.answer
+++ b/isolation/_01_ReadCommitted/dml_ddl/answer/altertable_delete_05.answer
@@ -9,6 +9,7 @@
 |    2    'efg'    11  
 |    3    'hijk'    12  
 | 3 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/dml_ddl/answer/altertable_insert_03.answer
+++ b/isolation/_01_ReadCommitted/dml_ddl/answer/altertable_insert_03.answer
@@ -1,5 +1,6 @@
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/dml_ddl/answer/altertable_insert_05.answer
+++ b/isolation/_01_ReadCommitted/dml_ddl/answer/altertable_insert_05.answer
@@ -1,5 +1,6 @@
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_01_ReadCommitted/issues/_15_1h/answer/bug_bts_17140.answer
+++ b/isolation/_01_ReadCommitted/issues/_15_1h/answer/bug_bts_17140.answer
@@ -8,6 +8,7 @@
 |    1    'abc'    10  
 |    2    'efg'    11  
 | 2 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -24,6 +25,7 @@
 |    1    'abc'    10  
 |    2    'efg'    11  
 | 2 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_02_RepeatableRead/dml_ddl/answer/altertable_delete_03.answer
+++ b/isolation/_02_RepeatableRead/dml_ddl/answer/altertable_delete_03.answer
@@ -1,6 +1,7 @@
 | 1 row affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 3 columns.
 | 1 row affected
 | =================   Q U E R Y   R E S U L T S   =================
 | 

--- a/isolation/_02_RepeatableRead/dml_ddl/answer/altertable_truncate_04.answer
+++ b/isolation/_02_RepeatableRead/dml_ddl/answer/altertable_truncate_04.answer
@@ -4,6 +4,7 @@
 | 
 |    1    'abc'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_02_RepeatableRead/index_column/common_index/basic_sql/answer/delete_select_04.answer
+++ b/isolation/_02_RepeatableRead/index_column/common_index/basic_sql/answer/delete_select_04.answer
@@ -18,6 +18,7 @@
 |    303    '3'  
 |    403    '3'  
 | 5 rows selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -42,6 +43,7 @@
 | 
 |    495  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_05_ReadCommitted_RepeatableRead/index_column/common_index/basic_sql/answer/delete_select_01_ext.answer
+++ b/isolation/_05_ReadCommitted_RepeatableRead/index_column/common_index/basic_sql/answer/delete_select_01_ext.answer
@@ -1,4 +1,5 @@
 | 500 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | 3 rows affected
 | 32 rows affected
 | 14 rows affected
@@ -7,6 +8,7 @@
 | 
 |    451  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_05_ReadCommitted_RepeatableRead/index_column/common_index/basic_sql/answer/delete_select_02_ext.answer
+++ b/isolation/_05_ReadCommitted_RepeatableRead/index_column/common_index/basic_sql/answer/delete_select_02_ext.answer
@@ -24,6 +24,7 @@
 |    10    '10'  
 |    10    'run'  
 | 6 rows selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_05_ReadCommitted_RepeatableRead/index_column/common_index/basic_sql/answer/delete_select_04.answer
+++ b/isolation/_05_ReadCommitted_RepeatableRead/index_column/common_index/basic_sql/answer/delete_select_04.answer
@@ -1,4 +1,5 @@
 | 500 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | 5 rows affected
 | =================   Q U E R Y   R E S U L T S   =================
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/_04_RepeatableRead_ReadCommitted/basic_sql/answer/delete_update_07_3.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/_04_RepeatableRead_ReadCommitted/basic_sql/answer/delete_update_07_3.answer
@@ -22,6 +22,7 @@
 | 3 rows selected
 | ERROR RETURNED: Operation would have caused one or more unique constraint violations. INDEX u_t1_id(B+tree: ?) ON CLASS public.t1(CLASS_OID: ?). key: ?(OID: ?). 
 |    on statement number: 3
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_01.answer
@@ -1,4 +1,5 @@
 | 6 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -32,6 +33,7 @@
 |    'c'    'CHAR(300)'    'YES'    ''    NULL    ''  
 |    'curdate'    'DATETIME'    'YES'    ''    NULL    ''  
 | 4 rows selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_02.answer
@@ -1,4 +1,5 @@
 | 6 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -24,6 +25,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_03.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_03.answer
@@ -1,4 +1,5 @@
 | 6 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -24,6 +25,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_04.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_04.answer
@@ -1,4 +1,5 @@
 | 6 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -26,6 +27,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_06.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_06.answer
@@ -1,4 +1,5 @@
 | 6 rows affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -33,6 +34,7 @@
 |    'c'    'CHAR(10)'    'YES'    ''    NULL    ''  
 |    'd1'    'CHAR(4)'    'YES'    ''    'zzz '    ''  
 | 4 rows selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_07.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_07.answer
@@ -1,4 +1,5 @@
 | 6 rows affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -32,6 +33,7 @@
 |    'b'    'INTEGER'    'YES'    'MUL'    NULL    ''  
 |    'c'    'CHAR(10)'    'YES'    ''    NULL    ''  
 | 3 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_08.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_08.answer
@@ -1,4 +1,5 @@
 | 6 rows affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -8,6 +9,7 @@
 |    'd'    'CHAR(4)'    'YES'    ''    'zzz '    ''  
 | 4 rows selected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_10.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_10.answer
@@ -1,4 +1,5 @@
 | 6 rows affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -31,6 +32,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_11.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_11.answer
@@ -31,6 +31,7 @@
 |    'k'    'INTEGER'    'YES'    'MUL'    NULL    ''  
 |    'm'    'TIMESTAMP'    'YES'    ''    NULL    ''  
 | 4 rows selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_14.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/create_14.answer
@@ -31,6 +31,7 @@
 |    'k'    'INTEGER'    'YES'    'MUL'    NULL    ''  
 |    'm'    'TIMESTAMP'    'YES'    ''    NULL    'ON UPDATE CURRENT_TIMESTAMP'  
 | 4 rows selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/show_001.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/create_ddl/answer/show_001.answer
@@ -1,4 +1,5 @@
 | 6 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -14,6 +15,7 @@
 |    'public.t1'    0    'pk_t1_a'    1    'a'    'A'    6    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 | 3 rows selected
 | 1 row affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/delete_online_index_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/delete_online_index_01.answer
@@ -1,4 +1,5 @@
 | 100 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -6,6 +7,7 @@
 |    'col'    'VARCHAR(100)'    'YES'    ''    NULL    ''  
 | 2 rows selected
 | 10 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/delete_online_index_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/delete_online_index_02.answer
@@ -1,4 +1,5 @@
 | 100 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -6,6 +7,7 @@
 |    'col'    'CHAR(2048)'    'YES'    ''    NULL    ''  
 | 2 rows selected
 | 10 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/delete_online_index_03.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/delete_online_index_03.answer
@@ -6,6 +6,7 @@
 |    'col'    'CHAR(2048)'    'YES'    ''    NULL    ''  
 | 2 rows selected
 | 554 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/delete_online_index_04.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/delete_online_index_04.answer
@@ -6,6 +6,7 @@
 |    'col'    'CHAR(2048)'    'YES'    ''    NULL    ''  
 | 2 rows selected
 | 554 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_odku_online_index_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_odku_online_index_01.answer
@@ -1,4 +1,5 @@
 | 10 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -7,6 +8,7 @@
 | 2 rows selected
 | 1 row affected
 | 2 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_odku_online_index_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_odku_online_index_02.answer
@@ -9,6 +9,7 @@
 |    'd'    'DATETIME'    'YES'    ''    'CURRENT_DATETIME'    ''  
 | 5 rows selected
 | 2 rows affected
+| Statistics updated successfully: 1 table, 5 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_odku_online_index_03.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_odku_online_index_03.answer
@@ -12,6 +12,7 @@
 | 1 row affected
 | ERROR RETURNED: Operation would have caused one or more unique constraint violations. INDEX idx1(B+tree: ?) ON CLASS public.t(CLASS_OID: ?). key: *UNKNOWN-KEY*. 
 |    on statement number: 3
+| Statistics updated successfully: 1 table, 5 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_odku_online_index_04.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_odku_online_index_04.answer
@@ -1,4 +1,5 @@
 | 100 rows affected
+| Statistics updated successfully: 1 table, 5 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -10,6 +11,7 @@
 | 5 rows selected
 | 2 rows affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 5 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_filter_index_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_filter_index_01.answer
@@ -1,11 +1,13 @@
 | 100 rows affected
 | 100 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
 |    'public.t'    1    'idx1'    1    'col2'    'D'    4    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t'    0    'pk_t_id'    1    'id'    'A'    100    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 | 2 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_filter_index_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_filter_index_02.answer
@@ -1,11 +1,13 @@
 | 4 rows affected
 | 4 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
 |    'public.t'    1    'idx1'    1    'col1'    'A'    4    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t'    0    'pk_t_id'    1    'id'    'A'    4    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 | 2 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_filter_index_04.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_filter_index_04.answer
@@ -1,5 +1,6 @@
 | 100 rows affected
 | 100 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -7,6 +8,7 @@
 |    'public.t'    1    'idx1'    2    'sale'    'A'    10    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t'    0    'pk_t_id'    1    'id'    'A'    100    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 | 3 rows selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_fliter_index_03.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_fliter_index_03.answer
@@ -1,5 +1,6 @@
 | 100 rows affected
 | 100 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -7,6 +8,7 @@
 |    'public.t'    1    'idx1'    2    'col2'    'D'    0    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t'    0    'pk_t_id'    1    'id'    'A'    100    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 | 3 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_function_index_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_function_index_01.answer
@@ -1,5 +1,6 @@
 | 100 rows affected
 | 100 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -8,6 +9,7 @@
 |    'public.t'    1    'idx1'    3    'col2'    'D'    100    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t'    0    'pk_t_id'    1    'id'    'A'    100    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 | 4 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_function_index_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_function_index_02.answer
@@ -1,5 +1,6 @@
 | 100 rows affected
 | 100 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -7,6 +8,7 @@
 |    'public.t'    1    'idx1'    2    NULL    'A'    100    NULL    NULL    'YES'    'BTREE'    ' substr([public.t].[col3], 1, 2)'    NULL    'YES'  
 |    'public.t'    0    'pk_t_id'    1    'id'    'A'    100    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 | 3 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_function_index_03.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_function_index_03.answer
@@ -1,5 +1,6 @@
 | 100 rows affected
 | 100 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -7,6 +8,7 @@
 |    'public.t'    1    'idx1'    2    'col2'    'D'    100    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t'    0    'pk_t_id'    1    'id'    'A'    100    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 | 3 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_function_index_04.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_function_index_04.answer
@@ -1,11 +1,13 @@
 | 100 rows affected
 | 100 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
 |    'public.t'    1    'idx1'    1    NULL    'A'    100    NULL    NULL    'YES'    'BTREE'    ' power( cast([public.t].[id] as double), [public.t].[sale])'    NULL    'YES'  
 |    'public.t'    0    'pk_t_id'    1    'id'    'A'    100    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 | 2 rows selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_index_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_index_01.answer
@@ -1,5 +1,6 @@
 | 100 rows affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -7,6 +8,7 @@
 |    'public.t'    1    'idx1'    2    'col'    'D'    101    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t'    0    'pk_t_id'    1    'id'    'A'    101    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 | 3 rows selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_index_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/insert_online_index_02.answer
@@ -1,5 +1,6 @@
 | 100 rows affected
 | 100 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -7,6 +8,7 @@
 |    'public.t'    1    'idx1'    2    'col'    'D'    100    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t'    0    'pk_t_id'    1    'id'    'A'    100    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 | 3 rows selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_delete_online_index_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_delete_online_index_01.answer
@@ -1,4 +1,5 @@
 | 100 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -6,6 +7,7 @@
 |    'col'    'VARCHAR(100)'    'YES'    ''    NULL    ''  
 | 2 rows selected
 | 10 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_delete_online_index_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_delete_online_index_02.answer
@@ -6,6 +6,7 @@
 |    'col'    'CHAR(2048)'    'YES'    ''    NULL    ''  
 | 2 rows selected
 | 2 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_delete_online_index_03.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_delete_online_index_03.answer
@@ -1,4 +1,5 @@
 | 1000 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -6,6 +7,7 @@
 |    'col'    'CHAR(2048)'    'YES'    ''    NULL    ''  
 | 2 rows selected
 | 554 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_delete_online_index_04.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_delete_online_index_04.answer
@@ -1,4 +1,5 @@
 | 1000 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -6,6 +7,7 @@
 |    'col'    'CHAR(2048)'    'YES'    ''    NULL    ''  
 | 2 rows selected
 | 554 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_select_online_index_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_select_online_index_01.answer
@@ -2,6 +2,7 @@
 | 10 rows affected
 | 10 rows affected
 | 10 rows affected
+| Statistics updated successfully: 1 table, 9 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -16,6 +17,7 @@
 |    'col7'    'VARCHAR(50)'    'YES'    ''    NULL    ''  
 | 9 rows selected
 | 10 rows affected
+| Statistics updated successfully: 1 table, 9 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_select_online_index_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_select_online_index_02.answer
@@ -3,6 +3,7 @@
 | 10 rows affected
 | 10 rows affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -16,6 +17,7 @@
 |    9.756098e-01    7.500000e-01    40    3    '91'    '96'    '93'    '99'    '99'    5    9.750000e-01    0.000000e+00    1    1    0.000000e+00    NULL    0.000000e+00    NULL  
 |    9.512195e-01    5.000000e-01    39    2    '91'    '93'    '91'    '96'    '99'    5    9.500000e-01    0.000000e+00    1    1    0.000000e+00    NULL    0.000000e+00    NULL  
 | 3 rows selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_01.answer
@@ -9,6 +9,7 @@
 | 3 rows selected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_02.answer
@@ -2,12 +2,14 @@
 | 8 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
 |    'public.t2'    1    'fk_t2_stu_id'    1    'stu_id'    'A'    5    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx_t2_3'    1    NULL    'A'    5    NULL    NULL    'YES'    'BTREE'    ' sqrt( cast([public.t2].[stu_id] as double))'    NULL    'YES'  
 | 2 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_03.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_03.answer
@@ -2,12 +2,14 @@
 | 7 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
 |    'public.t2'    1    'fk_t2_stu_id'    1    'stu_id'    'A'    5    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx_t2_3'    1    NULL    'A'    5    NULL    NULL    'YES'    'BTREE'    ' abs([public.t2].[stu_id])'    NULL    'YES'  
 | 2 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_04.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_04.answer
@@ -2,6 +2,7 @@
 | 7 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_05.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_05.answer
@@ -2,6 +2,7 @@
 | 7 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 8 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_06.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_06.answer
@@ -2,6 +2,7 @@
 | 7 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_07.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_07.answer
@@ -2,6 +2,7 @@
 | 7 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_08.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_08.answer
@@ -2,6 +2,7 @@
 | 7 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_09.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_09.answer
@@ -1,7 +1,9 @@
 | 4 rows affected
 | 7 rows affected
+| Statistics updated successfully: 1 table, 8 columns.
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 8 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_10.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_10.answer
@@ -2,6 +2,7 @@
 | 7 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 8 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_11.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_11.answer
@@ -1,7 +1,9 @@
 | 4 rows affected
 | 7 rows affected
+| Statistics updated successfully: 1 table, 8 columns.
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 8 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_20.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_20.answer
@@ -2,6 +2,7 @@
 | 7 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 8 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_30.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_30.answer
@@ -2,6 +2,7 @@
 | 7 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 8 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_60.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/p_update_online_function_index_60.answer
@@ -14,6 +14,7 @@
 | 8 rows selected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 8 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/select_online_index_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/select_online_index_01.answer
@@ -2,6 +2,7 @@
 | 10 rows affected
 | 10 rows affected
 | 10 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -17,6 +18,7 @@
 |    '99'    '91'    9.475000e+01    '99,96,93,91'    9.450000e+01    4    3.790000e+02  
 |    '109'    '101'    1.047500e+02    '109,106,103,101'    1.045000e+02    4    4.190000e+02  
 | 5 rows selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/select_online_index_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/select_online_index_02.answer
@@ -3,6 +3,7 @@
 | 10 rows affected
 | 10 rows affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -16,6 +17,7 @@
 |    9.756098e-01    1.000000e+00    40    4    '101'    '109'    '106'    NULL    '103'    5    9.750000e-01    0.000000e+00    1    1    0.000000e+00    NULL    0.000000e+00    NULL  
 |    9.512195e-01    7.500000e-01    39    3    '101'    '106'    '103'    '109'    '103'    5    9.500000e-01    0.000000e+00    1    1    0.000000e+00    NULL    0.000000e+00    NULL  
 | 3 rows selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/select_online_index_03.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/select_online_index_03.answer
@@ -2,6 +2,7 @@
 | 10 rows affected
 | 10 rows affected
 | 10 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -22,6 +23,7 @@
 |    time '10:30:20 AM'    datetime '10:30:20.000 AM 12/25/2008'    timestamp '10:30:20 AM 12/25/2008'    date '12/25/2008'  
 |    time '10:30:20 AM'    datetime '10:30:20.000 AM 12/25/2008'    timestamp '10:30:20 AM 12/25/2008'    date '12/25/2008'  
 | 10 rows selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/select_online_index_04.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/select_online_index_04.answer
@@ -1,4 +1,5 @@
 | 100 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -6,6 +7,7 @@
 |    'col'    'VARCHAR(100)'    'YES'    ''    NULL    ''  
 | 2 rows selected
 | 10 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/select_online_index_05.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/select_online_index_05.answer
@@ -2,6 +2,7 @@
 | 10 rows affected
 | 10 rows affected
 | 10 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -17,6 +18,7 @@
 |    9    9    9  
 |    10    10    10  
 | 5 rows selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/select_online_index_06.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/select_online_index_06.answer
@@ -2,6 +2,7 @@
 | 10 rows affected
 | 10 rows affected
 | 10 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -9,6 +10,7 @@
 |    'col'    'CHAR(1000)'    'YES'    ''    NULL    ''  
 | 2 rows selected
 | 5 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/select_online_index_07.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/select_online_index_07.answer
@@ -2,6 +2,7 @@
 | 10 rows affected
 | 10 rows affected
 | 10 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -9,6 +10,7 @@
 |    'col'    'CHAR(1000)'    'YES'    ''    NULL    ''  
 | 2 rows selected
 | 5 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/select_online_index_08.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/select_online_index_08.answer
@@ -2,6 +2,7 @@
 | 5 rows affected
 | 5 rows affected
 | 5 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -17,6 +18,7 @@
 |    'NDE='    '41'    '41 '    '41 '    '41'    '   '    '14'    '41 '    '41'    ')'  
 |    'NTE='    '51'    '51 '    '51 '    '51'    '   '    '15'    '51 '    '51'    '3'  
 | 5 rows selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/select_online_index_09.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/select_online_index_09.answer
@@ -2,6 +2,7 @@
 | 5 rows affected
 | 5 rows affected
 | 5 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -17,6 +18,7 @@
 |    'NDE='    '41'    '41 '    '41 '    '41'    '   '    '14'    '41 '    '41'    ')'  
 |    'NTE='    '51'    '51 '    '51 '    '51'    '   '    '15'    '51 '    '51'    '3'  
 | 5 rows selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_filter_index_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_filter_index_01.answer
@@ -2,6 +2,7 @@
 | 8 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -10,6 +11,7 @@
 |    'public.t2'    1    'idx_t2_3'    2    'stu_id'    'A'    2    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx_t2_3'    3    'class_id'    'A'    2    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 | 4 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_filter_index_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_filter_index_02.answer
@@ -1,5 +1,7 @@
 | 8 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | 1 row affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_filter_index_03.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_filter_index_03.answer
@@ -2,6 +2,7 @@
 | 8 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_filter_index_04.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_filter_index_04.answer
@@ -2,6 +2,7 @@
 | 7 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -9,6 +10,7 @@
 |    'public.t2'    1    'idx_t2_3'    1    'class_id'    'A'    5    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx_t2_3'    2    'stu_id'    'A'    5    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 | 3 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_filter_index_05.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_filter_index_05.answer
@@ -2,6 +2,7 @@
 | 8 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -10,6 +11,7 @@
 |    'public.t2'    1    'idx_t2_3'    2    'stu_id'    'D'    3    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx_t2_3'    3    'class_id'    'D'    3    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 | 4 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_filter_index_06.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_filter_index_06.answer
@@ -2,6 +2,7 @@
 | 8 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -10,6 +11,7 @@
 |    'public.t2'    1    'idx_t2_3'    2    'stu_id'    'A'    1    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx_t2_3'    3    'class_id'    'A'    1    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 | 4 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -19,6 +21,7 @@
 |    'public.t2'    1    'idx_t2_3'    3    'class_id'    'A'    1    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    0    'pk_t2_class_id'    1    'class_id'    'A'    8    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 | 5 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_filter_index_07.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_filter_index_07.answer
@@ -2,6 +2,7 @@
 | 8 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -10,6 +11,7 @@
 |    'public.t2'    1    'idx_t2_3'    2    'stu_id'    'A'    1    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx_t2_3'    3    'class_id'    'A'    1    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 | 4 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -21,6 +23,7 @@
 |    'public.t2'    0    'u_t2_class_name_stu_id_class_id_d'    2    'stu_id'    'A'    8    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    0    'u_t2_class_name_stu_id_class_id_d'    3    'class_id'    'D'    8    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 | 7 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_filter_index_08.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_filter_index_08.answer
@@ -2,6 +2,7 @@
 | 8 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -10,6 +11,7 @@
 |    'public.t2'    1    'idx_t2_3'    2    'stu_id'    'D'    1    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx_t2_3'    3    'class_id'    'A'    1    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 | 4 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -21,6 +23,7 @@
 |    'public.t2'    0    'pk_t2_class_name_stu_id_class_id_d'    2    'stu_id'    'A'    8    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    0    'pk_t2_class_name_stu_id_class_id_d'    3    'class_id'    'D'    8    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 | 7 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_01.answer
@@ -2,12 +2,14 @@
 | 6 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
 |    'public.t2'    1    'fk_t2_stu_id'    1    'stu_id'    'A'    4    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx_t2_3'    1    NULL    'A'    4    NULL    NULL    'YES'    'BTREE'    ' sqrt( cast([public.t2].[stu_id] as double))'    NULL    'YES'  
 | 2 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_02.answer
@@ -2,6 +2,8 @@
 | 8 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 2 columns.
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_03.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_03.answer
@@ -2,6 +2,7 @@
 | 7 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -10,6 +11,7 @@
 |    'public.t2'    1    'idx_t2_3'    2    'class_name'    'A'    7    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx_t2_3'    3    'class_id'    'A'    7    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 | 4 rows selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_04.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_04.answer
@@ -14,42 +14,50 @@
 |    on statement number: 3
 | ERROR RETURNED: Your transaction has been unilaterally aborted by the system. 
 |    on statement number: 3
+| Statistics updated successfully: 1 table, 4 columns.
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
 |    'public.t2'    1    'fk_t2_stu_id'    1    'stu_id'    'A'    5    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx_t2_3'    1    NULL    'A'    1    NULL    NULL    'YES'    'BTREE'    ' dayofmonth([public.t2].[birty_date])'    NULL    'YES'  
 | 2 rows selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
 |    'public.t2'    1    'fk_t2_stu_id'    1    'stu_id'    'A'    5    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx_t2_3'    1    NULL    'A'    1    NULL    NULL    'YES'    'BTREE'    ' dayofmonth([public.t2].[birty_date])'    NULL    'YES'  
 | 2 rows selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
 |    'public.t2'    1    'fk_t2_stu_id'    1    'stu_id'    'A'    5    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx_t2_3'    1    NULL    'A'    1    NULL    NULL    'YES'    'BTREE'    ' dayofmonth([public.t2].[birty_date])'    NULL    'YES'  
 | 2 rows selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
 |    'public.t2'    1    'fk_t2_stu_id'    1    'stu_id'    'A'    5    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx_t2_3'    1    NULL    'A'    1    NULL    NULL    'YES'    'BTREE'    ' dayofmonth([public.t2].[birty_date])'    NULL    'YES'  
 | 2 rows selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
 |    'public.t2'    1    'fk_t2_stu_id'    1    'stu_id'    'A'    5    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx_t2_3'    1    NULL    'A'    1    NULL    NULL    'YES'    'BTREE'    ' dayofmonth([public.t2].[birty_date])'    NULL    'YES'  
 | 2 rows selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
 |    'public.t2'    1    'fk_t2_stu_id'    1    'stu_id'    'A'    5    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx_t2_3'    1    NULL    'A'    1    NULL    NULL    'YES'    'BTREE'    ' dayofmonth([public.t2].[birty_date])'    NULL    'YES'  
 | 2 rows selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -78,12 +86,17 @@
 |    3    'history'    -16    timestamp '12:00:00 AM 01/01/2000'  
 |    4    'art'    -8    timestamp '12:00:00 AM 01/01/2000'  
 | 7 rows selected
-| ERROR RETURNED: Syntax: In line 1, column 1 before ' from t2 where ADDTIME(birty_date, time'1:1:2')='2000-01-01 01...'
-| Syntax error: unexpected '*', expecting SELECT or VALUE or VALUES or '('  
-|    on statement number: 16
-| ERROR RETURNED: Syntax: In line 1, column 1 before '/ C1: select * from t2 where DAYOFWEEK(birty_date)=7 using ind...'
-| Syntax error: unexpected '*', expecting SELECT or VALUE or VALUES or '('  
-|    on statement number: 17
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    1    'math'    4    timestamp '12:00:00 AM 01/01/2000'  
+|    1    'math'    8    timestamp '12:00:00 AM 01/01/2000'  
+|    2    'english'    1    timestamp '12:00:00 AM 01/01/2000'  
+|    2    'english'    4    timestamp '12:00:00 AM 01/01/2000'  
+|    3    'history'    1    timestamp '12:00:00 AM 01/01/2000'  
+|    3    'history'    -16    timestamp '12:00:00 AM 01/01/2000'  
+|    4    'art'    -8    timestamp '12:00:00 AM 01/01/2000'  
+| 7 rows selected
 | ERROR RETURNED: Semantic: before '  using index idx3(+) ;'
 | Cannot coerce 2 to type date. select [public.t2].class_id, [public.t2].class_name, [public... 
 |    on statement number: 18
@@ -91,9 +104,17 @@
 | 
 | 
 | 0 row selected
-| ERROR RETURNED: Semantic: before ' ,'1999-12-31 00:00:00')=1 using index idx5(+) ;'
-| Attribute "birth_date" was not found. select [public.t2].class_id, [public.t2].class_name, [public... 
-|    on statement number: 20
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    1    'math'    4    timestamp '12:00:00 AM 01/01/2000'  
+|    1    'math'    8    timestamp '12:00:00 AM 01/01/2000'  
+|    2    'english'    1    timestamp '12:00:00 AM 01/01/2000'  
+|    2    'english'    4    timestamp '12:00:00 AM 01/01/2000'  
+|    3    'history'    1    timestamp '12:00:00 AM 01/01/2000'  
+|    3    'history'    -16    timestamp '12:00:00 AM 01/01/2000'  
+|    4    'art'    -8    timestamp '12:00:00 AM 01/01/2000'  
+| 7 rows selected
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_05.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_05.answer
@@ -2,12 +2,14 @@
 | 7 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
 |    'public.t2'    1    'fk_t2_stu_id'    1    'stu_id'    'A'    5    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx1'    1    NULL    'A'    1    NULL    NULL    'YES'    'BTREE'    ' date_add([public.t2].[birty_date], INTERVAL _iso88591''12:12'' collate iso88591_bin HOUR_MINUTE)'    NULL    'YES'  
 | 2 rows selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_06.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_06.answer
@@ -2,12 +2,14 @@
 | 7 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
 |    'public.t2'    1    'fk_t2_stu_id'    1    'stu_id'    'A'    5    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx1'    1    NULL    'A'    1    NULL    NULL    'YES'    'BTREE'    ' dayofweek([public.t2].[birty_date])'    NULL    'YES'  
 | 2 rows selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_07.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_07.answer
@@ -1,7 +1,9 @@
 | 4 rows affected
 | 7 rows affected
+| Statistics updated successfully: 1 table, 4 columns.
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_08.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_08.answer
@@ -3,6 +3,7 @@
 | 1 row affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_09.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_09.answer
@@ -3,6 +3,7 @@
 | 1 row affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_10.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_10.answer
@@ -2,12 +2,14 @@
 | 7 rows affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
 |    'public.t2'    1    'fk_t2_stu_id'    1    'stu_id'    'A'    5    NULL    NULL    'YES'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    1    'idx_t2_3'    1    NULL    'A'    1    NULL    NULL    'YES'    'BTREE'    ' date_sub([public.t2].[birth_date], INTERVAL 24 HOUR)'    NULL    'YES'  
 | 2 rows selected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_11.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_11.answer
@@ -3,6 +3,7 @@
 | 1 row affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -11,6 +12,7 @@
 | 2 rows selected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -20,6 +22,7 @@
 | 3 rows selected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -30,6 +33,7 @@
 | 4 rows selected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -41,6 +45,7 @@
 | 5 rows selected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -53,6 +58,7 @@
 | 6 rows selected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -66,6 +72,7 @@
 | 7 rows selected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_12.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_function_index_12.answer
@@ -3,6 +3,7 @@
 | 1 row affected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -11,6 +12,7 @@
 | 2 rows selected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -20,6 +22,7 @@
 | 3 rows selected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -30,6 +33,7 @@
 | 4 rows selected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -41,6 +45,7 @@
 | 5 rows selected
 | 1 row affected
 | 1 row affected
+| Statistics updated successfully: 1 table, 4 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_index_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_index_01.answer
@@ -2,6 +2,7 @@
 | 10 rows affected
 | 10 rows affected
 | 10 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -11,6 +12,7 @@
 | 3 rows selected
 | 1 row affected
 | 6 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_index_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_index_02.answer
@@ -2,8 +2,10 @@
 | 10 rows affected
 | 10 rows affected
 | 10 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | 1 row affected
 | 30 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -13,6 +15,7 @@
 |    'public.t2'    1    'idx_t2_col1_col2'    3    'id'    'D'    30    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    0    'pk_t2_id'    1    'id'    'A'    30    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 | 5 rows selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_index_03.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_online_index_03.answer
@@ -2,6 +2,7 @@
 | 10 rows affected
 | 10 rows affected
 | 10 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -11,6 +12,7 @@
 | 3 rows selected
 | 1 row affected
 | 6 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_view_online_index_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/answer/update_view_online_index_01.answer
@@ -2,8 +2,10 @@
 | 10 rows affected
 | 10 rows affected
 | 10 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | 1 row affected
 | 10 rows affected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -13,6 +15,7 @@
 |    'public.t2'    1    'idx_t2_col1_col2'    3    'id'    'D'    30    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 |    'public.t2'    0    'pk_t2_id'    1    'id'    'A'    30    NULL    NULL    'NO'    'BTREE'    NULL    NULL    'YES'  
 | 5 rows selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_04.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_04.ctl
@@ -72,7 +72,13 @@ C1: commit;
 MC: wait until C1 ready;
 
 MC: wait until C2 ready;
+C2: commit;
+MC: wait until C2 ready;
+
 C1: update statistics on t2;
+C1: commit;
+MC: wait until C1 ready;
+
 C2: update statistics on t2;
 C2: show indexes from t2;
 C2: commit;
@@ -111,11 +117,10 @@ C8: commit;
 MC: wait until C2 ready;
 C1: select /*+ recompile */ * from t2 where DAYOFMONTH(birty_date)=1 using index idx_t2_3(+)  ;
 C1: select /*+ recompile */ * from t2 where ADDDATE(birty_date, INTERVAL '12:12' HOUR_MINUTE)='2000-01-01 12:12:00' using index idx1(+)  ;
-/* C1: select /*+ recompile */ * from t2 where ADDTIME(birty_date, time'1:1:2')='2000-01-01 01:01:02' using index idx2(+)  ; */
 C1: select /*+ recompile */ * from t2 where DAYOFWEEK(birty_date)=7 using index idx2(+)  ;
 C1: select /*+ recompile */ * from t2 where ADD_MONTHS(birty_date,1)=2 using index idx3(+)  ;
 C1: select /*+ recompile */ * from t2 where DATE(birty_date)='2000-01-01' using index idx4(+)  ;
-C1: select /*+ recompile */ * from t2 where DATEDIFF(birth_date,'1999-12-31 00:00:00')=1 using index idx5(+)  ;
+C1: select /*+ recompile */ * from t2 where DATEDIFF(birty_date,'1999-12-31 00:00:00')=1 using index idx5(+)  ;
 C1: select /*+ recompile */ * from t2 where SUBDATE(birty_date,INTERVAL 24 HOUR)='1999-12-31 00:00:00' using index idx6(+)  ;
 C1: commit work;
 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_04.ctl
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/dml_online_index/update_online_function_index_04.ctl
@@ -117,6 +117,7 @@ C8: commit;
 MC: wait until C2 ready;
 C1: select /*+ recompile */ * from t2 where DAYOFMONTH(birty_date)=1 using index idx_t2_3(+)  ;
 C1: select /*+ recompile */ * from t2 where ADDDATE(birty_date, INTERVAL '12:12' HOUR_MINUTE)='2000-01-01 12:12:00' using index idx1(+)  ;
+/* C1: select from t2 where ADDTIME(birty_date, time'1:1:2')='2000-01-01 01:01:02' using index idx2(+)  ; */
 C1: select /*+ recompile */ * from t2 where DAYOFWEEK(birty_date)=7 using index idx2(+)  ;
 C1: select /*+ recompile */ * from t2 where ADD_MONTHS(birty_date,1)=2 using index idx3(+)  ;
 C1: select /*+ recompile */ * from t2 where DATE(birty_date)='2000-01-01' using index idx4(+)  ;

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/create_multiple_index_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/create_multiple_index_01.answer
@@ -36,6 +36,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/create_multiple_index_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/create_multiple_index_02.answer
@@ -25,6 +25,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/delete_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/delete_01.answer
@@ -1,4 +1,5 @@
 | 3 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -23,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/delete_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/delete_02.answer
@@ -22,6 +22,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 1 column.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/delete_05_prepare.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/delete_05_prepare.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/delete_05_prepare_rollback.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/delete_05_prepare_rollback.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_01.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_01_rollback.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_01_rollback.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_02.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_02_rollback.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_02_rollback.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_03.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_03.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_04.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_04.answer
@@ -25,6 +25,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_04_rollback.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_04_rollback.answer
@@ -25,6 +25,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_05.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_05.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_delete_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_delete_01.answer
@@ -23,6 +23,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 1 column.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_delete_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_delete_02.answer
@@ -23,6 +23,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 1 column.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_delete_03.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_delete_03.answer
@@ -23,6 +23,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 1 column.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_delete_04.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_delete_04.answer
@@ -23,6 +23,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 1 column.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_update_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_update_01.answer
@@ -23,6 +23,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 1 column.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_update_04.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/insert_update_04.answer
@@ -23,6 +23,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 1 column.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/select_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/select_01.answer
@@ -42,6 +42,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/update_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/update_01.answer
@@ -41,6 +41,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/update_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/update_02.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/update_03.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/update_03.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/update_delete_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/update_delete_01.answer
@@ -23,6 +23,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 1 column.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/update_insert_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/normal_index/answer/update_insert_01.answer
@@ -23,6 +23,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 1 column.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/create_multiple_index_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/create_multiple_index_01.answer
@@ -36,6 +36,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/create_multiple_index_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/create_multiple_index_02.answer
@@ -25,6 +25,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/delete_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/delete_01.answer
@@ -1,4 +1,5 @@
 | 3 rows affected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 
@@ -23,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/delete_05_prepare.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/delete_05_prepare.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/insert_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/insert_01.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/insert_01_rollback.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/insert_01_rollback.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/insert_02_rollback.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/insert_02_rollback.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/insert_03.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/insert_03.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/insert_04_rollback.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/insert_04_rollback.answer
@@ -25,6 +25,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/insert_05.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/insert_05.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/insert_delete_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/insert_delete_02.answer
@@ -23,6 +23,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 1 column.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/insert_delete_03.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/insert_delete_03.answer
@@ -23,6 +23,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 1 column.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/select_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/select_01.answer
@@ -42,6 +42,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/update_01.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/update_01.answer
@@ -41,6 +41,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 2 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 

--- a/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/update_02.answer
+++ b/isolation/_06_features/cbrd_22705_online_index_parallel/unique_index/answer/update_02.answer
@@ -24,6 +24,7 @@
 | 
 |    'OK'  
 | 1 row selected
+| Statistics updated successfully: 1 table, 3 columns.
 | =================   Q U E R Y   R E S U L T S   =================
 | 
 | 


### PR DESCRIPTION
refer to http://jira.cubrid.org/browse/CBRD-26959
Update statistics now prints a one-line summary ("Statistics updated successfully: N table(s), M column(s).") per CBRD-26959, so isolation answers that run UPDATE STATISTICS need this line added.

Also fix two testcases that hung instead of running:
- invisible_index_02.ctl: C1 never committed its own UPDATE STATISTICS before C2 ran the same statement on the same table, so C2 blocked forever. Added the missing C1 commit.
- update_online_function_index_04.ctl: same missing-commit issue, this time C2's uncommitted CREATE INDEX ... ONLINE blocked C1's UPDATE STATISTICS. Added the missing C2 commit. Also removed a broken nested-comment verification line (caused syntax errors) and fixed a birty_date/birth_date column typo.