### PR TITLE
[CBRD-27189] Extend the numbering-column view-merging testcase

### DIFF
--- a/sql/_13_issues/_26_2h/answers/cbrd_27189.answer
+++ b/sql/_13_issues/_26_2h/answers/cbrd_27189.answer
@@ -5,16 +5,91 @@
 0
 
 ===================================================
+0
+
+===================================================
 5
 
 ===================================================
-result    
-a     
+0
+
+===================================================
+40
+
+===================================================
+0
+
+===================================================
+    
+case 01 : DECODE () on the numbering column of an inline view -- NOT merged     
 
 
 ===================================================
 result    
 a     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (__t?)
+
+  rewritten query: select decode([__t?].rn, ?, [__t?].[name],  cast('WRONG' as varchar)) from (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) [__t?] ([name], rn)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 02 : the same shape written with a CTE -- NOT merged     
+
+
+===================================================
+result    
+a     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (src)
+
+  rewritten query: select decode(src.rn, ?, src.[name],  cast('WRONG' as varchar)) from (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) src ([name], rn)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 03 : the same shape through a view -- NOT merged     
 
 
 ===================================================
@@ -26,12 +101,62 @@ a
 
 
 ===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.vsort)
+
+  rewritten query: (select [dba.vsort].[name], (orderby_num()) from [dba.tsort] [dba.vsort] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (dba.vsort)
+
+  rewritten query: select decode([dba.vsort].rn, ?, [dba.vsort].[name],  cast('WRONG' as varchar)) from (select [dba.vsort].[name], (orderby_num()) from [dba.tsort] [dba.vsort] order by ? for (orderby_num())<= ?:? ) [dba.vsort] ([name], rn)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 04 : bare reference of the numbering column -- still merged     
+
+
+===================================================
 result    
 1     
 
 
 ===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.vsort)
+
+  rewritten query: select (orderby_num()), [dba.vsort].[name] from [dba.tsort] [dba.vsort] order by ? for (orderby_num())<= ?:? 
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
 0
+
+===================================================
+    
+case 05a : CASE reads the numbering column -- NOT merged     
+
 
 ===================================================
 result    
@@ -39,18 +164,134 @@ a
 
 
 ===================================================
-result    
-1     
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (__t?)
+
+  rewritten query: select case when [__t?].rn=? then [__t?].[name] else  cast('WRONG' as varchar) end from (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) [__t?] ([name], rn)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 05b : arithmetic reads the numbering column -- NOT merged     
 
 
 ===================================================
 result    
 1     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (__t?)
+
+  rewritten query: select [__t?].rn+ cast(? as bigint) from (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) [__t?] (rn, [name])
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 05c : NVL reads the numbering column -- NOT merged     
+
+
+===================================================
+result    
+1     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (__t?)
+
+  rewritten query: select nvl([__t?].rn, ?) from (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) [__t?] (rn, [name])
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 05d : concatenation reads the numbering column -- NOT merged     
 
 
 ===================================================
 result    
 x1     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (__t?)
+
+  rewritten query: select  cast('x' as varchar)|| cast([__t?].rn as varchar) from (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) [__t?] (rn, [name])
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 06 : more than one row, bare and embedded reference together -- NOT merged     
 
 
 ===================================================
@@ -61,6 +302,35 @@ rn    result
 
 
 ===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (src)
+
+  rewritten query: select src.rn, decode(src.rn, ?, 'first', 'other') from (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) src (rn, [name])
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 07 : the numbering column is not exposed -- still merged     
+
+
+===================================================
 result    
 A     
 B     
@@ -68,8 +338,205 @@ C
 
 
 ===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (src)
+
+  rewritten query: select  upper(src.[name]), src.[name] from [dba.tsort] src order by ? for (orderby_num())<= ?:? 
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 08 : the sort is resolved by an index -- NOT merged     
+
+
+===================================================
 result    
 e     
