### PR TITLE
[CBRD-27189] Backport from develop to 11.4 - the numbering-column view-merging testcase

### DIFF
--- a/sql/_13_issues/_26_2h/answers/cbrd_27189.answer
+++ b/sql/_13_issues/_26_2h/answers/cbrd_27189.answer
@@ -1,0 +1,700 @@
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+5
+
+===================================================
+0
+
+===================================================
+40
+
+===================================================
+0
+
+===================================================
+    
+case 01 : DECODE () on the numbering column of an inline view -- NOT merged     
+
+
+===================================================
+result    
+a     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (__t?)
+
+  rewritten query: select decode([__t?].rn, ?, [__t?].[name],  cast('WRONG' as varchar)) from (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) [__t?] ([name], rn)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 02 : the same shape written with a CTE -- NOT merged     
+
+
+===================================================
+result    
+a     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? 
+
+  TABLE SCAN (dba.src)
+
+  rewritten query: with src([name], rn) as (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )select decode([dba.src].rn, ?, [dba.src].[name],  cast('WRONG' as varchar)) from [dba.src] [dba.src]
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      CTE (non_recursive_part)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 03 : the same shape through a view -- NOT merged     
+
+
+===================================================
+0
+
+===================================================
+result    
+a     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.vsort)
+
+  rewritten query: (select [dba.vsort].[name], (orderby_num()) from [dba.tsort] [dba.vsort] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (dba.vsort)
+
+  rewritten query: select decode([dba.vsort].rn, ?, [dba.vsort].[name],  cast('WRONG' as varchar)) from (select [dba.vsort].[name], (orderby_num()) from [dba.tsort] [dba.vsort] order by ? for (orderby_num())<= ?:? ) [dba.vsort] ([name], rn)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 04 : bare reference of the numbering column -- still merged     
+
+
+===================================================
+result    
+1     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.vsort)
+
+  rewritten query: select (orderby_num()), [dba.vsort].[name] from [dba.tsort] [dba.vsort] order by ? for (orderby_num())<= ?:? 
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+0
+
+===================================================
+    
+case 05a : CASE reads the numbering column -- NOT merged     
+
+
+===================================================
+result    
+a     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (__t?)
+
+  rewritten query: select case when [__t?].rn=? then [__t?].[name] else  cast('WRONG' as varchar) end from (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) [__t?] ([name], rn)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 05b : arithmetic reads the numbering column -- NOT merged     
+
+
+===================================================
+result    
+1     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (__t?)
+
+  rewritten query: select [__t?].rn+ cast(? as bigint) from (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) [__t?] (rn, [name])
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 05c : NVL reads the numbering column -- NOT merged     
+
+
+===================================================
+result    
+1     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (__t?)
+
+  rewritten query: select nvl([__t?].rn, ?) from (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) [__t?] (rn, [name])
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 05d : concatenation reads the numbering column -- NOT merged     
+
+
+===================================================
+result    
+x1     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (__t?)
+
+  rewritten query: select  cast('x' as varchar)|| cast([__t?].rn as varchar) from (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) [__t?] (rn, [name])
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 06 : more than one row, bare and embedded reference together -- NOT merged     
+
+
+===================================================
+rn    result    
+1     first     
+2     other     
+3     other     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (src)
+
+  rewritten query: select src.rn, decode(src.rn, ?, 'first', 'other') from (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) src (rn, [name])
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 07 : the numbering column is not exposed -- still merged     
+
+
+===================================================
+result    
+A     
+B     
+C     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (src)
+
+  rewritten query: select  upper(src.[name]), src.[name] from [dba.tsort] src order by ? for (orderby_num())<= ?:? 
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 08 : the sort is resolved by an index -- NOT merged     
+
+
+===================================================
+result    
+e     
+
+
+===================================================
+trace    
+
+Query Plan:
+  INDEX SCAN (__t?.pk_tsort_code) ()
+  skip order by: true
+
+  rewritten query: (select [__t?].[name], (orderby_num()), [__t?].code from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (__t?)
+
+  rewritten query: select decode([__t?].rn, ?, [__t?].[name],  cast('WRONG' as varchar)) from (select [__t?].[name], (orderby_num()), [__t?].code from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) [__t?] ([name], rn, code)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (index: dba.tsort.pk_tsort_code), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+     
+
+
+===================================================
+    
+case 09 : CAST () reads the numbering column -- NOT merged     
+
+
+===================================================
+result    
+1     
+2     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (src)
+
+  rewritten query: select  cast(src.rn as varchar) from (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) src (rn, [name])
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 10 : a subquery of the select list reads the numbering column -- NOT merged     
+
+
+===================================================
+result    
+5     
+0     
+
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (dba.tsort)
+
+  rewritten query: (select count(*) from [dba.tsort] [dba.tsort] where src.rn= ?:? )
+
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  TABLE SCAN (src)
+
+  rewritten query: select (select count(*) from [dba.tsort] [dba.tsort] where src.rn= ?:? ) from (select (orderby_num()), [__t?].[name] from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) src (rn, [name])
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SUBQUERY_CACHE (hit: ?, miss: ?, size: ?, status: enabled)
+     
+
+
+===================================================
+    
+case 11 : GROUPBY_NUM () read by an expression -- NOT merged     
+
+
+===================================================
+result    
+FIRST     
+OTHER     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    SORT (group by)
+      TABLE SCAN (dba.tpage)
+
+  rewritten query: (select groupby_num(), [dba.tpage].grp from [dba.tpage] [dba.tpage] group by [dba.tpage].grp order by ?)
+
+  TABLE SCAN (__t?)
+
+  rewritten query: select decode([__t?].gn, ?, 'FIRST', 'OTHER') from (select groupby_num() as [gn], [dba.tpage].grp from [dba.tpage] [dba.tpage] group by [dba.tpage].grp order by ?) [__t?] (gn, grp) where ([__t?].gn<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tpage), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+
+===================================================
+    
+case 12 : ORDERBY_NUM () written explicitly -- NOT merged     
+
+
+===================================================
+result    
+a     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (dba.tsort)
+
+  rewritten query: (select [dba.tsort].[name], (orderby_num()) from [dba.tsort] [dba.tsort] order by ? for orderby_num()<= ?:? )
+
+  TABLE SCAN (__t?)
+
+  rewritten query: select decode([__t?].rn, ?, [__t?].[name],  cast('WRONG' as varchar)) from (select [dba.tsort].[name], (orderby_num()) as [rn] from [dba.tsort] [dba.tsort] order by ? for orderby_num()<= ?:? ) [__t?] ([name], rn)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 13 : ROWNUM of a subquery which has no ORDER BY -- still merged     
+
+
+===================================================
+result    
+ONE     
+OTHER     
+OTHER     
+
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (__t?)
+
+  rewritten query: select decode((rownum), ?, 'ONE', 'OTHER') from [dba.tsort] [__t?] where ((rownum)<= ?:? )
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+case 14 : INST_NUM () inside an expression -- still merged     
+
+
+===================================================
+result    
+n001     
+
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (__t?)
+
+  rewritten query: select decode((inst_num()), ?, [__t?].[name],  cast('WRONG' as varchar)) from [dba.tpage] [__t?] where (inst_num()<= ?:? )
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tpage), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+
+===================================================
+    
+case 15 : ORDER BY on the numbering column -- NOT merged     
+
+
+===================================================
+result    
+c     
+b     
+a     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: select [__t?].[name], [__t?].rn from (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) [__t?] ([name] as [result], rn) order by ? desc 
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 16 : GROUP BY / HAVING on the numbering column -- NOT merged     
+
+
+===================================================
+result    
+b     
+c     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? )
+
+  SORT (group by)
+    TABLE SCAN (__t?)
+
+  rewritten query: select max([__t?].[name]) from (select [__t?].[name], (orderby_num()) from [dba.tsort] [__t?] order by ? for (orderby_num())<= ?:? ) [__t?] ([name], rn) where ([__t?].rn> ?:? ) group by [__t?].rn
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tsort), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+    
+case 17 : the numbering column is read only by WHERE -- still merged, folded into TOP-N     
+
+
+===================================================
+result    
+n007     
+n008     
+n009     
+
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: select [__t?].[name] from [dba.tpage] [__t?] order by ? for (orderby_num())>= ?:?  and (orderby_num())< ?:? 
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tpage), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, topnsort: true)
+     
+
+
+===================================================
+0
+
+===================================================
+0
+
+===================================================
+0
+

