### PR TITLE
[CBRD-26571] Add SQL testcase for PK count optimization across UNION …

### DIFF
--- a/sql/_36_guava/cbrd_26571/answers/cbrd_26571.answer
+++ b/sql/_36_guava/cbrd_26571/answers/cbrd_26571.answer
@@ -1,0 +1,425 @@
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+5
+===================================================
+3
+===================================================
+2
+===================================================
+4
+===================================================
+0
+===================================================
+0
+===================================================
+    
+Case 1: 2-way UNION ALL, count(*) on two PK tables -> both branches must be PK-count-optimized     
+
+===================================================
+'ta'    count(*)    
+ta     5     
+tb     3     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select 'tb', count(*) from [dba.tb] [dba.tb]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+     
+
+===================================================
+    
+Case 2: 3-way UNION ALL -> optimization must hold through the 3rd branch too     
+
+===================================================
+'ta'    count(*)    
+ta     5     
+tb     3     
+tc     2     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select 'tb', count(*) from [dba.tb] [dba.tb]
+
+  TABLE SCAN (dba.tc)
+
+  rewritten query: select 'tc', count(*) from [dba.tc] [dba.tc]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tc), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tc_id)
+     
+
+===================================================
+    
+Case 3: plain UNION (dedup) -> optimization must also apply for UNION, not only UNION ALL     
+
+===================================================
+'ta'    count(*)    
+ta     5     
+tb     3     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select 'tb', count(*) from [dba.tb] [dba.tb]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+     
+
+===================================================
+    
+Case 4: PK table branch mixed with non-PK (heap-only) table branch -> only the PK branch is optimized     
+
+===================================================
+'ta'    count(*)    
+ta     5     
+td     4     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.td)
+
+  rewritten query: select 'td', count(*) from [dba.td] [dba.td]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.td), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 5: empty-table branch (0 rows) -> count(*) = 0 must be optimized and correct     
+
+===================================================
+'te'    count(*)    
+te     0     
+ta     5     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.te)
+
+  rewritten query: select 'te', count(*) from [dba.te] [dba.te]
+
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.te), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_te_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+     
+
+===================================================
+    
+Case 6: the same table referenced twice in one UNION ALL (self-union)     
+
+===================================================
+'ta-1'    count(*)    
+ta-1     5     
+ta-2     5     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta-?', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta-?', count(*) from [dba.ta] [dba.ta]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+     
+
+===================================================
+    
+Case 7: optimizable branch (no WHERE) mixed with non-optimizable branch (count(*) with WHERE)     
+
+===================================================
+'ta'    count(*)    
+ta     5     
+tb-filtered     2     
+tc     2     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+  INDEX SCAN (dba.tb.pk_tb_id) (key range: ([dba.tb].id> ?:? ), covered: true)
+
+  rewritten query: select 'tb-filtered', count(*) from [dba.tb] [dba.tb] where ([dba.tb].id> ?:? )
+
+  TABLE SCAN (dba.tc)
+
+  rewritten query: select 'tc', count(*) from [dba.tc] [dba.tc]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (index: dba.tb.pk_tb_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true, count_only: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tc), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tc_id)
+     
+
+===================================================
+    
+Case 8: DML immediately before the UNION count -> optimized result must reflect the latest committed data     
+
+===================================================
+1
+===================================================
+0
+===================================================
+'ta'    count(*)    
+ta     5     
+tb     4     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select 'tb', count(*) from [dba.tb] [dba.tb]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+     
+
+===================================================
+1
+===================================================
+0
+===================================================
+    
+Case 9: INTERSECT ALL / EXCEPT ALL -> the fix must cover all set operators, not only UNION     
+
+===================================================
+'ta'    count(*)    
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select 'tb', count(*) from [dba.tb] [dba.tb]
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+               (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+     
+
+===================================================
+'ta'    count(*)    
+ta     5     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select 'tb', count(*) from [dba.tb] [dba.tb]
+
+
+Trace Statistics:
+  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+             (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+     
+
+===================================================
+    
+Case 10: UNION ALL wrapped inside a subquery (not the top-level statement)     
+
+===================================================
+'ta'    count(*)    
+ta     5     
+tb     3     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select 'tb', count(*) from [dba.tb] [dba.tb]
+
+  SORT (order by)
+    TABLE SCAN (x)
+
+  rewritten query: select x.['ta'], x.[count(*)] from (select 'ta', count(*) from [dba.ta] [dba.ta] union all select 'tb', count(*) from [dba.tb] [dba.tb]) x (['ta'], [count(*)]) order by ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+     
+
+===================================================
+    
+Case 11: DML immediately before the UNION count, then ROLLBACK -> optimized result must reflect the rolled-back (original) data     
+
+===================================================
+0
+===================================================
+'ta'    count(*)    
+ta     5     
+tb     3     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select 'tb', count(*) from [dba.tb] [dba.tb]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+     
+

--- a/sql/_36_guava/cbrd_26571/answers/cbrd_26571.answer
+++ b/sql/_36_guava/cbrd_26571/answers/cbrd_26571.answer
@@ -11,6 +11,10 @@
 ===================================================
 0
 ===================================================
+0
+===================================================
+0
+===================================================
 5
 ===================================================
 3
@@ -18,6 +22,10 @@
 2
 ===================================================
 4
+===================================================
+3
+===================================================
+0
 ===================================================
 0
 ===================================================
@@ -114,14 +122,22 @@ Query Plan:
 
   rewritten query: select 'tb', count(*) from [dba.tb] [dba.tb]
 
+  SORT (order by)
+    TABLE SCAN (x)
+
+  rewritten query: select x.['ta'], x.[count(*)] from (select 'ta', count(*) from [dba.ta] [dba.ta] union select 'tb', count(*) from [dba.tb] [dba.tb]) x (['ta'], [count(*)]) order by ?
+
 
 Trace Statistics:
-  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
-    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-      SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
      
 
 ===================================================
@@ -298,57 +314,61 @@ Trace Statistics:
 0
 ===================================================
     
-Case 9: INTERSECT ALL / EXCEPT ALL -> the fix must cover all set operators, not only UNION     
+Case 9: INTERSECT ALL, same table/same literal -> a wrong count on either branch must surface as a non-matching row     
 
 ===================================================
-'ta'    count(*)    
+'x'    count(*)    
+x     2     
 
 ===================================================
 trace    
 
 Query Plan:
-  TABLE SCAN (dba.ta)
+  TABLE SCAN (dba.tc)
 
-  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+  rewritten query: select 'x', count(*) from [dba.tc] [dba.tc]
 
-  TABLE SCAN (dba.tb)
+  TABLE SCAN (dba.tc)
 
-  rewritten query: select 'tb', count(*) from [dba.tb] [dba.tb]
+  rewritten query: select 'x', count(*) from [dba.tc] [dba.tc]
 
 
 Trace Statistics:
   INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
                (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+      SCAN (table: dba.tc), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tc_id)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-      SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+      SCAN (table: dba.tc), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tc_id)
      
 
 ===================================================
-'ta'    count(*)    
-ta     5     
+    
+Case 9b: EXCEPT ALL, same table/same literal -> matching branches must yield an empty result     
+
+===================================================
+'x'    count(*)    
 
 ===================================================
 trace    
 
 Query Plan:
-  TABLE SCAN (dba.ta)
+  TABLE SCAN (dba.tc)
 
-  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+  rewritten query: select 'x', count(*) from [dba.tc] [dba.tc]
 
-  TABLE SCAN (dba.tb)
+  TABLE SCAN (dba.tc)
 
-  rewritten query: select 'tb', count(*) from [dba.tb] [dba.tb]
+  rewritten query: select 'x', count(*) from [dba.tc] [dba.tc]
 
 
 Trace Statistics:
   DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
              (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+      SCAN (table: dba.tc), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tc_id)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-      SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+      SCAN (table: dba.tc), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tc_id)
      
 
 ===================================================