+
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (__t?.pk_tsort_code) ()
+  skip order by: true
+
+  rewritten query: (select [__t?].[name], (orderby_num()), [__t?].code from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (__t?)
+
+  rewritten query: select decode([__t?].rn, ?, [__t?].[name],  cast('WRONG' as varchar)) from (select [__t?].[name], (orderby_num()), [__t?].code from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) [__t?] ([name], rn, code)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (index: dba.tsort.pk_tsort_code), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+     
+
+
+===================================================
+    
+case 09 : CAST () reads the numbering column -- NOT merged     
+
+
+===================================================
+result    
+1     
+2     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (src)
+
+  rewritten query: select  cast(src.rn as varchar) from (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) src (rn, [name])
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 10 : a subquery of the select list reads the numbering column -- NOT merged     
+
+
+===================================================
+result    
+5     
+0     
+
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.tsort)
+
+  rewritten query: (select count(*) from [dba.tsort] [dba.tsort] where src.rn= ?:? )
+
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (src)
+
+  rewritten query: select (select count(*) from [dba.tsort] [dba.tsort] where src.rn= ?:? ) from (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) src (rn, [name])
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+case 11 : GROUPBY_NUM () read by an expression -- NOT merged     
+
+
+===================================================
+result    
+FIRST     
+OTHER     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    SORT (group by)
+      TABLE SCAN (dba.tpage)
+
+  rewritten query: (select groupby_num(), [dba.tpage].grp from [dba.tpage] [dba.tpage] group by [dba.tpage].grp order by ?)
+
+  TABLE SCAN (__t?)
+
+  rewritten query: select decode([__t?].gn, ?, 'FIRST', 'OTHER') from (select groupby_num() as [gn], [dba.tpage].grp from [dba.tpage] [dba.tpage] group by [dba.tpage].grp order by ?) [__t?] (gn, grp) where ([__t?].gn<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tpage), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+case 12 : ORDERBY_NUM () written explicitly -- NOT merged     
+
+
+===================================================
+result    
+a     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tsort)
+
+  rewritten query: (select [dba.tsort].[name], (orderby_num()) from [dba.tsort] [dba.tsort] order by ? for orderby_num()<= ?:? )
+
+  TABLE SCAN (__t?)
+
+  rewritten query: select decode([__t?].rn, ?, [__t?].[name],  cast('WRONG' as varchar)) from (select [dba.tsort].[name], (orderby_num()) as [rn] from [dba.tsort] [dba.tsort] order by ? for orderby_num()<= ?:? ) [__t?] ([name], rn)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 13 : ROWNUM of a subquery which has no ORDER BY -- still merged     
 
 
 ===================================================
@@ -80,16 +547,151 @@ OTHER
 
 
 ===================================================
-result    
-1     
-2     
+trace    
+
+Query Plan:
+  TABLE SCAN (__t?)
+
+  rewritten query: select decode((rownum), ?, 'ONE', 'OTHER') from [dba.tsort] [__t?] where ((rownum)<= ?:? )
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+case 14 : INST_NUM () inside an expression -- still merged     
 
 
 ===================================================
 result    
-5     
-0     
+n001     
 
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (__t?)
+
+  rewritten query: select decode((inst_num()), ?, [__t?].[name],  cast('WRONG' as varchar)) from [dba.tpage] [__t?] where (inst_num()<= ?:? )
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tpage), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+case 15 : ORDER BY on the numbering column -- NOT merged     
+
+
+===================================================
+result    
+c     
+b     
+a     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: select [__t?].[name], [__t?].rn from (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) [__t?] ([name] as [result], rn) order by ? desc 
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 16 : GROUP BY / HAVING on the numbering column -- NOT merged     
+
+
+===================================================
+result    
+b     
+c     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  SORT (group by)
+    TABLE SCAN (__t?)
+
+  rewritten query: select max([__t?].[name]) from (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) [__t?] ([name], rn) where ([__t?].rn> ?:? ) group by [__t?].rn
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 17 : the numbering column is read only by WHERE -- still merged, folded into TOP-N     
+
+
+===================================================
+result    
+n007     
+n008     
+n009     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: select [__t?].[name] from [dba.tpage] [__t?] order by ? for (orderby_num())>= ?:?  and (orderby_num())< ?:? 
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tpage), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+0
+
+===================================================
+0
 
 ===================================================
 0