--- a/sql/_13_issues/_26_2h/cases/cbrd_27189.sql
+++ b/sql/_13_issues/_26_2h/cases/cbrd_27189.sql
@@ -1,0 +1,169 @@
+/**
+ * This test case verifies CBRD-27189: a numbering column (ROWNUM/ORDERBY_NUM()/
+ * GROUPBY_NUM()) of a subquery(view) must not be exposed to an expression of the
+ * main query when the subquery is merged into it. Such a value is only settled
+ * after the sort (or grouping) of the subquery is done, so an expression reading
+ * it produced a wrong result.
+ *
+ * Every case prints, via evaluate (), whether the subquery is expected to be
+ * merged, and is followed by show trace. The "rewritten query:" line of the
+ * trace is what actually proves it: a merged query is flat, a blocked one keeps
+ * the derived table. Result values alone cannot tell the two apart, so without
+ * the trace this test could not detect over-blocking -- merging that stops
+ * happening where it still should.
+ *
+ * Table names are letter-only on purpose: digits inside the trace block are
+ * masked to '?', so t1/t2 would both render as "t?" and become indistinguishable.
+ *
+ * Coverage
+ *   NOT merged (the fix blocks it)
+ *     01 DECODE () on the numbering column of an inline view -- the main repro
+ *     02 the same shape through a CTE
+ *     03 the same shape through a view
+ *     05 CASE / arithmetic / NVL / concatenation
+ *     06 more than one row, bare and embedded reference together
+ *     08 sort resolved by an index (no real sort needed)
+ *     09 CAST ()
+ *     10 a subquery of the select list reads the numbering column
+ *     11 GROUPBY_NUM () instead of ORDERBY_NUM ()
+ *     12 ORDERBY_NUM () written explicitly instead of ROWNUM
+ *     15 ORDER BY on the numbering column
+ *     16 GROUP BY / HAVING on the numbering column
+ *   still merged (the fix must NOT block it)
+ *     04 bare reference of the numbering column
+ *     07 the numbering column is not exposed at all
+ *     13 ROWNUM of a subquery which has no ORDER BY
+ *     14 INST_NUM (), evaluated during the scan, so safe inside an expression
+ *     17 the numbering column is read only by WHERE -> folded into TOP-N.
+ *        Deliberately excluded from the check by the fix; including it broke
+ *        the pagination plans of cbrd_24258 / cbrd_26257.
+ */
+
+--+ server-message on
+
+DROP TABLE IF EXISTS tsort;
+DROP TABLE IF EXISTS tpage;
+
+CREATE TABLE tsort (name VARCHAR(20), code INT PRIMARY KEY);
+INSERT INTO tsort VALUES ('e', 1), ('d', 2), ('c', 3), ('b', 4), ('a', 5);
+
+-- tpage carries enough rows for the pagination and grouping cases below
+CREATE TABLE tpage (name VARCHAR(20), code INT PRIMARY KEY, grp INT);
+INSERT INTO tpage
+SELECT 'n' || LPAD(CAST(ROWNUM AS VARCHAR), 3, '0'), ROWNUM, MOD(ROWNUM, 5)
+  FROM db_class a, db_class b LIMIT 40;
+
+set trace on;
+
+evaluate 'case 01 : DECODE () on the numbering column of an inline view -- NOT merged';
+SELECT DECODE(rn, 1, name, 'WRONG') AS result
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 1);
+show trace;
+
+evaluate 'case 02 : the same shape written with a CTE -- NOT merged';
+WITH src AS (
+    SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 1
+)
+SELECT DECODE(rn, 1, name, 'WRONG') AS result FROM src;
+show trace;
+
+evaluate 'case 03 : the same shape through a view -- NOT merged';
+CREATE OR REPLACE VIEW vsort AS
+    SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 1;
+SELECT DECODE(rn, 1, name, 'WRONG') AS result FROM vsort;
+show trace;
+
+evaluate 'case 04 : bare reference of the numbering column -- still merged';
+SELECT rn AS result FROM vsort;
+show trace;
+DROP VIEW vsort;
+
+evaluate 'case 05a : CASE reads the numbering column -- NOT merged';
+SELECT CASE WHEN rn = 1 THEN name ELSE 'WRONG' END AS result
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 1);
+show trace;
+
+evaluate 'case 05b : arithmetic reads the numbering column -- NOT merged';
+SELECT rn + 0 AS result
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 1);
+show trace;
+
+evaluate 'case 05c : NVL reads the numbering column -- NOT merged';
+SELECT NVL(rn, 0) AS result
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 1);
+show trace;
+
+evaluate 'case 05d : concatenation reads the numbering column -- NOT merged';
+SELECT 'x' || rn AS result
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 1);
+show trace;
+
+evaluate 'case 06 : more than one row, bare and embedded reference together -- NOT merged';
+SELECT rn, DECODE(rn, 1, 'first', 'other') AS result
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 3) src;
+show trace;
+
+evaluate 'case 07 : the numbering column is not exposed -- still merged';
+SELECT UPPER(name) AS result
+FROM (SELECT name FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 3) src;
+show trace;
+
+evaluate 'case 08 : the sort is resolved by an index -- NOT merged';
+SELECT DECODE(rn, 1, name, 'WRONG') AS result
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY code) WHERE ROWNUM <= 1);
+show trace;
+
+evaluate 'case 09 : CAST () reads the numbering column -- NOT merged';
+SELECT CAST(rn AS VARCHAR) AS result
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 2) src;
+show trace;
+
+evaluate 'case 10 : a subquery of the select list reads the numbering column -- NOT merged';
+SELECT (SELECT COUNT(*) FROM tsort WHERE src.rn = 1) AS result
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 2) src;
+show trace;
+
+evaluate 'case 11 : GROUPBY_NUM () read by an expression -- NOT merged';
+SELECT DECODE(gn, 1, 'FIRST', 'OTHER') AS result
+FROM (SELECT grp, GROUPBY_NUM() AS gn FROM tpage GROUP BY grp ORDER BY grp) WHERE gn <= 2;
+show trace;
+
+evaluate 'case 12 : ORDERBY_NUM () written explicitly -- NOT merged';
+SELECT DECODE(rn, 1, name, 'WRONG') AS result
+FROM (SELECT name, ORDERBY_NUM() AS rn FROM tsort ORDER BY name FOR ORDERBY_NUM() <= 1);
+show trace;
+
+evaluate 'case 13 : ROWNUM of a subquery which has no ORDER BY -- still merged';
+SELECT DECODE(rn, 1, 'ONE', 'OTHER') AS result
+FROM (SELECT ROWNUM AS rn, name FROM tsort) WHERE rn <= 3;
+show trace;
+
+evaluate 'case 14 : INST_NUM () inside an expression -- still merged';
+SELECT DECODE(rn, 1, name, 'WRONG') AS result
+FROM (SELECT name, INST_NUM() AS rn FROM tpage WHERE INST_NUM() <= 1);
+show trace;
+
+evaluate 'case 15 : ORDER BY on the numbering column -- NOT merged';
+SELECT name AS result
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 3)
+ORDER BY rn DESC;
+show trace;
+
+evaluate 'case 16 : GROUP BY / HAVING on the numbering column -- NOT merged';
+SELECT MAX(name) AS result
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tsort ORDER BY name) WHERE ROWNUM <= 3)
+GROUP BY rn HAVING rn > 1;
+show trace;
+
+evaluate 'case 17 : the numbering column is read only by WHERE -- still merged, folded into TOP-N';
+SELECT name AS result
+FROM (SELECT name, ROWNUM AS rn FROM (SELECT name FROM tpage ORDER BY name))
+WHERE rn >= 7 AND rn < 10;
+show trace;
+
+set trace off;
+
+DROP TABLE tsort;
+DROP TABLE tpage;
+
+--+ server-message off