@@ -395,6 +415,8 @@ Trace Statistics:
 Case 11: DML immediately before the UNION count, then ROLLBACK -> optimized result must reflect the rolled-back (original) data     
 
 ===================================================
+1
+===================================================
 0
 ===================================================
 'ta'    count(*)    
@@ -423,3 +445,359 @@ Trace Statistics:
       SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
      
 
+===================================================
+    
+Case 12-1: REPEATABLE READ -> the PK count optimization must be OFF (heap scan)     
+
+===================================================
+0
+===================================================
+'ta'    count(*)    
+ta     5     
+tb     3     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select 'tb', count(*) from [dba.tb] [dba.tb]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 12-2: SERIALIZABLE -> the PK count optimization must be OFF (heap scan)     
+
+===================================================
+0
+===================================================
+'ta'    count(*)    
+ta     5     
+tb     3     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select 'tb', count(*) from [dba.tb] [dba.tb]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 12-3: back to READ COMMITTED -> the optimization must come back on both branches     
+
+===================================================
+0
+===================================================
+'ta'    count(*)    
+ta     5     
+tb     3     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select 'tb', count(*) from [dba.tb] [dba.tb]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+     
+
+===================================================
+    
+Case 13-1: serial execution, parallel(0) on the wrapped UNION ALL     
+
+===================================================
+'ta'    count(*)    
+ta     5     
+tb     3     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select 'tb', count(*) from [dba.tb] [dba.tb]
+
+  SORT (order by)
+    TABLE SCAN (x)
+
+  rewritten query: select /*+ PARALLEL(?) */ x.['ta'], x.[count(*)] from (select 'ta', count(*) from [dba.ta] [dba.ta] union all select 'tb', count(*) from [dba.tb] [dba.tb]) x (['ta'], [count(*)]) order by ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+     
+
+===================================================
+    
+Case 13-2: serial execution, parallel(0) on the top-level UNION ALL     
+
+===================================================
+'ta'    count(*)    
+ta     5     
+tb     3     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select /*+ PARALLEL(?) */ 'ta', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select 'tb', count(*) from [dba.tb] [dba.tb]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+     
+
+===================================================
+    
+Case 14: two count(*) in one select list -> records whether both, one, or neither are optimized     
+
+===================================================
+'ta'    count(*)    count(*)    
+ta     5     5     
+tb     3     3     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*), count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select 'tb', count(*), count(*) from [dba.tb] [dba.tb]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+     
+
+===================================================
+    
+Case 15-1: non-optimizable branch FIRST (no PK) -> the following PK branch must still be optimized     
+
+===================================================
+'td'    count(*)    
+td     4     
+ta     5     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.td)
+
+  rewritten query: select 'td', count(*) from [dba.td] [dba.td]
+
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.td), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+     
+
+===================================================
+    
+Case 15-2: non-optimizable branch FIRST (WHERE clause) -> the following PK branch must still be optimized     
+
+===================================================
+'ta-filtered'    count(*)    
+ta-filtered     4     
+tb     3     
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (dba.ta.pk_ta_id) (key range: ([dba.ta].id> ?:? ), covered: true)
+
+  rewritten query: select 'ta-filtered', count(*) from [dba.ta] [dba.ta] where ([dba.ta].id> ?:? )
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select 'tb', count(*) from [dba.tb] [dba.tb]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (index: dba.ta.pk_ta_id), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true, count_only: true)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+     
+
+===================================================
+    
+Case 15-3: same table, plain UNION, no literal in the select list     
+
+===================================================
+count(*)    
+5     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select count(*) from [dba.ta] [dba.ta]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+     
+
+===================================================
+    
+Case 15-4: no literal in the select list, control shape     
+
+===================================================
+count(*)    
+3     
+5     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select count(*) from [dba.tb] [dba.tb]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+  ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 16: unique index but no primary key -> records whether such a branch is optimized     
+
+===================================================
+'ta'    count(*)    
+ta     5     
+tf     3     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tf)
+
+  rewritten query: select 'tf', count(*) from [dba.tf] [dba.tf]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tf), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: idx_tf_id)
+     
+
+===================================================
+0