--- a/sql/_13_issues/_26_2h/cases/cbrd_27189.sql
+++ b/sql/_13_issues/_26_2h/cases/cbrd_27189.sql
@@ -1,84 +1,169 @@
 /**
- * This test case verifies CBRD-27189: a numbering column (ROWNUM/ORDERBY_NUM())
- * of a subquery(view) must not be exposed to an expression of the main query
- * when the subquery is merged into it. Such a value is only settled after the
- * sort of the subquery is done, so an expression reading it produced a wrong
- * result.
+ * This test case verifies CBRD-27189: a numbering column (ROWNUM/ORDERBY_NUM()/
+ * GROUPBY_NUM()) of a subquery(view) must not be exposed to an expression of the
+ * main query when the subquery is merged into it. Such a value is only settled
+ * after the sort (or grouping) of the subquery is done, so an expression reading
+ * it produced a wrong result.
  *
- * Coverage:
- * 1. Main repro - DECODE () on the numbering column of an inline view.
- * 2. Same shape through a CTE.
- * 3. Same shape through a view.
- * 4. CASE/arithmetic/NVL/concatenation on the numbering column.
- * 5. Bare reference of the numbering column keeps working (still merged).
- * 6. Numbering not exposed as a column keeps being merged.
- * 7. Sort resolved by an index (no real sort).
- * 8. ROWNUM of a subquery without ORDER BY.
- * 9. CAST () on the numbering column.
- * 10. A subquery of the select list reads the numbering column.
+ * Every case prints, via evaluate (), whether the subquery is expected to be
+ * merged, and is followed by show trace. The "rewritten query:" line of the
+ * trace is what actually proves it: a merged query is flat, a blocked one keeps
+ * the derived table. Result values alone cannot tell the two apart, so without
+ * the trace this test could not detect over-blocking -- merging that stops
+ * happening where it still should.
+ *
+ * Table names are letter-only on purpose: digits inside the trace block are
+ * masked to '?', so t1/t2 would both render as "t?" and become indistinguishable.
+ *
+ * Coverage
+ *   NOT merged (the fix blocks it)
+ *     01 DECODE () on the numbering column of an inline view -- the main repro
+ *     02 the same shape through a CTE
+ *     03 the same shape through a view
+ *     05 CASE / arithmetic / NVL / concatenation
+ *     06 more than one row, bare and embedded reference together
+ *     08 sort resolved by an index (no real sort needed)
+ *     09 CAST ()
+ *     10 a subquery of the select list reads the numbering column
+ *     11 GROUPBY_NUM () instead of ORDERBY_NUM ()
+ *     12 ORDERBY_NUM () written explicitly instead of ROWNUM
+ *     15 ORDER BY on the numbering column
+ *     16 GROUP BY / HAVING on the numbering column
+ *   still merged (the fix must NOT block it)
+ *     04 bare reference of the numbering column
+ *     07 the numbering column is not exposed at all
+ *     13 ROWNUM of a subquery which has no ORDER BY
+ *     14 INST_NUM (), evaluated during the scan, so safe inside an expression
+ *     17 the numbering column is read only by WHERE -> folded into TOP-N.
+ *        Deliberately excluded from the check by the fix; including it broke
+ *        the pagination plans of cbrd_24258 / cbrd_26257.
  */
 
 --+ server-message on
 
-DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS tsort;
+DROP TABLE IF EXISTS tpage;
 
-CREATE TABLE t1 (name VARCHAR(20), code INT PRIMARY KEY);
-INSERT INTO t1 VALUES ('e', 1), ('d', 2), ('c', 3), ('b', 4), ('a', 5);
+CREATE TABLE tsort (name VARCHAR(20), code INT PRIMARY KEY);
+INSERT INTO tsort VALUES ('e', 1), ('d', 2), ('c', 3), ('b', 4), ('a', 5);
 
--- 1. main repro: DECODE () reads the numbering column of an inline view
+-- tpage carries enough rows for the pagination and grouping cases below
+CREATE TABLE tpage (name VARCHAR(20), code INT PRIMARY KEY, grp INT);
+INSERT INTO tpage
+SELECT 'n' || LPAD(CAST(ROWNUM AS VARCHAR), 3, '0'), ROWNUM, MOD(ROWNUM, 5)
+  FROM db_class a, db_class b LIMIT 40;
+
+set trace on;
+
+evaluate 'case 01 : DECODE () on the numbering column of an inline view -- NOT merged';
 SELECT DECODE(rn, 1, name, 'WRONG') AS result
-FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM t1 ORDER BY name) WHERE ROWNUM <= 1);
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 1);
+show trace;
 
--- 2. the same shape written with a CTE
+evaluate 'case 02 : the same shape written with a CTE -- NOT merged';
 WITH src AS (
-    SELECT name, ROWNUM AS rn FROM (SELECT name FROM t1 ORDER BY name) WHERE ROWNUM <= 1
+    SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 1
 )
 SELECT DECODE(rn, 1, name, 'WRONG') AS result FROM src;
+show trace;
 
--- 3. the same shape through a view
-CREATE OR REPLACE VIEW v1 AS
-    SELECT name, ROWNUM AS rn FROM (SELECT name FROM t1 ORDER BY name) WHERE ROWNUM <= 1;
-SELECT DECODE(rn, 1, name, 'WRONG') AS result FROM v1;
-SELECT rn AS result FROM v1;
-DROP VIEW v1;
+evaluate 'case 03 : the same shape through a view -- NOT merged';
+CREATE OR REPLACE VIEW vsort AS
+    SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 1;
+SELECT DECODE(rn, 1, name, 'WRONG') AS result FROM vsort;
+show trace;
 
--- 4. other expressions reading the numbering column
+evaluate 'case 04 : bare reference of the numbering column -- still merged';
+SELECT rn AS result FROM vsort;
+show trace;
+DROP VIEW vsort;
+
+evaluate 'case 05a : CASE reads the numbering column -- NOT merged';
 SELECT CASE WHEN rn = 1 THEN name ELSE 'WRONG' END AS result
-FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM t1 ORDER BY name) WHERE ROWNUM <= 1);
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 1);
+show trace;
 
+evaluate 'case 05b : arithmetic reads the numbering column -- NOT merged';
 SELECT rn + 0 AS result
-FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM t1 ORDER BY name) WHERE ROWNUM <= 1);
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 1);
+show trace;
 
+evaluate 'case 05c : NVL reads the numbering column -- NOT merged';
 SELECT NVL(rn, 0) AS result
-FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM t1 ORDER BY name) WHERE ROWNUM <= 1);
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 1);
+show trace;
 
+evaluate 'case 05d : concatenation reads the numbering column -- NOT merged';
 SELECT 'x' || rn AS result
-FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM t1 ORDER BY name) WHERE ROWNUM <= 1);
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 1);
+show trace;
 
--- 5. more than one row, both the bare and the embedded reference
+evaluate 'case 06 : more than one row, bare and embedded reference together -- NOT merged';
 SELECT rn, DECODE(rn, 1, 'first', 'other') AS result
-FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM t1 ORDER BY name) WHERE ROWNUM <= 3) src;
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 3) src;
+show trace;
 
--- 6. the numbering column is not exposed, so the query is still merged
+evaluate 'case 07 : the numbering column is not exposed -- still merged';
 SELECT UPPER(name) AS result
-FROM (SELECT name FROM (SELECT name FROM t1 ORDER BY name) WHERE ROWNUM <= 3) src;
+FROM (SELECT name FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 3) src;
+show trace;
 
--- 7. the sort is resolved by an index
+evaluate 'case 08 : the sort is resolved by an index -- NOT merged';
 SELECT DECODE(rn, 1, name, 'WRONG') AS result
-FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM t1 ORDER BY code) WHERE ROWNUM <= 1);
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY code) WHERE ROWNUM <= 1);
+show trace;
 
--- 8. ROWNUM of a subquery which has no ORDER BY
-SELECT DECODE(rn, 1, 'ONE', 'OTHER') AS result
-FROM (SELECT ROWNUM AS rn, name FROM t1) WHERE rn <= 3;
-
--- 9. CAST () reads the numbering column
+evaluate 'case 09 : CAST () reads the numbering column -- NOT merged';
 SELECT CAST(rn AS VARCHAR) AS result
-FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM t1 ORDER BY name) WHERE ROWNUM <= 2) src;
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 2) src;
+show trace;
 
