### PR TITLE
[CBRD-26475] cbrd_23749.answer_cci 재베이스라인 (해시 조인 플랜)

### DIFF
--- a/sql/_13_issues/_20_2h/answers/cbrd_23749.answer_cci
+++ b/sql/_13_issues/_20_2h/answers/cbrd_23749.answer_cci
@@ -550,19 +550,27 @@ count(*)
 trace    
 
 Query Plan:
-  NESTED LOOPS (inner join)
-    TABLE SCAN (t?)
+  HASH JOIN (inner join)
     TABLE SCAN (t)
+    TABLE SCAN (t?)
 
   rewritten query: select count(*) from [dba.tree?] t inner join [dba.tree?] t? on t.id=t?.treeid start with t.mgrid is null  and t.gubun= ?:?  connect by  prior t.id=t.mgrid and t.gubun= ?:? 
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.tree?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (table: dba.tree?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     CONNECTBY (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (hash temp(m), build time: ?, time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      HASHJOIN (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        BUILD (time: ?, fetch: ?, ioread: ?, rows: ?, method: memory)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (table: dba.tree?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        PROBE (time: ?, fetch: ?, ioread: ?, readrows: ?, readkeys: ?, rows: ?)
+              (parallel workers: ?, time: ?..?, readrows: ?..?, readkeys: ?..?, rows: ?..?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (table: dba.tree?), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+                 (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
      
 
 ===================================================


### PR DESCRIPTION
https://github.com/CUBRID/cubrid/pull/6782 (CBRD-26475 — 이 케이스를 해시 조인으로 바꾼 변경)
http://jira.cubrid.org/browse/CBRD-26475

## Purpose

`sql/_13_issues/_20_2h/cases/cbrd_23749.sql` 은 csql 답지(`.answer`)와 CCI 답지(`.answer_cci`)를 함께 가지고 있다. CBRD-26475(비용 기반 해시 조인, CUBRID/cubrid#6782, 2026-07-16 머지)로 이 케이스의 tree3 CONNECT BY 조인 플랜이 NESTED LOOPS 에서 HASH JOIN 으로 바뀌었는데, 그 테스트 재베이스라인(#2987)이 `cbrd_23749.answer` 만 갱신하고 짝인 `cbrd_23749.answer_cci` 를 빠뜨렸다. 그래서 이 케이스는 그 시점부터 SQL_BY_CCI 카테고리에서 계속 실패하고 있었다.

QA 는 이 실패를 CBRD-27192(`05522fac8`)의 회귀로 신고했으나 그 변경과는 무관하다. 이 케이스는 인덱스를 하나도 만들지 않아 해당 수정 지점(`qo_iscan_cost`)에 도달하지 않으며, 그 변경을 토글로 끈 A/B 결과도 바이트 단위로 동일하다.

## Implementation

develop `11.5.0.2484-5862371` 빌드에서 CTP `sql_by_cci` 하네스(`CTP/sql_by_cci/execute`)로 실행해 `sql/_13_issues/_20_2h/answers/cbrd_23749.answer_cci` 를 다시 생성했다. 변경은 첫 번째 tree3 질의의 플랜 블록 한 곳(16줄)뿐이다.

```
-  NESTED LOOPS (inner join)     ->    +  HASH JOIN (inner join)
```

## Remarks

엔진 회귀가 아니라 답지만 낡은 상태였다.

| 빌드 | 플랜 | 코스트 |
|---|---|---|
| `739d506cd` — CBRD-26475 직전 커밋 (11.5.0.2334) | `nl-join`, outer `tree2(8)`, inner `tree3(42000)` | 15421 |
| `d213d0d`(11.5.0.2343) ~ `1244915`(11.5.0.2511) 의 모든 빌드 | `hash-join` | 3837 |

CBRD-26475 직전 빌드의 플랜이 기존 `answer_cci` 가 기대하던 것과 정확히 일치한다. 즉 이 불일치는 2026-07-16 부터 존재했고 `05522fac8` 보다 5주 앞선다.

검증:

- 새 DB·새 서버에서 케이스를 처음부터 다시 실행해 이 PR 의 답지와 바이트 단위로 일치함을 확인했다.
- 같은 하네스로 `sql/_36_guava` 44개 케이스를 돌렸고 이 케이스 외에는 기존 답지 그대로 통과한다. 로컬 환경 특성이 답지에 섞여 들어간 것이 아니라 CI 결과를 재현한다는 뜻이다.

같은 유형(`.answer` 만 갱신되고 `.answer_cci` 가 누락됨)의 답지를 8개 더 찾았지만 — CBRD-26884(`_09_percent_type` 6개), CBRD-26983(`alter_change_026`), CBRD-26889/26900/26959(`join_orderby_skip`) — 이 PR 은 #6782 관련 변경만 담는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