--- a/sql/_36_guava/cbrd_26571/answers/cbrd_26571.answer
+++ b/sql/_36_guava/cbrd_26571/answers/cbrd_26571.answer
@@ -15,6 +15,8 @@
 ===================================================
 0
 ===================================================
+0
+===================================================
 5
 ===================================================
 3
@@ -24,6 +26,8 @@
 4
 ===================================================
 3
+===================================================
+5
 ===================================================
 0
 ===================================================
@@ -412,10 +416,41 @@ Trace Statistics:
 
 ===================================================
     
-Case 11: DML immediately before the UNION count, then ROLLBACK -> optimized result must reflect the rolled-back (original) data     
+Case 11-1: uncommitted DML must be visible to the optimized count     
 
 ===================================================
 1
+===================================================
+'ta'    count(*)    
+ta     5     
+tb     4     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select 'tb', count(*) from [dba.tb] [dba.tb]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+     
+
+===================================================
+    
+Case 11-2: after ROLLBACK -> the optimized count must return to the original data     
+
 ===================================================
 0
 ===================================================
@@ -770,7 +805,7 @@ Trace Statistics:
 
 ===================================================
     
-Case 16: unique index but no primary key -> records whether such a branch is optimized     
+Case 16-1: unique index but no primary key -> records whether such a branch is optimized     
 
 ===================================================
 'ta'    count(*)    
@@ -799,5 +834,117 @@ Trace Statistics:
       SCAN (table: dba.tf), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: idx_tf_id)
      
 
+===================================================
+    
+Case 16-2: unique-index-only table containing a NULL key -> count(*) must include the NULL row     
+
+===================================================
+1
+===================================================
+0
+===================================================
+'ta'    count(*)    
+ta     5     
+tf     4     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tf)
+
+  rewritten query: select 'tf', count(*) from [dba.tf] [dba.tf]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tf), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: idx_tf_id)
+     
+
+===================================================
+    
+Case 17: partitioned PK table as the second branch of a UNION ALL     
+
+===================================================
+'ta'    count(*)    
+ta     5     
+tg     5     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select 'ta', count(*) from [dba.ta] [dba.ta]
+
+  TABLE SCAN (dba.tg)
+
+  rewritten query: select 'tg', count(*) from [dba.tg] [dba.tg]
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tg), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tg_id)
+     
+
+===================================================
+    
+Case 18-1: first execution, no recompile hint -> the plan gets cached     
+
+===================================================
+'ta'    count(*)    
+ta     5     
+tb     3     
+
+===================================================
+trace    
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+     
+
+===================================================
+    
+Case 18-2: identical statement text -> served from the plan cache, both branches must stay optimized     
+
+===================================================
+'ta'    count(*)    
+ta     5     
+tb     3     
+
+===================================================
+trace    
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_ta_id)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tb), (noscan time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?, agl: pk_tb_id)
+     
+
+===================================================
+0
+===================================================
+0
 ===================================================
 0

--- a/sql/_36_guava/cbrd_26571/cases/cbrd_26571.sql
+++ b/sql/_36_guava/cbrd_26571/cases/cbrd_26571.sql
@@ -27,7 +27,7 @@
  *
  * Result-order note: a plain UNION (dedup) does not guarantee row order, so
  * any case comparing a UNION (not UNION ALL) result against a fixed .answer
- * wraps the UNION in an outer query with an explicit order by (see Case 10)
+ * wraps the UNION in an outer query with an explicit order by (see Case 3)
  * to keep the comparison deterministic.
  *
  * Coverage:
@@ -60,10 +60,17 @@
  *   Case 10: UNION ALL wrapped inside a subquery (not the top-level statement)
  *           -> the optimization must still apply per branch when the set operation
  *              is not the outermost statement
- *   Case 11: DML immediately before the UNION count, then ROLLBACK (not COMMIT)
- *           -> symmetric counterpart to Case 8: the re-acquired MVCC snapshot must
- *              reflect that the uncommitted change was rolled back, not the
- *              uncommitted (or stale) value
+ *   Case 11: DML immediately before the UNION count, then ROLLBACK (not COMMIT) -
+ *           symmetric counterpart to Case 8, split into two checks because the
+ *           fix re-reads global B-tree stats (a committed-data aggregate) and
+ *           then applies a correction for the current transactions own
+ *           uncommitted changes - checking only after rollback (as a single
+ *           case) never exercises that correction step, since by then the
+ *           stats and the actual data already agree again
+ *   Case 11-1: query issued before the ROLLBACK, while the insert is still
+ *           pending -> the optimized count must reflect that pending insert
+ *   Case 11-2: query issued after the ROLLBACK
+ *           -> the optimized count must return to the original data
  *   Case 12: transaction isolation level gating (CBRD-26705)
  *           -> REPEATABLE READ / SERIALIZABLE must turn the optimization off
  *              (heap scan), READ COMMITTED must turn it back on
