### PR TITLE
[CBRD-27200] Add SQL testcase for constant TRUE predicates and view merging

### DIFF
--- a/sql/_13_issues/_26_2h/answers/cbrd_27200.answer
+++ b/sql/_13_issues/_26_2h/answers/cbrd_27200.answer
@@ -1,0 +1,2130 @@
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+5
+
+===================================================
+0
+
+===================================================
+5
+
+===================================================
+0
+
+===================================================
+    
+A00 : no predicate (baseline) -- merged     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+A01 : WHERE TRUE -- merged (already before the fix)     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+A02 : WHERE 1=1 -- merged (the reported case)     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+A03 : WHERE 'a'='a' -- merged     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+A04 : WHERE 1=1 AND 2=2 -- merged     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+A05 : WHERE 2>1 -- merged     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+A06 : WHERE NOT (1=0) -- merged     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+A07 : WHERE 'abc' LIKE 'abc' -- merged     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+A08 : WHERE 1=1 AND 'x'='x' AND 3>2 -- merged     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+A09 : WHERE 1=1 OR v.a > 0 -- merged (folds to a single TRUE)     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+A10 : WHERE CAST(1 AS INT)=1 -- NOT merged (not folded; the boundary of this change)     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (left outer join)
+    TABLE SCAN (dba.tleft)
+    TABLE SCAN (dba.tright)
+
+  rewritten query: (select [dba.tleft].a, [dba.tright].y from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x)
+
+  SORT (order by)
+    TABLE SCAN (v)
+
+  rewritten query: select v.a, v.b from (select [dba.tleft].a as [a], [dba.tright].y as [b] from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x) v (a, b) where  cast(? as integer)=? order by ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+A11 : WHERE 1 IN (1,2) -- merged     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+A12 : WHERE 'a' IS NOT NULL -- merged     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+A13 : WHERE 1=1 AND TRUE -- merged     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+A14 : WHERE 1<>0 -- merged     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+A15 : WHERE 3 BETWEEN 1 AND 5 -- merged     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+A16 : WHERE 1=1 only INSIDE the view, none outside -- merged     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+B01 : WHERE v.a > 0 -- NOT merged     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (left outer join)
+    TABLE SCAN (dba.tleft)
+    TABLE SCAN (dba.tright)
+
+  rewritten query: (select [dba.tleft].a, [dba.tright].y from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x where ([dba.tleft].a> ?:? ))
+
+  SORT (order by)
+    TABLE SCAN (v)
+
+  rewritten query: select v.a, v.b from (select [dba.tleft].a as [a], [dba.tright].y as [b] from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x where ([dba.tleft].a> ?:? )) v (a, b) order by ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+B02 : WHERE 1=1 AND v.a > 0 -- NOT merged (a real conjunct remains)     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (left outer join)
+    TABLE SCAN (dba.tleft)
+    TABLE SCAN (dba.tright)
+
+  rewritten query: (select [dba.tleft].a, [dba.tright].y from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x where ([dba.tleft].a> ?:? ))
+
+  SORT (order by)
+    TABLE SCAN (v)
+
+  rewritten query: select v.a, v.b from (select [dba.tleft].a as [a], [dba.tright].y as [b] from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x where ([dba.tleft].a> ?:? )) v (a, b) order by ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+B03 : WHERE 1=0 -- always false, no plan is produced     
+
+
+===================================================
+a    b    
+
+
+===================================================
+trace    
+null     
+
+
+===================================================
+    
+B04 : WHERE v.a = NULL -- unknown, no plan is produced     
+
+
+===================================================
+a    b    
+
+
+===================================================
+trace    
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dual), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+B05 : WHERE ROWNUM <= 2 -- merged (rownum-only predicate path)     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (left outer join)
+    TABLE SCAN (v)
+    TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x where (rownum<= ?:? )
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+B06 : WHERE v.a IN (subquery) -- NOT merged     
+
+
+===================================================
+a    b    
+1     100     
+3     300     
+
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (left outer join)
+    TABLE SCAN (dba.tleft)
+    TABLE SCAN (dba.tright)
+
+  rewritten query: (select [dba.tleft].a, [dba.tright].y from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x)
+
+  SORT (distinct)
+    TABLE SCAN (dba.tright)
+
+  rewritten query: (select distinct [dba.tright].x from [dba.tright] [dba.tright])
+
+  SORT (order by)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (v)
+      TABLE SCAN (av?)
+
+  rewritten query: select v.a, v.b from (select [dba.tleft].a as [a], [dba.tright].y as [b] from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x) v (a, b), (select distinct [dba.tright].x from [dba.tright] [dba.tright]) av? (av_?) where v.a=av?.av_? order by ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (hash temp(m), build time: ?, time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+             (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+B07 : WHERE v.a IS NOT NULL -- NOT merged     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (left outer join)
+    TABLE SCAN (dba.tleft)
+    TABLE SCAN (dba.tright)
+
+  rewritten query: (select [dba.tleft].a, [dba.tright].y from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x where [dba.tleft].a is not null )
+
+  SORT (order by)
+    TABLE SCAN (v)
+
+  rewritten query: select v.a, v.b from (select [dba.tleft].a as [a], [dba.tright].y as [b] from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x where [dba.tleft].a is not null ) v (a, b) order by ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+B08 : WHERE v.b IS NULL -- NOT merged (filters outer-join NULL-extended rows)     
+
+
+===================================================
+a    b    
+2     null     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (left outer join)
+    TABLE SCAN (dba.tleft)
+    TABLE SCAN (dba.tright)
+
+  rewritten query: (select [dba.tleft].a, [dba.tright].y from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x where [dba.tright].y is null )
+
+  SORT (order by)
+    TABLE SCAN (v)
+
+  rewritten query: select v.a, v.b from (select [dba.tleft].a as [a], [dba.tright].y as [b] from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x where [dba.tright].y is null ) v (a, b) order by ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+B09 : WHERE 1=1 AND v.b IS NULL -- NOT merged     
+
+
+===================================================
+a    b    
+2     null     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (left outer join)
+    TABLE SCAN (dba.tleft)
+    TABLE SCAN (dba.tright)
+
+  rewritten query: (select [dba.tleft].a, [dba.tright].y from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x where [dba.tright].y is null )
+
+  SORT (order by)
+    TABLE SCAN (v)
+
+  rewritten query: select v.a, v.b from (select [dba.tleft].a as [a], [dba.tright].y as [b] from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x where [dba.tright].y is null ) v (a, b) order by ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+B10 : WHERE 0=1 OR v.a > 3 -- NOT merged     
+
+
+===================================================
+a    b    
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (left outer join)
+    TABLE SCAN (dba.tleft)
+    TABLE SCAN (dba.tright)
+
+  rewritten query: (select [dba.tleft].a, [dba.tright].y from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x where ([dba.tleft].a> ?:? ))
+
+  SORT (order by)
+    TABLE SCAN (v)
+
+  rewritten query: select v.a, v.b from (select [dba.tleft].a as [a], [dba.tright].y as [b] from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x where ([dba.tleft].a> ?:? )) v (a, b) order by ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+B11 : WHERE NULL = NULL -- unknown, no plan is produced     
+
+
+===================================================
+a    b    
+
+
+===================================================
+trace    
+null     
+
+
+===================================================
+    
+B12 : WHERE 1=1 AND ROWNUM <= 2 -- merged (already before the fix)     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (left outer join)
+    TABLE SCAN (v)
+    TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x where (rownum<= ?:? )
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+B13 : WHERE v.a = v.a -- NOT merged (column reference, not a constant)     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (left outer join)
+    TABLE SCAN (dba.tleft)
+    TABLE SCAN (dba.tright)
+
+  rewritten query: (select [dba.tleft].a, [dba.tright].y from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x where [dba.tleft].a=[dba.tleft].a)
+
+  SORT (order by)
+    TABLE SCAN (v)
+
+  rewritten query: select v.a, v.b from (select [dba.tleft].a as [a], [dba.tright].y as [b] from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x where [dba.tleft].a=[dba.tleft].a) v (a, b) order by ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+C01 : inner join view -- merged     
+
+
+===================================================
+a    b    
+1     100     
+3     300     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v, [dba.tright] [dba.tright] where v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+C02 : right outer join view -- merged     
+
+
+===================================================
+a    b    
+null     900     
+null     1000     
+null     2000     
+1     100     
+3     300     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (dba.tright)
+      TABLE SCAN (v)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v right outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+C03 : GROUP BY view -- NOT merged (blocked by another rule)     
+
+
+===================================================
+a    b    
+1     1     
+2     1     
+3     1     
+4     1     
+5     1     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.tleft)
+
+  rewritten query: (select [dba.tleft].a, count(*) from [dba.tleft] [dba.tleft] group by [dba.tleft].a)
+
+  SORT (order by)
+    TABLE SCAN (v)
+
+  rewritten query: select v.a, v.b from (select [dba.tleft].a as [a], count(*) as [b] from [dba.tleft] [dba.tleft] group by [dba.tleft].a) v (a, b) order by ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+C04 : ORDER BY view -- merged     
+
+
+===================================================
+a    b    
+1     10     
+2     null     
+3     30     
+4     null     
+5     50     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (v)
+
+  rewritten query: select v.a, v.b from [dba.tleft] v order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+C05 : DISTINCT view -- NOT merged     
+
+
+===================================================
+a    b    
+1     10     
+2     null     
+3     30     
+4     null     
+5     50     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    TABLE SCAN (dba.tleft)
+
+  rewritten query: (select distinct [dba.tleft].a, [dba.tleft].b from [dba.tleft] [dba.tleft])
+
+  SORT (order by)
+    TABLE SCAN (v)
+
+  rewritten query: select v.a, v.b from (select distinct [dba.tleft].a as [a], [dba.tleft].b as [b] from [dba.tleft] [dba.tleft]) v (a, b) order by ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+C06 : UNION ALL view -- NOT merged     
+
+
+===================================================
+a    b    
+1     10     
+1     100     
+2     null     
+3     30     
+3     300     
+4     null     
+5     50     
+9     900     
+10     1000     
+20     2000     
+
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.tleft)
+
+  rewritten query: select [dba.tleft].a, [dba.tleft].b from [dba.tleft] [dba.tleft]
+
+  TABLE SCAN (dba.tright)
+
+  rewritten query: select [dba.tright].x, [dba.tright].y from [dba.tright] [dba.tright]
+
+  SORT (order by)
+    TABLE SCAN (v)
+
+  rewritten query: select v.a, v.b from (select [dba.tleft].a, [dba.tleft].b from [dba.tleft] [dba.tleft] union all select [dba.tright].x, [dba.tright].y from [dba.tright] [dba.tright]) v (a, b) order by ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+C07 : ROWNUM inside the view -- merged     
+
+
+===================================================
+a    b    
+1     10     
+2     null     
+3     30     
+4     null     
+5     50     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (v)
+
+  rewritten query: select (rownum), v.b from [dba.tleft] v order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+C08 : ORDER BY + LIMIT view -- NOT merged     
+
+
+===================================================
+a    b    
+1     10     
+2     null     
+3     30     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tleft)
+
+  rewritten query: (select [dba.tleft].a, [dba.tleft].b from [dba.tleft] [dba.tleft] order by ? for orderby_num()<= ?:? )
+
+  SORT (order by)
+    TABLE SCAN (v)
+
+  rewritten query: select v.a, v.b from (select [dba.tleft].a as [a], [dba.tleft].b as [b] from [dba.tleft] [dba.tleft] order by ? for orderby_num()<= ?:? ) v (a, b) order by ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+C09 : no join, plain view -- merged     
+
+
+===================================================
+a    b    
+1     10     
+2     null     
+3     30     
+4     null     
+5     50     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (v)
+
+  rewritten query: select v.a, v.b from [dba.tleft] v order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+C10 : two nested outer joins -- merged     
+
+
+===================================================
+a    b    c    
+1     100     100     
+2     null     null     
+3     300     300     
+4     null     null     
+5     null     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      NESTED LOOPS (left outer join)
+        TABLE SCAN (v)
+        TABLE SCAN (dba.tright)
+      TABLE SCAN (tright_b)
+
+  rewritten query: select v.a, [dba.tright].y, tright_b.y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x left outer join [dba.tright] tright_b on v.a=tright_b.x order by ?, ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+C11 : outer join + aggregate -- NOT merged     
+
+
+===================================================
+a    b    
+1     1     
+2     0     
+3     1     
+4     0     
+5     0     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (dba.tleft)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: (select [dba.tleft].a, count([dba.tright].y) from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x group by [dba.tleft].a)
+
+  SORT (order by)
+    TABLE SCAN (v)
+
+  rewritten query: select v.a, v.b from (select [dba.tleft].a as [a], count([dba.tright].y) as [b] from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x group by [dba.tleft].a) v (a, b) order by ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+C12 : named view over an outer join -- merged     
+
+
+===================================================
+0
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (dba.v_oj)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select [dba.v_oj].a, [dba.tright].y from [dba.tleft] [dba.v_oj] left outer join [dba.tright] [dba.tright] on [dba.v_oj].a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+C13 : view on top of a view -- merged     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+0
+
+===================================================
+    
+C14 : expression in the view select list -- merged     
+
+
+===================================================
+a    b    
+2     100     
+4     null     
+6     300     
+8     null     
+10     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select (v.a*?), [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+C15 : CTE instead of an inline view -- merged on develop; 11.4 keeps the CTE spec     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (cte)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select cte.a, [dba.tright].y from [dba.tleft] cte left outer join [dba.tright] [dba.tright] on cte.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+D01 : outer ORDER BY -- merged     
+
+
+===================================================
+a    b    
+5     null     
+4     null     
+3     300     
+2     null     
+1     100     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ? desc , ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+D02 : outer GROUP BY -- merged     
+
+
+===================================================
+a    count(*)    
+1     1     
+2     1     
+3     1     
+4     1     
+5     1     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, count(*) from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x group by v.a
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+D03 : outer ORDER BY ... LIMIT -- merged     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      SORT (limit)
+        TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ? for orderby_num()<= ?:? 
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, topnsort: true)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+D04 : outer COUNT(*) -- merged     
+
+
+===================================================
+count(*)    
+5     
+
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (left outer join)
+    TABLE SCAN (v)
+    TABLE SCAN (dba.tright)
+
+  rewritten query: select count(*) from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+D05 : outer DISTINCT -- merged     
+
+
+===================================================
+a    
+1     
+2     
+3     
+4     
+5     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select distinct v.a from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+D06 : partial column selection -- merged     
+
+
+===================================================
+b    
+null     
+null     
+null     
+100     
+300     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+D07 : outer GROUP BY ... HAVING -- merged     
+
+
+===================================================
+a    count(*)    
+1     1     
+2     1     
+3     1     
+4     1     
+5     1     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    SORT (group by)
+      NESTED LOOPS (left outer join)
+        TABLE SCAN (v)
+        TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, count(*) from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x group by v.a having count(*)>=? order by ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+D08 : expression in the outer select list -- merged     
+
+
+===================================================
+v.a*2    
+2     
+4     
+6     
+8     
+10     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a*? from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+D09 : ORDER BY a nullable outer-join column -- merged     
+
+
+===================================================
+a    b    
+2     null     
+4     null     
+5     null     
+1     100     
+3     300     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+D10 : HAVING 1=1 -- merged (HAVING is not the predicate list being checked)     
+
+
+===================================================
+a    count(*)    
+1     1     
+2     1     
+3     1     
+4     1     
+5     1     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, count(*) from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x group by v.a
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+D11 : the view is not the only spec of the main query -- NOT merged     
+
+
+===================================================
+a    b    x    y    
+1     100     1     100     
+3     300     3     300     
+
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (left outer join)
+    TABLE SCAN (dba.tleft)
+    TABLE SCAN (dba.tright)
+
+  rewritten query: (select [dba.tleft].a, [dba.tright].y from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x)
+
+  SORT (order by)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (v)
+      TABLE SCAN (w)
+
+  rewritten query: select v.a, v.b, w.x, w.y from (select [dba.tleft].a as [a], [dba.tright].y as [b] from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x) v (a, b), [dba.tright] w where v.a=w.x order by ?, ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+D12 : the same two specs without any constant predicate -- NOT merged either     
+
+
+===================================================
+a    b    x    y    
+1     100     1     100     
+3     300     3     300     
+
+
+===================================================
+trace    
+
+Query Plan:
+  NESTED LOOPS (left outer join)
+    TABLE SCAN (dba.tleft)
+    TABLE SCAN (dba.tright)
+
+  rewritten query: (select [dba.tleft].a, [dba.tright].y from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x)
+
+  SORT (order by)
+    NESTED LOOPS (inner join)
+      TABLE SCAN (v)
+      TABLE SCAN (w)
+
+  rewritten query: select v.a, v.b, w.x, w.y from (select [dba.tleft].a as [a], [dba.tright].y as [b] from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x) v (a, b), [dba.tright] w where v.a=w.x order by ?, ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+0
+
+===================================================
+    
+E01 : UPDATE ... WHERE a IN (inline view ... WHERE 1=1)     
+
+
+===================================================
+5
+
+===================================================
+a    b    
+1     11     
+2     null     
+3     31     
+4     null     
+5     51     
+
+
+===================================================
+    
+E02 : DELETE ... WHERE a IN (inline view ... WHERE 1=1)     
+
+
+===================================================
+1
+
+===================================================
+a    b    
+1     11     
+2     null     
+3     31     
+4     null     
+
+
+===================================================
+    
+E03 : INSERT ... SELECT ... WHERE 1=1     
+
+
+===================================================
+4
+
+===================================================
+a    b    c    
+1     11     p     
+2     null     q     
+3     31     null     
+4     null     null     
+101     11     z     
+102     null     z     
+103     31     z     
+104     null     z     
+
+
+===================================================
+    
+E04 : a view that itself contains WHERE 1=1     
+
+
+===================================================
+0
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+101     null     
+102     null     
+103     null     
+104     null     
+
+
+===================================================
+    
+E05 : the same view with an outer predicate     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+
+
+===================================================
+0
+
+===================================================
+    
+E06 : scalar subquery containing WHERE 1=1     
+
+
+===================================================
+cnt    
+8     
+
+
+===================================================
+    
+E07 : UNION ALL of two inline views with WHERE 1=1     
+
+
+===================================================
+a    
+1     
+1     
+2     
+3     
+3     
+4     
+9     
+10     
+20     
+101     
+102     
+103     
+104     
+
+
+===================================================
+    
+E08 : row count through the inline view     
+
+
+===================================================
+count(*)    
+8     
+
+
+===================================================
+    
+E09 : outer join NULL-extended rows are preserved     
+
+
+===================================================
+count(*)    
+6     
+
+
+===================================================
+    
+E10 : always-false predicate returns no rows     
+
+
+===================================================
+count(*)    
+0     
+
+
+===================================================
+0
+
+===================================================
+0
+

