### PR TITLE
[CBRD-24252] Revised test case for update expected plan for cbrd_24252_9: 11.3 uses index scan (skip order by) instead of sort

### DIFF
--- a/sql/_34_fig/cbrd_24252/answers/cbrd_24252_9.answer
+++ b/sql/_34_fig/cbrd_24252/answers/cbrd_24252_9.answer
@@ -53,13 +53,15 @@ col_a    col_b
 trace    
 
 Query Plan:
-  TABLE SCAN (c)
+  SORT (order by)
+    TABLE SCAN (c)
 
-  rewritten query: select c.col_a, c.col_b from [dba.t_child] c where c.col_b= ?:?  and c.parent_col_a is not null 
+  rewritten query: select c.col_a, c.col_b from [dba.t_child] c where c.col_b= ?:?  and c.parent_col_a is not null  order by ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.t_child), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
 ===================================================
@@ -73,13 +75,15 @@ col_a    col_b
 trace    
 
 Query Plan:
-  TABLE SCAN (c)
+  SORT (order by)
+    TABLE SCAN (c)
 
-  rewritten query: select c.col_a, c.col_b from [dba.t_child] c where c.col_b= ?:?  and c.parent_col_a is not null 
+  rewritten query: select c.col_a, c.col_b from [dba.t_child] c where c.col_b= ?:?  and c.parent_col_a is not null  order by ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, ioread: ?)
     SCAN (table: dba.t_child), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
 ===================================================

--- a/sql/_34_fig/cbrd_24252/answers/cbrd_24252_9.answer
+++ b/sql/_34_fig/cbrd_24252/answers/cbrd_24252_9.answer
@@ -53,15 +53,14 @@ col_a    col_b
 trace    
 
 Query Plan:
-  SORT (order by)
-    TABLE SCAN (c)
+  INDEX SCAN (c.pk_t_child_col_a) ()
+  skip order by: true
 
   rewritten query: select c.col_a, c.col_b from [dba.t_child] c where c.col_b= ?:?  and c.parent_col_a is not null  order by ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, ioread: ?)
-    SCAN (table: dba.t_child), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SCAN (index: dba.t_child.pk_t_child_col_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
 
 ===================================================
@@ -75,15 +74,14 @@ col_a    col_b
 trace    
 
 Query Plan:
-  SORT (order by)
-    TABLE SCAN (c)
+  INDEX SCAN (c.pk_t_child_col_a) ()
+  skip order by: true
 
   rewritten query: select c.col_a, c.col_b from [dba.t_child] c where c.col_b= ?:?  and c.parent_col_a is not null  order by ?
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, ioread: ?)
-    SCAN (table: dba.t_child), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SCAN (index: dba.t_child.pk_t_child_col_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
      
 
 ===================================================

--- a/sql/_34_fig/cbrd_24252/cases/cbrd_24252_9.sql
+++ b/sql/_34_fig/cbrd_24252/cases/cbrd_24252_9.sql
@@ -49,7 +49,8 @@ from
     inner join t_parent as p on c.parent_col_a = p.col_a
     inner join t_super_parent as s on p.super_parent_col_a = s.col_a
 where
-    c.col_b = -1;
+    c.col_b = -1
+order by c.col_a;
 show trace;
 
 select /*+ recompile */
@@ -62,7 +63,8 @@ from
 where
     c.parent_col_a = p.col_a
     and p.super_parent_col_a = s.col_a
-    and c.col_b = -1;
+    and c.col_b = -1
+order by c.col_a;
 show trace;
 
 drop table if exists t_child;


### PR DESCRIPTION
to refer : http://jira.cubrid.org/browse/CBRD-24252
( #2035 )

### Purpose
최신 11.4 regression test의 TC( release/11.3 ) sql문의 order by절이 없어서 간헐적으로 Failed이 발생 → order by절을 추가해서 보정
회귀 테스트에서 이 TC가 간헐적으로 fail하던 걸(원본 정렬 미보장 버그), develop의 order by 추가 fix(cherry-pick 대상, #2035)로 고치려고 합니다.

### Implementation
as-is : select ... where c.col_b = -1;
to-be : select ... where c.col_b = -1 order by c.col_a;
as-is : select ... where ... and c.col_b = -1;
to-be : select ... where ... and c.col_b = -1 order by c.col_a;

- 기본 키를 가진 테이블이 해당 기본 키를 참조하는 외래 키를 가진 테이블과의 조인에서 제거됩니다. 
조인 조건 외에는 제거할 테이블에 대한 참조가 없어야 합니다. 
이는 기본 키와 외래 키 간의 관계가 조인의 데이터 필터를 대체하기 때문입니다.
기본 키를 가진 테이블이 제거되면, NULL 값을 기준으로 필터링할 수 없으므로 IS NOT NULL 조건을 추가할 수 있습니다.
- 실제 쿼리(t_child join t_parent on ... join t_super_parent on ...)를 보면 t_parent/t_super_parent는 컬럼을 select하거나 조건에 쓰지 않고 오직 PK-FK 조인 조건에만 쓰입니다 — 이건 정확히 "PK-FK 관계로 조인을 제거(join elimination)할 수 있는지"를 검증하는 CBRD-24252의 원래 취지와 일치.

### Remarks
develop의 답지와 release/11.3가 다른 이유
develop의 fix(#2035)를 cherry-pick했으나, 11.3 실제 바이너리로 검증한 결과 옵티마이저가 PK 인덱스(pk_t_child_col_a)를 이용해 정렬을 생략(index scan, skip order by)하는 것을 확인 — develop 기준 answer(table scan+sort)는 11.3에 맞지 않아 실제 11.3 실행 결과로 answer를 재생성하였음.