@@ -76,12 +83,36 @@
  *           -> a non-optimizable branch placed FIRST must not block optimization
  *              of a later PK branch, and the fix must not depend on a literal
  *              being present in the select list
- *   Case 16: unique index but no primary key
+ *   Case 16: unique index but no primary key, split into two checks
+ *   Case 16-1: no NULL keys present in the table
  *           -> records whether a unique-index-only branch is optimized the
  *              same way as a primary-key branch
+ *   Case 16-2: same table with one NULL-key row inserted
+ *           -> count(*) must still include the NULL row when the count is
+ *              answered from index statistics rather than a heap scan
+ *   Case 17: a partitioned PK table (2 range partitions) as the second
+ *           branch of a UNION ALL
+ *           -> the fix loops per aggregate over every B-tree it has already
+ *              read stats for - every other branch in this file is a
+ *              single unpartitioned table, so that loop always runs exactly
+ *              once. A partitioned table is the practical way to force it
+ *              to visit more than one B-tree for a single branch, and
+ *              CBRD-26705s own regression history had 5 of its 8 cases on
+ *              the partitioned-table path - this closes a real gap, not a
+ *              hypothetical one
+ *   Case 18: plan-cache reuse across transactions - every other case in
+ *           this file uses recompile, so every execution builds a fresh
+ *           plan. The state this fix touches (count_state, snapshot) is
+ *           attached to the transaction, not the plan, so reusing a cached
+ *           plan across two separate (autocommit) transactions is a
+ *           distinct code path that recompile always skips
+ *   Case 18-1: first execution, no hint -> populates the plan cache
+ *   Case 18-2: the exact same statement text again
+ *           -> served from the cached plan - both branches must still be
+ *              optimized, not just the one from Case 18-1s own transaction
  */
 
-drop table if exists ta, tb, tc, td, te, tf;
+drop table if exists ta, tb, tc, td, te, tf, tg;
 create table ta (id int primary key, cola varchar(20));
 create table tb (id int primary key, colb int);
 create table tc (id int primary key);
@@ -89,12 +120,17 @@ create table td (id int, cold varchar(20));
 create table te (id int primary key);
 create table tf (id int, colf varchar(20));
 create unique index idx_tf_id on tf(id);
+create table tg (id int primary key, colg int)
+partition by range (id) (
+  partition p0 values less than (100),
+  partition p1 values less than (200));
 
 insert into ta values (1,'a'), (2,'b'), (3,'c'), (4,'d'), (5,'e');
 insert into tb values (1,10), (2,20), (3,30);
 insert into tc values (1), (2);
 insert into td values (1,'x'), (2,'y'), (3,'z'), (4,'w');
 insert into tf values (1,'a'), (2,'b'), (3,'c');
+insert into tg values (1,1), (2,2), (101,101), (102,102), (103,103);
 commit;
 
 set transaction isolation level read committed;