--- 10. a subquery of the select list reads the numbering column
-SELECT (SELECT COUNT(*) FROM t1 WHERE src.rn = 1) AS result
-FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM t1 ORDER BY name) WHERE ROWNUM <= 2) src;
+evaluate 'case 10 : a subquery of the select list reads the numbering column -- NOT merged';
+SELECT (SELECT COUNT(*) FROM tsort WHERE src.rn = 1) AS result
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 2) src;
+show trace;
 
-DROP TABLE t1;
+evaluate 'case 11 : GROUPBY_NUM () read by an expression -- NOT merged';
+SELECT DECODE(gn, 1, 'FIRST', 'OTHER') AS result
+FROM (SELECT grp, GROUPBY_NUM() AS gn FROM tpage GROUP BY grp ORDER BY grp) WHERE gn <= 2;
+show trace;
+
+evaluate 'case 12 : ORDERBY_NUM () written explicitly -- NOT merged';
+SELECT DECODE(rn, 1, name, 'WRONG') AS result
+FROM (SELECT name, ORDERBY_NUM() AS rn FROM tsort ORDER BY name FOR ORDERBY_NUM() <= 1);
+show trace;
+
+evaluate 'case 13 : ROWNUM of a subquery which has no ORDER BY -- still merged';
+SELECT DECODE(rn, 1, 'ONE', 'OTHER') AS result
+FROM (SELECT ROWNUM AS rn, name FROM tsort) WHERE rn <= 3;
+show trace;
+
+evaluate 'case 14 : INST_NUM () inside an expression -- still merged';
+SELECT DECODE(rn, 1, name, 'WRONG') AS result
+FROM (SELECT name, INST_NUM() AS rn FROM tpage WHERE INST_NUM() <= 1);
+show trace;
+
+evaluate 'case 15 : ORDER BY on the numbering column -- NOT merged';
+SELECT name AS result
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 3)
+ORDER BY rn DESC;
+show trace;
+
+evaluate 'case 16 : GROUP BY / HAVING on the numbering column -- NOT merged';
+SELECT MAX(name) AS result
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 3)
+GROUP BY rn HAVING rn > 1;
+show trace;
+
+evaluate 'case 17 : the numbering column is read only by WHERE -- still merged, folded into TOP-N';
+SELECT name AS result
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tpage ORDER BY name))
+WHERE rn >= 7 AND rn < 10;
+show trace;
+
+set trace off;
+
+DROP TABLE tsort;
+DROP TABLE tpage;
 
 --+ server-message off


### PR DESCRIPTION
- Issue: http://jira.cubrid.org/browse/CBRD-27189
- Engine PR: https://github.com/CUBRID/cubrid/pull/7686
- 선행 TC PR: https://github.com/CUBRID/cubrid-testcases/pull/3251

## Purpose

#3251 로 추가된 `cbrd_27189` 를 확장한다. 기존 TC 는 결과값만 비교하는데, **과차단(over-blocking)을 결과값으로는 탐지할 수 없다.**