### PR DESCRIPTION
- Issue: http://jira.cubrid.org/browse/CBRD-27189
- Backport engine PR: https://github.com/CUBRID/cubrid/pull/7699 (`release/11.4`)
- develop engine PR: https://github.com/CUBRID/cubrid/pull/7686
- develop TC:  #3251 + 확장 PR (#3312)

## Purpose

엔진 백포트 #7699 에 맞춰 `cbrd_27189` TC 를 `release/11.4` 로 이관한다.

`ROWNUM`/`ORDERBY_NUM ()` 을 컬럼으로 노출한 서브쿼리를 메인 쿼리가 **표현식의 피연산자로** 읽으면, 뷰 머징 후 잘못된 결과가 나온다. 이 값은 정렬 결과를 내보내는 시점에 top-level 출력 컬럼 위치에만 채워지므로, 표현식 안에서 읽으면 설정 전 값을 읽는다.

## `.sql` 은 develop 과 동일하다

**케이스 파일은 수정 없이 그대로 쓴다.** 11.4 에서 20 개 구문 전부 에러 없이 실행되고 결과 블록 수도 73 개로 동일함을 확인했다.

**결과값도 17 개 케이스 전부 develop 과 동일**하다. 백포트가 동일하게 동작한다.

## 답지는 별도다