@@ -161,9 +197,14 @@ select * from (select /*+ recompile */ 'ta', count(*) from ta union all select '
 show trace;
 
 
-evaluate 'Case 11: DML immediately before the UNION count, then ROLLBACK -> optimized result must reflect the rolled-back (original) data';
+evaluate 'Case 11-1: uncommitted DML must be visible to the optimized count';
 autocommit off;
 insert into tb values (200, 200);
+select /*+ recompile */ 'ta', count(*) from ta union all select 'tb', count(*) from tb;
+show trace;
+
+
+evaluate 'Case 11-2: after ROLLBACK -> the optimized count must return to the original data';
 rollback;
 select /*+ recompile */ 'ta', count(*) from ta union all select 'tb', count(*) from tb;
 show trace;
@@ -223,9 +264,33 @@ select /*+ recompile */ count(*) from ta union all select count(*) from tb order
 show trace;
 
 
-evaluate 'Case 16: unique index but no primary key -> records whether such a branch is optimized';
+evaluate 'Case 16-1: unique index but no primary key -> records whether such a branch is optimized';
 select /*+ recompile */ 'ta', count(*) from ta union all select 'tf', count(*) from tf;
 show trace;
 
 
-drop table if exists ta, tb, tc, td, te, tf;
+evaluate 'Case 16-2: unique-index-only table containing a NULL key -> count(*) must include the NULL row';
+insert into tf values (null, 'd');
+commit;
+select /*+ recompile */ 'ta', count(*) from ta union all select 'tf', count(*) from tf;
+show trace;
+
+
+evaluate 'Case 17: partitioned PK table as the second branch of a UNION ALL';
+select /*+ recompile */ 'ta', count(*) from ta union all select 'tg', count(*) from tg;
+show trace;
+
+
+evaluate 'Case 18-1: first execution, no recompile hint -> the plan gets cached';
+select 'ta', count(*) from ta union all select 'tb', count(*) from tb;
+show trace;
+
+
+evaluate 'Case 18-2: identical statement text -> served from the plan cache, both branches must stay optimized';
+select 'ta', count(*) from ta union all select 'tb', count(*) from tb;
+show trace;
+
+set transaction isolation level read committed;
+set trace off;
+
+drop table if exists ta, tb, tc, td, te, tf, tg;

--- a/sql/_36_guava/cbrd_26571/cases/cbrd_26571.sql
+++ b/sql/_36_guava/cbrd_26571/cases/cbrd_26571.sql
@@ -15,10 +15,20 @@
  * before evaluating the optimization for each branch, then re-acquire the
  * MVCC snapshot.
  *
- * Note: table/column names use letters (ta/tb/tc/td/te), not digits,
- * because CTP masks digits in the trace output to '?' -- digit-named
- * objects (t1, t2, ...) would all collapse to "t?" and become
- * indistinguishable, same convention as CBRD-26522's cbrd_26522.sql.
+ * Note: table/column names use letters (ta/tb/tc/td/te/tf), not digits,
+ * because CTP masks digits in the trace output to a single question mark --
+ * digit-named objects (t1, t2, ...) would all collapse to t-question-mark
+ * and become indistinguishable, same convention as cbrd_26522.sql (CBRD-26522).
+ *
+ * Isolation level: the optimization is gated by transaction isolation level
+ * (see CBRD-26705) -- it only applies under READ COMMITTED. The session
+ * isolation level is set explicitly right after setup so this file does not
+ * depend on the CTP/broker default, and Case 12 exercises the gating itself.
+ *
+ * Result-order note: a plain UNION (dedup) does not guarantee row order, so
+ * any case comparing a UNION (not UNION ALL) result against a fixed .answer
+ * wraps the UNION in an outer query with an explicit order by (see Case 10)
+ * to keep the comparison deterministic.
  *
  * Coverage:
  *   Case 1: 2-way UNION ALL, count(*) on two PK tables
@@ -28,7 +38,7 @@
  *   Case 3: plain UNION (dedup)
  *           -> the fix must also apply when the set operator is UNION, not only UNION ALL
  *   Case 4: PK table branch mixed with a non-PK (heap-only) table branch
- *           -> only the PK branch is optimized; the non-PK branch is unaffected
+ *           -> only the PK branch is optimized - the non-PK branch is unaffected
  *              (no false-positive optimization introduced by the fix)
  *   Case 5: empty-table branch (0 rows)
  *           -> count(*) = 0 must still be optimized and return the correct value
@@ -36,14 +46,17 @@
  *           -> repeated invalidate/re-fetch of the same PK btree stats must still work
  *   Case 7: an optimizable branch (no WHERE) mixed with a non-optimizable branch
  *           (count(*) with a WHERE clause)
- *           -> each branch's eligibility must be judged independently; the fix
+ *           -> each branch eligibility must be judged independently - the fix
  *              must not force optimization onto a branch that legitimately needs a scan
  *   Case 8: DML immediately before the UNION count query
  *           -> since the fix re-acquires the MVCC snapshot, the optimized count
  *              must reflect the latest committed data, not a stale value
- *   Case 9: INTERSECT ALL / EXCEPT ALL (not just UNION)
+ *   Case 9: INTERSECT ALL / EXCEPT ALL (not just UNION), self-referential check
  *           -> UNION, INTERSECT and EXCEPT all share the same XASL UNION proc
- *              internally; the fix must cover all three set operators, not only UNION
+ *              internally - the fix must cover all three set operators. Both
+ *              branches use the same table and the same literal so a wrong
+ *              count on either branch surfaces as a non-matching row instead
+ *              of being masked by differing literals (see PR review comment)
  *   Case 10: UNION ALL wrapped inside a subquery (not the top-level statement)
  *           -> the optimization must still apply per branch when the set operation
  *              is not the outermost statement
@@ -51,20 +64,40 @@
  *           -> symmetric counterpart to Case 8: the re-acquired MVCC snapshot must
  *              reflect that the uncommitted change was rolled back, not the
  *              uncommitted (or stale) value
+ *   Case 12: transaction isolation level gating (CBRD-26705)
+ *           -> REPEATABLE READ / SERIALIZABLE must turn the optimization off
+ *              (heap scan), READ COMMITTED must turn it back on
+ *   Case 13: same query shape executed with parallel(0) (serial execution path)
+ *           -> the fix must not depend on the parallel-heap-scan execution path
+ *   Case 14: two count(*) expressions in the same select list
+ *           -> only one of them is expected to be optimized (COS_LOADED guard) -
+ *              this records the actual behavior rather than assuming it
+ *   Case 15: branch ordering and literal-less variants
+ *           -> a non-optimizable branch placed FIRST must not block optimization
+ *              of a later PK branch, and the fix must not depend on a literal
+ *              being present in the select list
+ *   Case 16: unique index but no primary key
+ *           -> records whether a unique-index-only branch is optimized the
+ *              same way as a primary-key branch
  */
 
-drop table if exists ta, tb, tc, td, te;
+drop table if exists ta, tb, tc, td, te, tf;
 create table ta (id int primary key, cola varchar(20));
 create table tb (id int primary key, colb int);
 create table tc (id int primary key);
 create table td (id int, cold varchar(20));
 create table te (id int primary key);
+create table tf (id int, colf varchar(20));
+create unique index idx_tf_id on tf(id);
 
 insert into ta values (1,'a'), (2,'b'), (3,'c'), (4,'d'), (5,'e');
 insert into tb values (1,10), (2,20), (3,30);
 insert into tc values (1), (2);
 insert into td values (1,'x'), (2,'y'), (3,'z'), (4,'w');
+insert into tf values (1,'a'), (2,'b'), (3,'c');
 commit;
+
+set transaction isolation level read committed;
 
 set trace on;
 
@@ -80,7 +113,7 @@ show trace;
 
 
 evaluate 'Case 3: plain UNION (dedup) -> optimization must also apply for UNION, not only UNION ALL';
-select /*+ recompile */ 'ta', count(*) from ta union select 'tb', count(*) from tb;
+select * from (select /*+ recompile */ 'ta', count(*) from ta union select 'tb', count(*) from tb) x order by 1;
 show trace;
 
 
@@ -113,10 +146,13 @@ delete from tb where id = 100;
 commit;
 
 
-evaluate 'Case 9: INTERSECT ALL / EXCEPT ALL -> the fix must cover all set operators, not only UNION';
-select /*+ recompile */ 'ta', count(*) from ta intersect all select 'tb', count(*) from tb;
+evaluate 'Case 9: INTERSECT ALL, same table/same literal -> a wrong count on either branch must surface as a non-matching row';
+select /*+ recompile */ 'x', count(*) from tc intersect all select 'x', count(*) from tc;
 show trace;
-select /*+ recompile */ 'ta', count(*) from ta except all select 'tb', count(*) from tb;
+
+
+evaluate 'Case 9b: EXCEPT ALL, same table/same literal -> matching branches must yield an empty result';
+select /*+ recompile */ 'x', count(*) from tc except all select 'x', count(*) from tc;
 show trace;
 
 
@@ -126,12 +162,70 @@ show trace;
 
 
 evaluate 'Case 11: DML immediately before the UNION count, then ROLLBACK -> optimized result must reflect the rolled-back (original) data';
-;autocommit off
+autocommit off;
 insert into tb values (200, 200);
 rollback;
 select /*+ recompile */ 'ta', count(*) from ta union all select 'tb', count(*) from tb;
 show trace;
-;autocommit on
+autocommit on;
 
 
-drop table if exists ta, tb, tc, td, te;
+evaluate 'Case 12-1: REPEATABLE READ -> the PK count optimization must be OFF (heap scan)';
+set transaction isolation level repeatable read;
+select /*+ recompile */ 'ta', count(*) from ta union all select 'tb', count(*) from tb;
+show trace;
+
+
+evaluate 'Case 12-2: SERIALIZABLE -> the PK count optimization must be OFF (heap scan)';
+set transaction isolation level serializable;
+select /*+ recompile */ 'ta', count(*) from ta union all select 'tb', count(*) from tb;
+show trace;
+
+
+evaluate 'Case 12-3: back to READ COMMITTED -> the optimization must come back on both branches';
+set transaction isolation level read committed;
+select /*+ recompile */ 'ta', count(*) from ta union all select 'tb', count(*) from tb;
+show trace;
+
+
+evaluate 'Case 13-1: serial execution, parallel(0) on the wrapped UNION ALL';
+select /*+ recompile parallel(0) */ * from (select 'ta', count(*) from ta union all select 'tb', count(*) from tb) x order by 1;
+show trace;
+
+
+evaluate 'Case 13-2: serial execution, parallel(0) on the top-level UNION ALL';
+select /*+ recompile parallel(0) */ 'ta', count(*) from ta union all select 'tb', count(*) from tb;
+show trace;
+
+
+evaluate 'Case 14: two count(*) in one select list -> records whether both, one, or neither are optimized';
+select /*+ recompile */ 'ta', count(*), count(*) from ta union all select 'tb', count(*), count(*) from tb;
+show trace;
+
+
+evaluate 'Case 15-1: non-optimizable branch FIRST (no PK) -> the following PK branch must still be optimized';
+select /*+ recompile */ 'td', count(*) from td union all select 'ta', count(*) from ta;
+show trace;
+
+
+evaluate 'Case 15-2: non-optimizable branch FIRST (WHERE clause) -> the following PK branch must still be optimized';
+select /*+ recompile */ 'ta-filtered', count(*) from ta where id > 1 union all select 'tb', count(*) from tb;
+show trace;
+
+
+evaluate 'Case 15-3: same table, plain UNION, no literal in the select list';
+select /*+ recompile */ count(*) from ta union select count(*) from ta;
+show trace;
+
+
+evaluate 'Case 15-4: no literal in the select list, control shape';
+select /*+ recompile */ count(*) from ta union all select count(*) from tb order by 1;
+show trace;
+
+
+evaluate 'Case 16: unique index but no primary key -> records whether such a branch is optimized';
+select /*+ recompile */ 'ta', count(*) from ta union all select 'tf', count(*) from tf;
+show trace;
+
+
+drop table if exists ta, tb, tc, td, te, tf;

--- a/sql/_36_guava/cbrd_26571/cases/cbrd_26571.sql
+++ b/sql/_36_guava/cbrd_26571/cases/cbrd_26571.sql
@@ -1,0 +1,137 @@
+/**
+ * This test case verifies CBRD-26571 : PK count optimization is not applied
+ * from the second branch onward in a UNION / UNION ALL statement.
+ *
+ * Bug: count(*) on a table with a primary key is normally answered directly
+ * from the PK B-tree statistics (trace shows "noscan ..., agl: pk_xxx_id")
+ * instead of a full heap scan. In a UNION statement, this optimization was
+ * only applied to the FIRST branch -- every branch from the second one
+ * onward silently fell back to a full heap scan ("heap ..., readrows: N"),
+ * because qexec_evaluate_aggregates_optimize() did not invalidate and
+ * re-fetch the MVCC snapshot / btree stats when the snapshot was already
+ * valid (which is always true by the time the second branch executes).
+ *
+ * Fix: invalidate mvccinfo.snapshot and re-run logtb_tran_find_btid_stats
+ * before evaluating the optimization for each branch, then re-acquire the
+ * MVCC snapshot.
+ *
+ * Note: table/column names use letters (ta/tb/tc/td/te), not digits,
+ * because CTP masks digits in the trace output to '?' -- digit-named
+ * objects (t1, t2, ...) would all collapse to "t?" and become
+ * indistinguishable, same convention as CBRD-26522's cbrd_26522.sql.
+ *
+ * Coverage:
+ *   Case 1: 2-way UNION ALL, count(*) on two PK tables
+ *           -> both branches must show the PK count optimization (basic repro)
+ *   Case 2: 3-way UNION ALL
+ *           -> optimization must hold through the 3rd branch too, not just 1st/2nd
+ *   Case 3: plain UNION (dedup)
+ *           -> the fix must also apply when the set operator is UNION, not only UNION ALL
+ *   Case 4: PK table branch mixed with a non-PK (heap-only) table branch
+ *           -> only the PK branch is optimized; the non-PK branch is unaffected
+ *              (no false-positive optimization introduced by the fix)
+ *   Case 5: empty-table branch (0 rows)
+ *           -> count(*) = 0 must still be optimized and return the correct value
+ *   Case 6: the same table referenced twice in one UNION ALL (self-union)
+ *           -> repeated invalidate/re-fetch of the same PK btree stats must still work
+ *   Case 7: an optimizable branch (no WHERE) mixed with a non-optimizable branch
+ *           (count(*) with a WHERE clause)
+ *           -> each branch's eligibility must be judged independently; the fix
+ *              must not force optimization onto a branch that legitimately needs a scan
+ *   Case 8: DML immediately before the UNION count query
+ *           -> since the fix re-acquires the MVCC snapshot, the optimized count
+ *              must reflect the latest committed data, not a stale value
+ *   Case 9: INTERSECT ALL / EXCEPT ALL (not just UNION)
+ *           -> UNION, INTERSECT and EXCEPT all share the same XASL UNION proc
+ *              internally; the fix must cover all three set operators, not only UNION
+ *   Case 10: UNION ALL wrapped inside a subquery (not the top-level statement)
+ *           -> the optimization must still apply per branch when the set operation
+ *              is not the outermost statement
+ *   Case 11: DML immediately before the UNION count, then ROLLBACK (not COMMIT)
+ *           -> symmetric counterpart to Case 8: the re-acquired MVCC snapshot must
+ *              reflect that the uncommitted change was rolled back, not the
+ *              uncommitted (or stale) value
+ */
+
+drop table if exists ta, tb, tc, td, te;
+create table ta (id int primary key, cola varchar(20));
+create table tb (id int primary key, colb int);
+create table tc (id int primary key);
+create table td (id int, cold varchar(20));
+create table te (id int primary key);
+
+insert into ta values (1,'a'), (2,'b'), (3,'c'), (4,'d'), (5,'e');
+insert into tb values (1,10), (2,20), (3,30);
+insert into tc values (1), (2);
+insert into td values (1,'x'), (2,'y'), (3,'z'), (4,'w');
+commit;
+
+set trace on;
+
+
+evaluate 'Case 1: 2-way UNION ALL, count(*) on two PK tables -> both branches must be PK-count-optimized';
+select /*+ recompile */ 'ta', count(*) from ta union all select 'tb', count(*) from tb;
+show trace;
+
+
+evaluate 'Case 2: 3-way UNION ALL -> optimization must hold through the 3rd branch too';
+select /*+ recompile */ 'ta', count(*) from ta union all select 'tb', count(*) from tb union all select 'tc', count(*) from tc;
+show trace;
+
+
+evaluate 'Case 3: plain UNION (dedup) -> optimization must also apply for UNION, not only UNION ALL';
+select /*+ recompile */ 'ta', count(*) from ta union select 'tb', count(*) from tb;
+show trace;
+
+
+evaluate 'Case 4: PK table branch mixed with non-PK (heap-only) table branch -> only the PK branch is optimized';
+select /*+ recompile */ 'ta', count(*) from ta union all select 'td', count(*) from td;
+show trace;
+
+
+evaluate 'Case 5: empty-table branch (0 rows) -> count(*) = 0 must be optimized and correct';
+select /*+ recompile */ 'te', count(*) from te union all select 'ta', count(*) from ta;
+show trace;
+
+
+evaluate 'Case 6: the same table referenced twice in one UNION ALL (self-union)';
+select /*+ recompile */ 'ta-1', count(*) from ta union all select 'ta-2', count(*) from ta;
+show trace;
+
+
+evaluate 'Case 7: optimizable branch (no WHERE) mixed with non-optimizable branch (count(*) with WHERE)';
+select /*+ recompile */ 'ta', count(*) from ta union all select 'tb-filtered', count(*) from tb where id > 1 union all select 'tc', count(*) from tc;
+show trace;
+
+
+evaluate 'Case 8: DML immediately before the UNION count -> optimized result must reflect the latest committed data';
+insert into tb values (100, 100);
+commit;
+select /*+ recompile */ 'ta', count(*) from ta union all select 'tb', count(*) from tb;
+show trace;
+delete from tb where id = 100;
+commit;
+
+
+evaluate 'Case 9: INTERSECT ALL / EXCEPT ALL -> the fix must cover all set operators, not only UNION';
+select /*+ recompile */ 'ta', count(*) from ta intersect all select 'tb', count(*) from tb;
+show trace;
+select /*+ recompile */ 'ta', count(*) from ta except all select 'tb', count(*) from tb;
+show trace;
+
+
+evaluate 'Case 10: UNION ALL wrapped inside a subquery (not the top-level statement)';
+select * from (select /*+ recompile */ 'ta', count(*) from ta union all select 'tb', count(*) from tb) x order by 1;
+show trace;
+
+
+evaluate 'Case 11: DML immediately before the UNION count, then ROLLBACK -> optimized result must reflect the rolled-back (original) data';
+;autocommit off
+insert into tb values (200, 200);
+rollback;
+select /*+ recompile */ 'ta', count(*) from ta union all select 'tb', count(*) from tb;
+show trace;
+;autocommit on
+
+
+drop table if exists ta, tb, tc, td, te;


### PR DESCRIPTION
…branches

http://jira.cubrid.org/browse/CBRD-26571

### Purpose

UNION(ALL) 문에서 PK가 있는 테이블에 대한 count(*) 최적화(PK B-tree 통계를 이용한 no-scan 처리)가
첫 번째 branch에만 적용되고, 두 번째 이후 branch부터는 풀 힙스캔으로 떨어지는 오류가 있었습니다
(CUBRID/cubrid#6958). qexec_evaluate_aggregates_optimize에서 union의 두 번째 branch부터
이미 valid한 MVCC 스냅샷을 invalidate하고 btree 통계를 재조회하지 않던 것이 원인입니다.

### Implementation

11개 케이스로 UNION 계열 집합 연산의 각 branch에 대해 PK count 최적화가 올바르게(그리고
필요한 경우에만) 적용되는지 검증합니다.

- Case 1: 2-way UNION ALL — 두 branch 모두 최적화되는지 (기본 재현)
- Case 2: 3-way UNION ALL — 3번째 branch까지 최적화가 유지되는지
- Case 3: 순수 UNION(dedup) — UNION ALL이 아닌 경우도 적용되는지
- Case 4: PK 테이블 + non-PK 테이블 혼합 — non-PK branch는 정상적으로 heap scan을 유지하는지
  (과잉 적용 방지 대조군)
- Case 5: 빈 테이블(0건) branch — count(*)=0도 최적화 + 값 정확
- Case 6: 동일 테이블을 UNION 안에서 두 번 참조 — 같은 PK btree를 반복 재조회해도 문제없는지
- Case 7: WHERE 없는(최적화 대상) branch와 WHERE 있는(비대상) branch 혼합 — 각 branch가
  독립적으로 판단되는지
- Case 8: UNION 조회 직전 DML(insert+commit) — 재획득한 MVCC 스냅샷이 최신 커밋 데이터를
  정확히 반영하는지
- Case 9: INTERSECT ALL / EXCEPT ALL — UNION뿐 아니라 INTERSECT/EXCEPT도 내부적으로 동일한
  XASL UNION proc를 공유하므로, 이 두 연산자에도 fix가 동일하게 적용되는지 확인
- Case 10: UNION ALL을 서브쿼리로 감싼 경우 — UNION이 최상위 문이 아니어도(outer에서
  order by 등으로 감싸도) branch별 최적화가 유지되는지 확인
- Case 11: UNION 조회 직전 DML(insert) 후 ROLLBACK — Case 8과 대칭으로, 커밋이 아니라
  롤백된 경우에도 재획득한 스냅샷이 원래(롤백 후) 값을 정확히 반영하는지 확인

**리뷰 반영 (2026-08-26, bagus-kim)**
- Docblock의 잘못된 케이스 참조 수정 (Case 10 -> Case 3)
- Case 11을 11-1(롤백 전)/11-2(롤백 후)로 분리 — 기존엔 롤백 후에만 조회해서 "B-tree 통계 + 현재 트랜잭션의 미커밋 변경분 보정" 로직이 한 번도 검증되지 않고 있었음
- Case 16을 16-1(NULL 없음)/16-2(NULL 키 행 포함)로 분리 — 유일 인덱스 기반 카운트가 NULL 행도 정확히 포함하는지 확인
- Case 17 추가: 파티션 PK 테이블을 UNION ALL 두 번째 분기로 — 이 fix가 처리하는 "이미 읽은 B-tree인지 확인 후 재적재"하는 반복이 단일 테이블에서는 항상 1회로 끝나므로, 여러 B-tree를 갖는 파티션 테이블로 실제 반복 경로를 검증
  (CBRD-26705 회귀 8건 중 5건이 파티션 테이블 경로였던 것과 연관)
- Case 18 추가: 힌트 없이 동일한 질의문을 서로 다른 트랜잭션에서 두 번 실행 — 이 fix가 건드리는 상태(count_state, snapshot)는 플랜이 아니라 트랜잭션에  귀속되므로, 캐시된 플랜을 재사용하는 경로도 별도로 검증 필요

### Remarks

- 올린 시점에 CUBRID 11.4.6, 11.5.0.2456-f8407ce 두 버전에서 실행 검증, 11개 케이스 모두 기대대로 동작 (결과값 정확 + 최적화 적용/미적용 여부 정확)
- 두 버전 사이에 trace 포맷 차이 발견: 11.5.0.2456-f8407ce부터는 PK count 최적화된 SCAN에도 `(parallel workers: ...)` 줄이 추가로 붙음(별개의 병렬 스캔 관련 개선으로 보이며 CBRD-26571 자체와는 무관). 최종 answer는 11.5.0.2456-f8407ce 기준으로 작성됨
- Case 11 작성 중 발견한 사항: 이 테스트 하네스는 `CCI_DEFAULT_AUTOCOMMIT=ON`으로 접속하기 때문에, 일반적인 `insert; rollback;`은 즉시 자동 커밋되어 롤백이 무효화됩니다. Case 11은 `;autocommit off` / `;autocommit on`으로 명시적으로 감싸서 실제 롤백 동작을 검증하도록 작성함 (CBRD-26571 자체와 무관한, 이 TC 작성 과정에서의 환경적 유의사항)
- table/column명은 문자(ta/tb/tc/td/te) 사용 — CTP가 trace 출력에서 숫자를 `?`로 마스킹하는  특성 때문 (cbrd_26522.sql과 동일 컨벤션)