--- a/sql/_13_issues/_26_2h/answers/cbrd_27200.answer
+++ b/sql/_13_issues/_26_2h/answers/cbrd_27200.answer
@@ -704,13 +704,16 @@ Trace Statistics:
 
 ===================================================
     
-B05 : WHERE ROWNUM <= 2 -- merged (rownum-only predicate path)     
+B05 : WHERE ROWNUM <= 5 -- merged (rownum-only predicate path)     
 
 
 ===================================================
 a    b    
 1     100     
 2     null     
+3     300     
+4     null     
+5     null     
 
 
 ===================================================
@@ -953,13 +956,16 @@ null
 
 ===================================================
     
-B12 : WHERE 1=1 AND ROWNUM <= 2 -- merged (already before the fix)     
+B12 : WHERE 1=1 AND ROWNUM <= 5 -- merged (already before the fix)     
 
 
 ===================================================
 a    b    
 1     100     
 2     null     
+3     300     
+4     null     
+5     null     
 
 
 ===================================================
@@ -1560,6 +1566,75 @@ Trace Statistics:
 
 ===================================================
     
+C16 : the same ORDER BY + LIMIT view as C08, without the outer ORDER BY -- NOT merged     
+
+
+===================================================
+a    b    
+1     10     
+2     null     
+3     30     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tleft)
+
+  rewritten query: (select [dba.tleft].a, [dba.tleft].b from [dba.tleft] [dba.tleft] order by ? for orderby_num()<= ?:? )
+
+  TABLE SCAN (v)
+
+  rewritten query: select v.a, v.b from (select [dba.tleft].a as [a], [dba.tleft].b as [b] from [dba.tleft] [dba.tleft] order by ? for orderby_num()<= ?:? ) v (a, b)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+C17 : constant TRUE at both nesting levels of a doubly nested view -- merged     
+
+
+===================================================
+a    b    
+1     100     
+2     null     
+3     300     
+4     null     
+5     null     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    NESTED LOOPS (left outer join)
+      TABLE SCAN (v)
+      TABLE SCAN (dba.tright)
+
+  rewritten query: select v.a, [dba.tright].y from [dba.tleft] v left outer join [dba.tright] [dba.tright] on v.a=[dba.tright].x order by ?, ?
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tleft), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tright), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
 D01 : outer ORDER BY -- merged     
 
 