`show trace` 를 포함하므로 플랜 텍스트가 버전에 따라 다르다. develop 답지와 18 줄 차이가 나며, 모두 엔진 버전 차이지 TC 결함이 아니다.

| 케이스 | 차이 |
|---|---|
| 02 | develop 은 CTE 를 파생 테이블로 변환, 11.4 는 `with ... as` 유지. 11.4 플랜에 `CTE (non_recursive_part)` 노드 존재 |
| 10 | 11.4 에만 `SUBQUERY_CACHE (hit: ?, miss: ?, ...)` 줄 |
| 11, 16 | `GROUPBY (...)` 통계에 develop 은 `readrows: ?` 포함, 11.4 미포함 |

케이스 02 를 자세히 보면 재작성 결과가 다음과 같다.

```
-- develop : CTE -> 파생 테이블
select decode(src.rn, ?, src.[name], ...) from (select [__t?].[name], (orderby_num()) from [dba.tsort] ...) src ([name], rn)
-- 11.4 : CTE 유지
with src([name], rn) as (select [__t?].[name], (orderby_num()) from [dba.tsort] ...) select decode([dba.src].rn, ?, ...) from [dba.src]
```

표현 방식은 다르지만 양쪽 모두 `rn` 을 스펙의 컬럼으로 읽는다 — `orderby_num()` 이 `DECODE ()` 안으로 인라인되지 않았으므로 **차단 판정은 동일**하다.

## Verification

| 빌드 | 백포트 | CTP |
|---|---|---|
| 11.4.6.1932-7654942 | 포함 | **OK** |
| 11.4.5.1906-4e4fa29 | 미포함 | **NOK** |

백포트 이전 빌드에서 탐지된 내역:

| 탐지 근거 | 케이스 | 백포트 전 값 |
|---|---|---|
| 값 + 머징 | 01, 03, 05a~d, 06, 09, 10 (9 건) | `'WRONG'`, `0`, `'x0'`, `'0','0'`, `0,0`, `1 other` |
| **머징만** | **08** | 결과는 `'e'` 로 동일 |
| 탐지 안 됨 | **02**, 04, 07, 11~17 | — |