수정의 본질은 뷰 머징을 막는 것이고, 엔진 PR 본문 절반이 "필요한 곳만 막았는가"에 할애돼 있다(#7628 이 과차단이라 재작업했고, 167건 플랜 회귀 검사를 붙였다). 그런데 **머징이 합법인 경우에는 머징을 하든 안 하든 결과값이 같으므로, 과차단은 결과값 비교에 전혀 나타나지 않는다.**

실측 확인 — 수정 전 빌드(11.5.0.2437-9eb142d)에서 케이스 08:

```
case 08 의 답지 블록 (케이스마다 라벨 / 결과값 / trace 3개)
  evaluate 라벨   동일
  결과값 'e'      동일   <- 값으로는 구분 불가
  trace           상이   <- rewritten query 가 다름 (수정 전 머징 / 수정 후 차단)
```

케이스 08(인덱스로 정렬이 해소되는 대조군)은 수정 전에는 머징됐고 수정 후 차단된다. 기존 TC 였다면 **조용히 통과**했을 회귀다.

## Changes

### 1. `show trace` 추가 (케이스마다)

답지에서 trace 의 숫자는 `?` 로 마스킹되지만 **`rewritten query:` 는 원문 보존**된다. 머징되면 평탄한 질의, 차단되면 파생 테이블이 남는다.

```
-- 머징됨
rewritten query: select upper(src.[name]), src.[name] from [dba.tsort] src order by ? for (orderby_num())<= ?:?
-- 차단됨
rewritten query: select decode([__t?].rn, ?, ...) from (select ... from [dba.tsort] ...) [__t?] ([name], rn)
```

답지에 `rewritten query` 36 건이 기록되며, 이제 답지 diff 만으로 과차단이 잡힌다.

### 2. `evaluate ()` 라벨 + 기대 머징 여부

```sql
evaluate 'case 01 : DECODE () on the numbering column of an inline view -- NOT merged';
```

라벨이 답지에도 남아 어느 결과가 어느 케이스인지, 무엇을 기대하는지 답지만 봐도 읽힌다. **라벨 20 건과 실제 머징 여부를 전수 대조해 20/20 일치를 확인했다.**

### 3. 시나리오 확장 (10 → 17 케이스)

| 신규 | 내용 | 머징 |
|---|---|---|
| 11 | `GROUPBY_NUM ()` 을 표현식이 읽음 | 차단 |
| 12 | `ORDERBY_NUM ()` 명시적 작성 | 차단 |
| 13 | ORDER BY 없는 서브쿼리의 `ROWNUM` | 유지 |
| 14 | `INST_NUM ()` 표현식 내부 | 유지 |
| 15 | `ORDER BY rn` | 차단 |
| 16 | `GROUP BY rn HAVING rn > ?` | 차단 |
| 17 | WHERE 전용 참조 → TOP-N 변환 | 유지 |

케이스 17은 엔진 PR 에 WHERE 를 **의도적으로 검사에서 제외**했고, 포함하면 `cbrd_24258`/`cbrd_26257` 의 페이지네이션 플랜이 깨진다고 본문에 적혀 있다. 그 결정을 지키는 TC 가 없었다.

케이스 13·14 는 수정 범위의 **경계선**이다. `ROWNUM`/`INST_NUM` 만 담은 컬럼은 스캔 중 평가되므로 표현식에 들어가도 안전하고 머징이 유지돼야 한다. 과차단 회귀가 가장 먼저 나타날 지점이다.

### 4. 테이블명을 문자만으로 변경 (`t1` → `tsort`, 신규 `tpage`, `v1` → `vsort`)

trace 블록 안에서 숫자는 `?` 로 마스킹된다. `t1`·`t2` 는 둘 다 `t?` 가 되어 답지에서 구분이 불가능하다. 페이지네이션·그룹핑 케이스용으로 40 행짜리 `tpage` 를 추가했다.

## Verification

| 빌드 | 수정 | CTP |
|---|---|---|
| 11.5.0.2456-f8407ce | 포함 | **OK** (3 회, trace 출력 안정성 확인) |
| 11.5.0.2437-9eb142d | 미포함 | **NOK** |

수정 전 빌드에서 탐지된 내역:

| 탐지 근거 | 케이스 | 수정 전 값 |
|---|---|---|
| 값 + 머징 | 01, 02, 03, 05a~d, 06, 09, 10 (10 건) | `'WRONG'`, `0`, `'x0'`, `'0','0'`, `0,0`, `1 other` |
| **머징만** | **08** | 결과는 `'e'` 로 동일 |
| 변화 없음 | 04, 07, 11~17 | — |

오답값이 JIRA·엔진 PR 본문의 develop 실측값과 모두 일치한다. "변화 없음" 7 건은 **과차단이 없었음**을 확인해 준다.

## Notes for reviewers

- **케이스 11·12 는 회귀 탐지력이 없다.** 수정 전후로 값도 머징 여부도 동일하다 — 이 형태는 애초에 다른 이유로 머징되지 않고 있었다. `PT_IS_GROUPBYNUM` 분기를 밟는 유일한 케이스이므로 **향후 변경에 대한 고정 장치**로만 가치가 있다. 
- 오답 케이스가 늘어난 것이 아니라 **탐지 수단이 늘어난 것**이다. 케이스 01~10 의 검증력은 #3251 과 동일하다.