@@ -1913,7 +1988,7 @@ Query Plan:
       TABLE SCAN (v)
       TABLE SCAN (w)
 
-  rewritten query: select v.a, v.b, w.x, w.y from (select [dba.tleft].a as [a], [dba.tright].y as [b] from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x) v (a, b), [dba.tright] w where v.a=w.x order by ?, ?, ?
+  rewritten query: select v.a, v.b, w.x, w.y from (select [dba.tleft].a as [a], [dba.tright].y as [b] from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x) v (a, b), [dba.tright] w where v.a=w.x order by ?, ?, ?, ?
 
 
 Trace Statistics:
@@ -1954,7 +2029,7 @@ Query Plan:
       TABLE SCAN (v)
       TABLE SCAN (w)
 
-  rewritten query: select v.a, v.b, w.x, w.y from (select [dba.tleft].a as [a], [dba.tright].y as [b] from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x) v (a, b), [dba.tright] w where v.a=w.x order by ?, ?, ?
+  rewritten query: select v.a, v.b, w.x, w.y from (select [dba.tleft].a as [a], [dba.tright].y as [b] from [dba.tleft] [dba.tleft] left outer join [dba.tright] [dba.tright] on [dba.tleft].a=[dba.tright].x) v (a, b), [dba.tright] w where v.a=w.x order by ?, ?, ?, ?
 
 
 Trace Statistics:

--- a/sql/_13_issues/_26_2h/cases/cbrd_27200.sql
+++ b/sql/_13_issues/_26_2h/cases/cbrd_27200.sql
@@ -1,0 +1,323 @@
+/**
+ * CBRD-27200: a constant TRUE predicate (WHERE 1=1) must not be treated as a
+ * real predicate when deciding whether an inline view can be merged.
+ * Engine PR #7632; 11.4 backport PR #7703.
+ *
+ * mq_is_pushable_subquery () used "is the main query's predicate list empty?"
+ * to compute is_only_spec. A folded-always-true conjunct is still in the list,
+ * so is_only_spec became false and the relaxations for an outer-joined spec
+ * inside the view, inst_num and ORDER BY were lost -> NON_PUSHABLE. The
+ * conjunct survives because pt_where_type () strips always-true conjuncts
+ * during the type-check walk, while constant folding happens in the NEXT walk:
+ * a literal TRUE is already a value and gets stripped, but 1=1 is still an
+ * expression at that point. The fix adds pt_true_search_condition () and uses
+ * it instead of "pred == NULL".
+ *
+ * Every case prints, via evaluate (), whether the view is expected to be
+ * merged, and is followed by show trace. The "rewritten query:" line is what
+ * proves it: a merged query is flat, a blocked one keeps "from (select ...)".
+ * Result values cannot tell the two apart -- the JIRA report measured 62 cases
+ * and found 28 plan changes with ZERO result changes -- so without the trace
+ * this test would verify nothing about the fix.
+ *
+ * Data mirrors the JIRA report: tleft has NULLs in b/c, and only tleft.a 1 and 3
+ * match tright.x, so the LEFT OUTER JOIN produces NULL-extended rows and tright keeps
+ * non-matching rows (9, 10, 20).
+ *
+ * Groups (67 cases; 62 of them from the attached CBRD-27200_test_report.md)
+ *   A 17  constant TRUE predicates            -> merged (A00/A01 already were)
+ *   B 13  real predicates                     -> unchanged
+ *   C 15  view shapes, WHERE 1=1 fixed
+ *   D 12  outer clauses / main-query shape, WHERE 1=1 fixed
+ *   E 10  non-SELECT paths                    -> results only, no plan needed
+ */
+
+--+ server-message on
+
+DROP TABLE IF EXISTS tleft;
+DROP TABLE IF EXISTS tright;
+
+CREATE TABLE tleft (a INT, b INT, c VARCHAR(10));
+INSERT INTO tleft VALUES (1,10,'p'),(2,NULL,'q'),(3,30,NULL),(4,NULL,NULL),(5,50,'r');
+CREATE TABLE tright (x INT, y INT);
+INSERT INTO tright VALUES (1,100),(3,300),(9,900),(10,1000),(20,2000);
+
+set trace on;
+
+-- ===== Group A : constant TRUE predicates ================================
+evaluate 'A00 : no predicate (baseline) -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v ORDER BY 1, 2;
+show trace;
+
+evaluate 'A01 : WHERE TRUE -- merged (already before the fix)';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE TRUE ORDER BY 1, 2;
+show trace;
+
+evaluate 'A02 : WHERE 1=1 -- merged (the reported case)';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 ORDER BY 1, 2;
+show trace;
+
+evaluate 'A03 : WHERE ''a''=''a'' -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 'a'='a' ORDER BY 1, 2;
+show trace;
+
+evaluate 'A04 : WHERE 1=1 AND 2=2 -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 AND 2=2 ORDER BY 1, 2;
+show trace;
+
+evaluate 'A05 : WHERE 2>1 -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 2>1 ORDER BY 1, 2;
+show trace;
+
+evaluate 'A06 : WHERE NOT (1=0) -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE NOT (1=0) ORDER BY 1, 2;
+show trace;
+
+evaluate 'A07 : WHERE ''abc'' LIKE ''abc'' -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 'abc' LIKE 'abc' ORDER BY 1, 2;
+show trace;
+
+evaluate 'A08 : WHERE 1=1 AND ''x''=''x'' AND 3>2 -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 AND 'x'='x' AND 3>2 ORDER BY 1, 2;
+show trace;
+
+evaluate 'A09 : WHERE 1=1 OR v.a > 0 -- merged (folds to a single TRUE)';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 OR v.a > 0 ORDER BY 1, 2;
+show trace;
+
+evaluate 'A10 : WHERE CAST(1 AS INT)=1 -- NOT merged (not folded; the boundary of this change)';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE CAST(1 AS INT)=1 ORDER BY 1, 2;
+show trace;
+
+evaluate 'A11 : WHERE 1 IN (1,2) -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1 IN (1,2) ORDER BY 1, 2;
+show trace;
+
+evaluate 'A12 : WHERE ''a'' IS NOT NULL -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 'a' IS NOT NULL ORDER BY 1, 2;
+show trace;
+
+evaluate 'A13 : WHERE 1=1 AND TRUE -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 AND TRUE ORDER BY 1, 2;
+show trace;
+
+evaluate 'A14 : WHERE 1<>0 -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1<>0 ORDER BY 1, 2;
+show trace;
+
+evaluate 'A15 : WHERE 3 BETWEEN 1 AND 5 -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 3 BETWEEN 1 AND 5 ORDER BY 1, 2;
+show trace;
+
+evaluate 'A16 : WHERE 1=1 only INSIDE the view, none outside -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x WHERE 1=1) v ORDER BY 1, 2;
+show trace;
+
+-- ===== Group B : real predicates, must stay unchanged ====================
+evaluate 'B01 : WHERE v.a > 0 -- NOT merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE v.a > 0 ORDER BY 1, 2;
+show trace;
+
+evaluate 'B02 : WHERE 1=1 AND v.a > 0 -- NOT merged (a real conjunct remains)';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 AND v.a > 0 ORDER BY 1, 2;
+show trace;
+
+evaluate 'B03 : WHERE 1=0 -- always false, no plan is produced';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=0 ORDER BY 1, 2;
+show trace;
+
+evaluate 'B04 : WHERE v.a = NULL -- unknown, no plan is produced';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE v.a = NULL ORDER BY 1, 2;
+show trace;
+
+evaluate 'B05 : WHERE ROWNUM <= 2 -- merged (rownum-only predicate path)';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE ROWNUM <= 2;
+show trace;
+
+evaluate 'B06 : WHERE v.a IN (subquery) -- NOT merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE v.a IN (SELECT x FROM tright) ORDER BY 1, 2;
+show trace;
+
+evaluate 'B07 : WHERE v.a IS NOT NULL -- NOT merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE v.a IS NOT NULL ORDER BY 1, 2;
+show trace;
+
+evaluate 'B08 : WHERE v.b IS NULL -- NOT merged (filters outer-join NULL-extended rows)';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE v.b IS NULL ORDER BY 1, 2;
+show trace;
+
+evaluate 'B09 : WHERE 1=1 AND v.b IS NULL -- NOT merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 AND v.b IS NULL ORDER BY 1, 2;
+show trace;
+
+evaluate 'B10 : WHERE 0=1 OR v.a > 3 -- NOT merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 0=1 OR v.a > 3 ORDER BY 1, 2;
+show trace;
+
+evaluate 'B11 : WHERE NULL = NULL -- unknown, no plan is produced';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE NULL = NULL ORDER BY 1, 2;
+show trace;
+
+evaluate 'B12 : WHERE 1=1 AND ROWNUM <= 2 -- merged (already before the fix)';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 AND ROWNUM <= 2;
+show trace;
+
+evaluate 'B13 : WHERE v.a = v.a -- NOT merged (column reference, not a constant)';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE v.a = v.a ORDER BY 1, 2;
+show trace;
+
+-- ===== Group C : view shapes, WHERE 1=1 fixed ============================
+evaluate 'C01 : inner join view -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft INNER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 ORDER BY 1, 2;
+show trace;
+
+evaluate 'C02 : right outer join view -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft RIGHT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 ORDER BY 1, 2;
+show trace;
+
+evaluate 'C03 : GROUP BY view -- NOT merged (blocked by another rule)';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, COUNT(*) AS b FROM tleft GROUP BY tleft.a) v WHERE 1=1 ORDER BY 1, 2;
+show trace;
+
+evaluate 'C04 : ORDER BY view -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tleft.b AS b FROM tleft ORDER BY tleft.a) v WHERE 1=1 ORDER BY 1, 2;
+show trace;
+
+evaluate 'C05 : DISTINCT view -- NOT merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT DISTINCT tleft.a AS a, tleft.b AS b FROM tleft) v WHERE 1=1 ORDER BY 1, 2;
+show trace;
+
+evaluate 'C06 : UNION ALL view -- NOT merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT a, b FROM tleft UNION ALL SELECT x, y FROM tright) v WHERE 1=1 ORDER BY 1, 2;
+show trace;
+
+evaluate 'C07 : ROWNUM inside the view -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT ROWNUM AS a, tleft.b AS b FROM tleft) v WHERE 1=1 ORDER BY 1, 2;
+show trace;
+
+evaluate 'C08 : ORDER BY + LIMIT view -- NOT merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tleft.b AS b FROM tleft ORDER BY tleft.a LIMIT 3) v WHERE 1=1 ORDER BY 1, 2;
+show trace;
+
+evaluate 'C09 : no join, plain view -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tleft.b AS b FROM tleft) v WHERE 1=1 ORDER BY 1, 2;
+show trace;
+
+evaluate 'C10 : two nested outer joins -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b, tright_b.y AS c FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x LEFT OUTER JOIN tright tright_b ON tleft.a = tright_b.x) v WHERE 1=1 ORDER BY 1, 2, 3;
+show trace;
+
+evaluate 'C11 : outer join + aggregate -- NOT merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, COUNT(tright.y) AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x GROUP BY tleft.a) v WHERE 1=1 ORDER BY 1, 2;
+show trace;
+
+evaluate 'C12 : named view over an outer join -- merged';
+CREATE OR REPLACE VIEW v_oj AS SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x;
+SELECT /*+ RECOMPILE */ * FROM v_oj WHERE 1=1 ORDER BY 1, 2;
+show trace;
+
+evaluate 'C13 : view on top of a view -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT a, b FROM v_oj) v WHERE 1=1 ORDER BY 1, 2;
+show trace;
+DROP VIEW v_oj;
+
+evaluate 'C14 : expression in the view select list -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a * 2 AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 ORDER BY 1, 2;
+show trace;
+
+evaluate 'C15 : CTE instead of an inline view -- merged on develop; 11.4 keeps the CTE spec';
+WITH cte AS (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x)
+SELECT /*+ RECOMPILE */ * FROM cte WHERE 1=1 ORDER BY 1, 2;
+show trace;
+
+-- ===== Group D : outer clauses, WHERE 1=1 fixed ==========================
+evaluate 'D01 : outer ORDER BY -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 ORDER BY v.a DESC, 2;
+show trace;
+
+evaluate 'D02 : outer GROUP BY -- merged';
+SELECT /*+ RECOMPILE */ v.a, COUNT(*) FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 GROUP BY v.a ORDER BY 1;
+show trace;
+
+evaluate 'D03 : outer ORDER BY ... LIMIT -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 ORDER BY v.a LIMIT 3;
+show trace;
+
+evaluate 'D04 : outer COUNT(*) -- merged';
+SELECT /*+ RECOMPILE */ COUNT(*) FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1;
+show trace;
+
+evaluate 'D05 : outer DISTINCT -- merged';
+SELECT /*+ RECOMPILE */ DISTINCT v.a FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 ORDER BY 1;
+show trace;
+
+evaluate 'D06 : partial column selection -- merged';
+SELECT /*+ RECOMPILE */ v.b FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 ORDER BY 1;
+show trace;
+
+evaluate 'D07 : outer GROUP BY ... HAVING -- merged';
+SELECT /*+ RECOMPILE */ v.a, COUNT(*) FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 GROUP BY v.a HAVING COUNT(*) >= 1 ORDER BY 1;
+show trace;
+
+evaluate 'D08 : expression in the outer select list -- merged';
+SELECT /*+ RECOMPILE */ v.a * 2 FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 ORDER BY 1;
+show trace;
+
+evaluate 'D09 : ORDER BY a nullable outer-join column -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 ORDER BY v.b, v.a;
+show trace;
+
+evaluate 'D10 : HAVING 1=1 -- merged (HAVING is not the predicate list being checked)';
+SELECT /*+ RECOMPILE */ v.a, COUNT(*) FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v GROUP BY v.a HAVING 1=1 ORDER BY 1;
+show trace;
+
+evaluate 'D11 : the view is not the only spec of the main query -- NOT merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v, tright w WHERE 1=1 AND v.a = w.x ORDER BY 1, 2, 3;
+show trace;
+
+evaluate 'D12 : the same two specs without any constant predicate -- NOT merged either';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v, tright w WHERE v.a = w.x ORDER BY 1, 2, 3;
+show trace;
+
+set trace off;
+
+-- ===== Group E : non-SELECT paths, results only ==========================
+evaluate 'E01 : UPDATE ... WHERE a IN (inline view ... WHERE 1=1)';
+UPDATE tleft SET b = b + 1 WHERE a IN (SELECT v.a FROM (SELECT tleft.a AS a FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1);
+SELECT a, b FROM tleft ORDER BY 1;
+
+evaluate 'E02 : DELETE ... WHERE a IN (inline view ... WHERE 1=1)';
+DELETE FROM tleft WHERE a IN (SELECT v.a FROM (SELECT tleft.a AS a FROM tleft WHERE tleft.a = 5) v WHERE 1=1);
+SELECT a, b FROM tleft ORDER BY 1;
+
+evaluate 'E03 : INSERT ... SELECT ... WHERE 1=1';
+INSERT INTO tleft SELECT v.a + 100, v.b, 'z' FROM (SELECT tleft.a AS a, tleft.b AS b FROM tleft) v WHERE 1=1;
+SELECT a, b, c FROM tleft ORDER BY 1;
+
+evaluate 'E04 : a view that itself contains WHERE 1=1';
+CREATE OR REPLACE VIEW v_true AS SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x WHERE 1=1;
+SELECT * FROM v_true ORDER BY 1, 2;
+
+evaluate 'E05 : the same view with an outer predicate';
+SELECT * FROM v_true WHERE a <= 3 ORDER BY 1, 2;
+DROP VIEW v_true;
+
+evaluate 'E06 : scalar subquery containing WHERE 1=1';
+SELECT (SELECT COUNT(*) FROM (SELECT tleft.a AS a FROM tleft) v WHERE 1=1) AS cnt FROM db_root;
+
+evaluate 'E07 : UNION ALL of two inline views with WHERE 1=1';
+SELECT * FROM (SELECT a FROM tleft WHERE 1=1 UNION ALL SELECT x FROM tright WHERE 1=1) v ORDER BY 1;
+
+evaluate 'E08 : row count through the inline view';
+SELECT COUNT(*) FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1;
+
+evaluate 'E09 : outer join NULL-extended rows are preserved';
+SELECT COUNT(*) FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 AND v.b IS NULL;
+
+evaluate 'E10 : always-false predicate returns no rows';
+SELECT COUNT(*) FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=0;
+
+DROP TABLE tleft;
+DROP TABLE tright;
+
+--+ server-message off

--- a/sql/_13_issues/_26_2h/cases/cbrd_27200.sql
+++ b/sql/_13_issues/_26_2h/cases/cbrd_27200.sql
@@ -24,10 +24,10 @@
  * match tright.x, so the LEFT OUTER JOIN produces NULL-extended rows and tright keeps
  * non-matching rows (9, 10, 20).
  *
- * Groups (67 cases; 62 of them from the attached CBRD-27200_test_report.md)
- *   A 17  constant TRUE predicates            -> merged (A00/A01 already were)
+ * Groups (69 cases; 62 of them from the attached CBRD-27200_test_report.md)
+ *   A 17  constant TRUE predicates            -> merged, except A10 (not folded)
  *   B 13  real predicates                     -> unchanged
- *   C 15  view shapes, WHERE 1=1 fixed
+ *   C 17  view shapes, WHERE 1=1 fixed
  *   D 12  outer clauses / main-query shape, WHERE 1=1 fixed
  *   E 10  non-SELECT paths                    -> results only, no plan needed
  */
@@ -130,8 +130,8 @@ evaluate 'B04 : WHERE v.a = NULL -- unknown, no plan is produced';
 SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE v.a = NULL ORDER BY 1, 2;
 show trace;
 
-evaluate 'B05 : WHERE ROWNUM <= 2 -- merged (rownum-only predicate path)';
-SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE ROWNUM <= 2;
+evaluate 'B05 : WHERE ROWNUM <= 5 -- merged (rownum-only predicate path)';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE ROWNUM <= 5;
 show trace;
 
 evaluate 'B06 : WHERE v.a IN (subquery) -- NOT merged';
@@ -158,8 +158,8 @@ evaluate 'B11 : WHERE NULL = NULL -- unknown, no plan is produced';
 SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE NULL = NULL ORDER BY 1, 2;
 show trace;
 
-evaluate 'B12 : WHERE 1=1 AND ROWNUM <= 2 -- merged (already before the fix)';
-SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 AND ROWNUM <= 2;
+evaluate 'B12 : WHERE 1=1 AND ROWNUM <= 5 -- merged (already before the fix)';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 AND ROWNUM <= 5;
 show trace;
 
 evaluate 'B13 : WHERE v.a = v.a -- NOT merged (column reference, not a constant)';
@@ -230,6 +230,14 @@ WITH cte AS (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN trigh
 SELECT /*+ RECOMPILE */ * FROM cte WHERE 1=1 ORDER BY 1, 2;
 show trace;
 
+evaluate 'C16 : the same ORDER BY + LIMIT view as C08, without the outer ORDER BY -- NOT merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tleft.b AS b FROM tleft ORDER BY tleft.a LIMIT 3) v WHERE 1=1;
+show trace;
+
+evaluate 'C17 : constant TRUE at both nesting levels of a doubly nested view -- merged';
+SELECT /*+ RECOMPILE */ * FROM (SELECT w.a AS a, w.b AS b FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x WHERE 1=1) w WHERE 1=1) v WHERE 1=1 ORDER BY 1, 2;
+show trace;
+
 -- ===== Group D : outer clauses, WHERE 1=1 fixed ==========================
 evaluate 'D01 : outer ORDER BY -- merged';
 SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v WHERE 1=1 ORDER BY v.a DESC, 2;
@@ -272,11 +280,11 @@ SELECT /*+ RECOMPILE */ v.a, COUNT(*) FROM (SELECT tleft.a AS a, tright.y AS b F
 show trace;
 
 evaluate 'D11 : the view is not the only spec of the main query -- NOT merged';
-SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v, tright w WHERE 1=1 AND v.a = w.x ORDER BY 1, 2, 3;
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v, tright w WHERE 1=1 AND v.a = w.x ORDER BY 1, 2, 3, 4;
 show trace;
 
 evaluate 'D12 : the same two specs without any constant predicate -- NOT merged either';
-SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v, tright w WHERE v.a = w.x ORDER BY 1, 2, 3;
+SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v, tright w WHERE v.a = w.x ORDER BY 1, 2, 3, 4;
 show trace;
 
 set trace off;


### PR DESCRIPTION
# [CBRD-27200] Add SQL testcase for constant TRUE predicates and view merging

- Issue: http://jira.cubrid.org/browse/CBRD-27200
- Engine PR: https://github.com/CUBRID/cubrid/pull/7632 (`develop`, `f0e2c07bc`)
- JIRA 첨부: `CBRD-27200_test_report.md` (62 케이스 A/B 측정 보고서)

## Description

상수 폴딩으로 항상 참이 되는 술어(`WHERE 1=1`)가 뷰 머징 판정에서 실제 조회조건과 동일하게 취급되어, 의미 없는 술어 하나가 인라인뷰 머징을 막았다.

`mq_is_pushable_subquery ()` 는 메인 쿼리 술어의 유무를 `is_only_spec` 계산에 쓰는데, 항상 참 conjunct 도 목록에 남아 있어 `is_only_spec` 이 거짓이 되고 외부조인 spec·`inst_num`·`ORDER BY` 완화가 사라져 `NON_PUSHABLE` 이 된다. conjunct 가 남는 이유는 제거 시점이다 — 항상 참 conjunct 를 잘라내는 `pt_where_type ()` 은 타입 체크 walk 에서 돌고, 상수 폴딩은 그 다음 walk 에서 수행된다. 리터럴 `TRUE` 는 이미 값이라 제거되지만 `1=1` 은 그 시점에 아직 식이다.

수정은 `pt_true_search_condition ()` 을 추가해 `pred == NULL` 대신 사용한다. 파스 트리는 바꾸지 않고 판정만 바꾼다.

## Files

```
sql/_13_issues/_26_2h/cases/cbrd_27200.sql
sql/_13_issues/_26_2h/answers/cbrd_27200.answer
```

## 결과값으로는 검증할 수 없다

JIRA 첨부 보고서가 62 케이스를 base/fix 빌드에서 측정해 **플랜 변화 28건, 결과 집합 차이 0건**을 확인했다(이 TC 는 여기에 7 건을 더한 69 케이스다). 즉 이 수정은 플랜만 바꾼다. 답지에 결과 행만 담으면 이 TC 는 아무것도 검증하지 못한다.

그래서 케이스마다 `evaluate ()` 로 기대 머징 여부를 적고 `show trace` 를 붙인다. 답지의 `rewritten query:` 가 판정 근거다 — 머징되면 `from (select ...)` 가 사라지고, 차단되면 그대로 남는다.

## Test design

데이터는 보고서대로 외부조인 미매칭이 생기게 구성한다 — `tleft` 5행(`b`·`c` 에 NULL 포함), `tright` 5행이고 `tleft.a` 중 1·3 만 `tright.x` 와 매칭되어 NULL 확장 행 3건이 발생하고 `tright` 에 미매칭 행(9·10·20)이 남는다.

기준 질의는 파생 테이블이 메인 쿼리의 유일한 spec 인 형태다.

```sql
SELECT /*+ RECOMPILE */ * FROM (SELECT tleft.a AS a, tright.y AS b
                                  FROM tleft LEFT OUTER JOIN tright ON tleft.a = tright.x) v
 WHERE <조건>;
```

### 케이스 — 첨부 보고서의 62 건 전부

총 **69 케이스**다 — 첨부 보고서의 62 건에 7 건을 더했다.

| 그룹 | 건수 | 내용 | `show trace` |
|---|---|---|---|
| A | 17 | 상수 참 술어 (`1=1`, `'a'='a'`, `2>1`, `NOT(1=0)`, `LIKE`, `IN`, `IS NOT NULL`, `BETWEEN` …) | O |
| B | 13 | 실제 술어로 유지돼야 하는 경우 | O |
| C | 17 | 뷰 모양별 (`WHERE 1=1` 고정) | O |
| D | 12 | 바깥 절 조합 및 메인 쿼리 형태 (`WHERE 1=1` 고정) | O |
| E | 10 | SELECT 이외 경로 (UPDATE/DELETE/INSERT/뷰/스칼라 서브쿼리) | X (결과만) |

E 그룹에 trace 를 붙이지 않은 것은 보고서가 이 그룹을 출력 diff 로 검증했기 때문이다(diff 0).

### 보고서를 넘어 추가한 7 건

보고서는 기준 질의를 고정해 **술어만** 변화시킨다 — 파생 테이블이 메인 쿼리의 유일한 spec 이고 술어는 바깥 `WHERE` 에 있다. 그런데 `is_only_spec` 은 세 조건의 AND 다.

```c
is_only_spec = ((statement_spec->next == NULL && (pred == NULL || is_rownum_only)
                 && (subquery->info.query.order_by == NULL || order_by == NULL)) ? true : false);
```

| 케이스 | 내용 | 수정 전 → 후 |
|---|---|---|
| A16 | `WHERE 1=1` 을 인라인뷰 **안쪽에만** | 머징 → 머징 |
| **C15** | 인라인뷰 대신 **CTE** | **미머징 → 머징** |
| D10 | `HAVING 1=1` — 검사 대상 술어 목록이 아님 | 머징 → 머징 |
| D11 | 메인 쿼리 spec **2 개** + `1=1` | 미머징 → 미머징 |
| D12 | 같은 spec 2 개, 상수 술어 **없음** | 미머징 → 미머징 |
| C16 | C08 과 같은 `ORDER BY`+`LIMIT` 뷰, 바깥 `ORDER BY` 없음 | 미머징 → 미머징 |
| **C17** | 2 단 중첩 뷰의 **양쪽 층에** `1=1` | **미머징 → 머징** |

**C15 와 C17 이 회귀 탐지력을 갖는다.** 둘 다 보고서에 없던 케이스이고, CTE 와 2 단 중첩 뷰도 이 수정의 영향을 받음을 실측으로 확인했다. 기존 A16 은 1 단 중첩이라 뒤집히지 않는다. 나머지 5 건은 경계 고정용이다.

D11·D12 가 짝이다. D11 만으로는 미머징 원인을 알 수 없고, 상수 술어를 뺀 D12 도 미머징이므로 원인이 only-spec 조건(`statement_spec->next != NULL`)임이 증명된다 — **이 수정이 도달할 수 없는 경계**를 고정한다.


**라벨과 실제 머징 여부를 54건 전수 대조해 불일치 0건**을 확인했고, 플랜 없음으로 선언한 3건(B03 `1=0`, B04 `v.a = NULL`, B11 `NULL = NULL`)은 실제로 `rewritten query` 를 내지 않는다.

### 경계 케이스

| 케이스 | 동작 | 의미 |
|---|---|---|
| A10 `CAST(1 AS INT)=1` | 수정 전후 모두 **미머징** | 폴딩 대상이 아니라 이번 변경의 적용 경계. 실패 방향이 안전한 쪽(기존 유지) |
| A01 `WHERE TRUE` | 수정 전에도 머징 | 리터럴은 타입 체크 walk 에서 이미 제거됨 |
| B12 `1=1 AND ROWNUM<=5` | 수정 전에도 머징 | `mq_is_rownum_only_predicate ()` 경로 |
| C03·C05·C06·C08·C11·C16 | 미머징 유지 | GROUP BY·DISTINCT·UNION·LIMIT·집계는 다른 규칙이 막음 — 변경 범위가 좁다는 증거 |
| A09 `1=1 OR v.a > 0` | 미머징 → **머징** | `or_next` 가 있어도 폴딩 단계에서 단일 참 값으로 접히면 no-op 로 인식됨 |

## Acceptance Criteria 매핑

| # | Acceptance Criteria | 케이스 |
|---|---|---|
| 1 | 외부조인 인라인뷰에 `WHERE 1=1` 만 추가해도 조건 없을 때와 머징 결과 동일 | A00 + A02 — 답지의 재작성문이 **문자열까지 완전히 같다** |
| 2 | 실제 술어(`v.a > 0`)면 기존대로 미머징 | B01 |
| 3 | `1=1 AND v.a > 0` 혼합이면 기존과 동일 | B02 (재작성문이 B01 과 동일) |
| 4 | 상수 거짓(`1=0`) 경로 영향 없음 | B03 |
| 5 | 모든 케이스에서 결과 집합 불변 | 62 케이스 전부 — before/after 실측 차이 0건 |

## Verification

| 빌드 | 수정 | 결과 |
|---|---|---|
| 11.5.0.2494-4b6ae5c (debug) | 포함 | **OK** |
| 11.5.0.2437-9eb142d (debug) | 미포함 | **NOK** (30 케이스 플랜 상이) |

수정 이전 빌드의 측정이 첨부 보고서와 일치한다. 보고서의 62 케이스에서 28 건, 추가한 C15·C17 까지 **30 건**이다.

| 항목 | 보고서 (62) | 이 TC (69) |
|---|---|---|
| 플랜이 바뀐 케이스 | 28 | **30** |
| 역방향 변화 | 0 | **0** (전부 미머징 → 머징) |
| 결과 집합 차이 | 0 | **0** |

뒤집힌 30 건: A02\~A09·A11\~A15 (13), C02·C07·C10·C12·C13·C14·**C15**·**C17** (8), D01~D09 (9).

추가한 7 건의 수정 전후 동작은 다음과 같다.

| 케이스 | 수정 전 | 수정 후 | |
|---|---|---|---|
| A16 안쪽에만 `1=1` | 머징 | 머징 | 바깥 `WHERE` 가 비어 `pred == NULL` |
| **C15 CTE** | **미머징** | **머징** | **뒤집힘 — 보고서에 없던 케이스** |
| D10 `HAVING 1=1` | 머징 | 머징 | 검사 대상은 `WHERE` 술어 목록 |
| D11 spec 2 개 + `1=1` | 미머징 | 미머징 | only-spec 조건이 막음 |
| D12 spec 2 개, 술어 없음 | 미머징 | 미머징 | 원인이 상수 술어가 아님을 확정 |
| C16 바깥 `ORDER BY` 없는 `LIMIT` 뷰 | 미머징 | 미머징 | `LIMIT` 이 `is_only_spec` 과 무관한 규칙으로 막음 |
| **C17 2 단 중첩 양쪽에 `1=1`** | **미머징** | **머징** | **뒤집힘 — 중첩 뷰도 이 수정의 대상** |

**추가분 중 C15 와 C17 이 회귀 탐지력을 갖는다.** 나머지 5 건은 경계 고정용이다.
