### PR TITLE
[CBRD-27169] Add new test case for add SQL testcase for ON-clause constant propagation acro…

### DIFF
--- a/sql/_36_guava/cbrd_27169/answers/cbrd_27169.answer
+++ b/sql/_36_guava/cbrd_27169/answers/cbrd_27169.answer
@@ -1,0 +1,250 @@
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+5
+===================================================
+5
+===================================================
+5
+===================================================
+0
+===================================================
+0
+===================================================
+    
+Case A: constant on tb ON clause, join term on tc ON clause -- different ON clauses     
+
+===================================================
+a    b    c    
+1     X     1     
+1     X     2     
+2     X     1     
+2     X     2     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    NESTED LOOPS (cross join)
+      NESTED LOOPS (inner join)
+        TABLE SCAN (dba.tb)
+        INDEX SCAN (dba.ta.pk_ta_a) (key range: [dba.ta].a=[dba.tb].a, covered: true)
+      INDEX SCAN (dba.tc.pk_tc_b_c) (key range: [dba.tc].b= ?:? , covered: true)
+
+  rewritten query: select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.ta.pk_ta_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+        SCAN (index: dba.tc.pk_tc_b_c), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case B: constant and join term both on tc ON clause -- same result set as A, different position     
+
+===================================================
+a    b    c    
+1     X     1     
+1     X     2     
+2     X     1     
+2     X     2     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    NESTED LOOPS (cross join)
+      NESTED LOOPS (inner join)
+        TABLE SCAN (dba.tb)
+        INDEX SCAN (dba.ta.pk_ta_a) (key range: [dba.ta].a=[dba.tb].a, covered: true)
+      INDEX SCAN (dba.tc.pk_tc_b_c) (key range: [dba.tc].b= ?:? , covered: true)
+
+  rewritten query: select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.ta.pk_ta_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+        SCAN (index: dba.tc.pk_tc_b_c), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case C: Case B wrapped as an inline view with an outer WHERE 1=1     
+
+===================================================
+a    b    c    
+1     X     1     
+1     X     2     
+2     X     1     
+2     X     2     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    NESTED LOOPS (cross join)
+      NESTED LOOPS (inner join)
+        TABLE SCAN (dba.tb)
+        INDEX SCAN (dba.ta.pk_ta_a) (key range: [dba.ta].a=[dba.tb].a, covered: true)
+      INDEX SCAN (dba.tc.pk_tc_b_c) (key range: [dba.tc].b= ?:? , covered: true)
+
+  rewritten query: (select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b)
+
+  TABLE SCAN (z)
+
+  rewritten query: select z.a, z.b, z.c from (select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b) z (a, b, c)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SCAN (index: dba.ta.pk_ta_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+            SCAN (index: dba.tc.pk_tc_b_c), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case D: same as C with the outer WHERE 1=1 removed     
+
+===================================================
+a    b    c    
+1     X     1     
+1     X     2     
+2     X     1     
+2     X     2     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    NESTED LOOPS (cross join)
+      NESTED LOOPS (inner join)
+        TABLE SCAN (dba.tb)
+        INDEX SCAN (dba.ta.pk_ta_a) (key range: [dba.ta].a=[dba.tb].a, covered: true)
+      INDEX SCAN (dba.tc.pk_tc_b_c) (key range: [dba.tc].b= ?:? , covered: true)
+
+  rewritten query: (select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b)
+
+  TABLE SCAN (z)
+
+  rewritten query: select z.a, z.b, z.c from (select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b) z (a, b, c)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SCAN (index: dba.ta.pk_ta_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+            SCAN (index: dba.tc.pk_tc_b_c), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case E: same as D with an outer JOIN ... ON in place of an outer WHERE     
+
+===================================================
+a    b    c    a    x    
+1     X     1     1     1     
+1     X     2     1     1     
+2     X     1     2     2     
+2     X     2     2     2     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    NESTED LOOPS (cross join)
+      NESTED LOOPS (inner join)
+        TABLE SCAN (dba.tb)
+        INDEX SCAN (dba.ta.pk_ta_a) (key range: [dba.ta].a=[dba.tb].a, covered: true)
+      INDEX SCAN (dba.tc.pk_tc_b_c) (key range: [dba.tc].b= ?:? , covered: true)
+
+  rewritten query: (select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b)
+
+  NESTED LOOPS (inner join)
+    TABLE SCAN (z)
+    INDEX SCAN (w.pk_ta_a) (key range: w.a=z.a)
+
+  rewritten query: select z.a, z.b, z.c, w.a, w.x from (select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b) z (a, b, c), [dba.ta] w where w.a=z.a
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.ta.pk_ta_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+      MEMOIZE (time: ?, hit: ?, miss: ?, size: ?KB, enabled: true)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SCAN (index: dba.ta.pk_ta_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+            SCAN (index: dba.tc.pk_tc_b_c), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case F: same as C but the inline view itself uses a comma join and a WHERE clause instead of ON clauses     
+
+===================================================
+a    b    c    
+1     X     1     
+1     X     2     
+2     X     1     
+2     X     2     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    NESTED LOOPS (cross join)
+      NESTED LOOPS (inner join)
+        TABLE SCAN (dba.tb)
+        INDEX SCAN (dba.ta.pk_ta_a) (key range: [dba.ta].a=[dba.tb].a, covered: true)
+      INDEX SCAN (dba.tc.pk_tc_b_c) (key range: [dba.tc].b= ?:? , covered: true)
+
+  rewritten query: (select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b)
+
+  TABLE SCAN (z)
+
+  rewritten query: select z.a, z.b, z.c from (select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b) z (a, b, c)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SCAN (index: dba.ta.pk_ta_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+            SCAN (index: dba.tc.pk_tc_b_c), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+0
+===================================================
+0

--- a/sql/_36_guava/cbrd_27169/answers/cbrd_27169.answer
+++ b/sql/_36_guava/cbrd_27169/answers/cbrd_27169.answer
@@ -7,9 +7,17 @@
 ===================================================
 0
 ===================================================
+0
+===================================================
+0
+===================================================
 5
 ===================================================
 5
+===================================================
+5
+===================================================
+1
 ===================================================
 5
 ===================================================
@@ -18,7 +26,7 @@
 0
 ===================================================
     
-Case A: constant on tb ON clause, join term on tc ON clause -- different ON clauses     
+Case 1: constant on tb ON clause, join term on tc ON clause -- different ON clauses (= report case 2)     
 
 ===================================================
 a    b    c    
@@ -50,7 +58,7 @@ Trace Statistics:
 
 ===================================================
     
-Case B: constant and join term both on tc ON clause -- same result set as A, different position     
+Case 2: constant and join term both on tc ON clause -- same result set as 1, different position (= report case 1)     
 
 ===================================================
 a    b    c    
@@ -82,7 +90,7 @@ Trace Statistics:
 
 ===================================================
     
-Case C: Case B wrapped as an inline view with an outer WHERE 1=1     
+Case 3: Case 2 wrapped as an inline view with an outer WHERE 1=1 (= report case 3)     
 
 ===================================================
 a    b    c    
@@ -122,7 +130,7 @@ Trace Statistics:
 
 ===================================================
     
-Case D: same as C with the outer WHERE 1=1 removed     
+Case 4: same as 3 with the outer WHERE 1=1 removed     
 
 ===================================================
 a    b    c    
@@ -162,14 +170,14 @@ Trace Statistics:
 
 ===================================================
     
-Case E: same as D with an outer JOIN ... ON in place of an outer WHERE     
+Case 5: same as 3 with the outer WHERE 1=1 replaced by an outer JOIN ... ON     
 
 ===================================================
-a    b    c    a    x    
-1     X     1     1     1     
-1     X     2     1     1     
-2     X     1     2     2     
-2     X     2     2     2     
+a    b    c    
+1     X     1     
+1     X     2     
+2     X     1     
+2     X     2     
 
 ===================================================
 trace    
@@ -184,18 +192,17 @@ Query Plan:
 
   rewritten query: (select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b)
 
-  NESTED LOOPS (inner join)
+  NESTED LOOPS (cross join)
     TABLE SCAN (z)
-    INDEX SCAN (w.pk_ta_a) (key range: w.a=z.a)
+    TABLE SCAN (w)
 
-  rewritten query: select z.a, z.b, z.c, w.a, w.x from (select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b) z (a, b, c), [dba.ta] w where w.a=z.a
+  rewritten query: select z.a, z.b, z.c from (select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b) z (a, b, c), [dba.td] w
 
 
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      SCAN (index: dba.ta.pk_ta_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
-      MEMOIZE (time: ?, hit: ?, miss: ?, size: ?KB, enabled: true)
+      SCAN (table: dba.td), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
@@ -206,7 +213,235 @@ Trace Statistics:
 
 ===================================================
     
-Case F: same as C but the inline view itself uses a comma join and a WHERE clause instead of ON clauses     
+Case 6: same as 3 but the inline view itself uses a comma join and a WHERE clause instead of ON clauses     
+
+===================================================
+a    b    c    
+1     X     1     
+1     X     2     
+2     X     1     
+2     X     2     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    NESTED LOOPS (cross join)
+      NESTED LOOPS (inner join)
+        TABLE SCAN (dba.tb)
+        INDEX SCAN (dba.ta.pk_ta_a) (key range: [dba.ta].a=[dba.tb].a, covered: true)
+      INDEX SCAN (dba.tc.pk_tc_b_c) (key range: [dba.tc].b= ?:? , covered: true)
+
+  rewritten query: (select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b)
+
+  TABLE SCAN (z)
+
+  rewritten query: select z.a, z.b, z.c from (select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b) z (a, b, c)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SCAN (index: dba.ta.pk_ta_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+            SCAN (index: dba.tc.pk_tc_b_c), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 7: constant on tb propagated two joins away to te via tc     
+
+===================================================
+a    b    c    d    
+1     X     1     1     
+1     X     1     2     
+1     X     2     1     
+1     X     2     2     
+2     X     1     1     
+2     X     1     2     
+2     X     2     1     
+2     X     2     2     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    NESTED LOOPS (cross join)
+      NESTED LOOPS (cross join)
+        NESTED LOOPS (inner join)
+          TABLE SCAN (dba.tb)
+          INDEX SCAN (dba.ta.pk_ta_a) (key range: [dba.ta].a=[dba.tb].a, covered: true)
+        INDEX SCAN (dba.tc.pk_tc_b_c) (key range: [dba.tc].b= ?:? , covered: true)
+      INDEX SCAN (dba.te.pk_te_b_d) (key range: [dba.te].b= ?:? , covered: true)
+
+  rewritten query: select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c, [dba.te].d from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc], [dba.te] [dba.te] where [dba.ta].a=[dba.tb].a and [dba.te].b= ?:?  and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b and [dba.tc].b=[dba.te].b
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.ta.pk_ta_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+        SCAN (index: dba.tc.pk_tc_b_c), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+          SCAN (index: dba.te.pk_te_b_d), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 8: UNION ALL of two branches with different constants, wrapped in an outer WHERE 1=1     
+
+===================================================
+a    b    c    
+1     X     1     
+1     X     2     
+2     X     1     
+2     X     2     
+3     Y     3     
+3     Y     4     
+4     Y     3     
+4     Y     4     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    NESTED LOOPS (cross join)
+      NESTED LOOPS (inner join)
+        TABLE SCAN (dba.tb)
+        INDEX SCAN (dba.ta.pk_ta_a) (key range: [dba.ta].a=[dba.tb].a, covered: true)
+      INDEX SCAN (dba.tc.pk_tc_b_c) (key range: [dba.tc].b= ?:? , covered: true)
+
+  rewritten query: select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b
+
+  SORT (distinct)
+    NESTED LOOPS (cross join)
+      NESTED LOOPS (inner join)
+        TABLE SCAN (dba.tb)
+        INDEX SCAN (dba.ta.pk_ta_a) (key range: [dba.ta].a=[dba.tb].a, covered: true)
+      INDEX SCAN (dba.tc.pk_tc_b_c) (key range: [dba.tc].b= ?:? , covered: true)
+
+  rewritten query: select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b
+
+  TABLE SCAN (z)
+
+  rewritten query: select z.a, z.b, z.c from (select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b union all select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc] where [dba.ta].a=[dba.tb].a and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b) z (a, b, c)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+            SCAN (index: dba.ta.pk_ta_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+              SCAN (index: dba.tc.pk_tc_b_c), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+          ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+            SCAN (index: dba.ta.pk_ta_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+              SCAN (index: dba.tc.pk_tc_b_c), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+          ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 9: constant on tb fanned out to two separate join columns, tc.b and te.b     
+
+===================================================
+a    b    c    d    
+1     X     1     1     
+1     X     1     2     
+1     X     2     1     
+1     X     2     2     
+2     X     1     1     
+2     X     1     2     
+2     X     2     1     
+2     X     2     2     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    NESTED LOOPS (cross join)
+      NESTED LOOPS (cross join)
+        NESTED LOOPS (inner join)
+          TABLE SCAN (dba.tb)
+          INDEX SCAN (dba.ta.pk_ta_a) (key range: [dba.ta].a=[dba.tb].a, covered: true)
+        INDEX SCAN (dba.tc.pk_tc_b_c) (key range: [dba.tc].b= ?:? , covered: true)
+      INDEX SCAN (dba.te.pk_te_b_d) (key range: [dba.te].b= ?:? , covered: true)
+
+  rewritten query: select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c, [dba.te].d from [dba.ta] [dba.ta], [dba.tb] [dba.tb], [dba.tc] [dba.tc], [dba.te] [dba.te] where [dba.ta].a=[dba.tb].a and [dba.te].b= ?:?  and [dba.tc].b= ?:?  and [dba.tb].b= ?:?  and [dba.tb].b=[dba.tc].b and [dba.tb].b=[dba.te].b
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (index: dba.ta.pk_ta_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+        SCAN (index: dba.tc.pk_tc_b_c), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+          SCAN (index: dba.te.pk_te_b_d), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+1
+===================================================
+1
+===================================================
+    
+Case 10: same as 3 but the inline view uses a LEFT OUTER JOIN to tc     
+
+===================================================
+a    b    c    
+1     X     1     
+1     X     2     
+2     X     1     
+2     X     2     
+3     Y     null     
+4     Y     null     
+5     Z     null     
+6     W     null     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    NESTED LOOPS (left outer join)
+      NESTED LOOPS (inner join)
+        TABLE SCAN (dba.tb)
+        INDEX SCAN (dba.ta.pk_ta_a) (key range: [dba.ta].a=[dba.tb].a, covered: true)
+      INDEX SCAN (dba.tc.pk_tc_b_c) (key range: [dba.tb].b=[dba.tc].b, key filter: [dba.tc].b= ?:? )
+
+  rewritten query: (select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta] inner join [dba.tb] [dba.tb] on [dba.ta].a=[dba.tb].a left outer join [dba.tc] [dba.tc] on [dba.tb].b=[dba.tc].b and [dba.tb].b= ?:?  and [dba.tc].b= ?:? )
+
+  SORT (order by)
+    TABLE SCAN (z)
+
+  rewritten query: select z.a, z.b, z.c from (select distinct [dba.ta].a, [dba.tb].b, [dba.tc].c from [dba.ta] [dba.ta] inner join [dba.tb] [dba.tb] on [dba.ta].a=[dba.tb].a left outer join [dba.tc] [dba.tc] on [dba.tb].b=[dba.tc].b and [dba.tb].b= ?:?  and [dba.tc].b= ?:? ) z (a, b, c) order by ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SCAN (index: dba.ta.pk_ta_a), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?, covered: true)
+            SCAN (index: dba.tc.pk_tc_b_c), (btree time: ?, fetch: ?, ioread: ?, readkeys: ?, filteredkeys: ?, rows: ?) (lookup time: ?, rows: ?)
+            MEMOIZE (time: ?, hit: ?, miss: ?, size: ?KB, enabled: true)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 11: Case 3 nested one level deeper, with an outer condition list at each level     
 
 ===================================================
 a    b    c    

--- a/sql/_36_guava/cbrd_27169/cases/cbrd_27169.sql
+++ b/sql/_36_guava/cbrd_27169/cases/cbrd_27169.sql
@@ -1,0 +1,133 @@
+/*
+ * This test case verifies CBRD-27169 : an ON-clause constant term is not
+ * always propagated (transitive closure) into the join column it should
+ * constrain, depending on where in the ON clauses it is physically written,
+ * and whether the query is wrapped as an inline view with an outer WHERE.
+ *
+ * Bug: qo_reduce_equality_terms() needs ON-clause conditions already merged
+ * into WHERE, and inner-join-only segment locations already reset, before it
+ * can propagate a constant term across a join column (e.g. tb.b = X and
+ * tb.b = tc.b should let it infer tc.b = X too). Both prerequisites could
+ * still be pending when the propagation ran, and the propagation itself was
+ * one-shot, so:
+ *   - a constant term written in one tables ON clause was not propagated to
+ *     a join term written in a different tables ON clause (Case A)
+ *   - wrapping the query as an inline view with any outer WHERE list forced
+ *     the propagation pass to run before the ON-to-WHERE merge happened
+ *     inside the view, so it silently missed the propagation entirely
+ *     (Cases C and E)
+ *
+ * Fix: qo_reduce_equality_terms_post() now performs both prerequisites (the
+ * ON-to-WHERE merge and the segment location reset) immediately before the
+ * propagation runs, instead of relying on them having already happened.
+ *
+ * Note: table names use letters (ta/tb/tc), not digits, because CTP masks
+ * digits in the trace output to ?, same convention as CBRD-26571
+ * cbrd_26571.sql and CBRD-26522s cbrd_26522.sql. The original report used
+ * t1/t2/t3, which would all collapse to the indistinguishable t? here.
+ *
+ * How to read the trace: each cases rewritten query is checked for an
+ * auto-added tc.b= ? term. If present, the constant was propagated into tc
+ * (the fix is working) - if absent, tc must fall back to a full index range
+ * scan on its join column instead of the direct-b key range CBRD-27169 is
+ * about.
+ *
+ * Coverage (per the original report, before / after this fix, 11.5 basis):
+ *              A     B     C     D     E     F
+ *   before     no    yes   no    yes   no    yes
+ *   after      yes   yes   yes   yes   yes   yes
+ *
+ *   Case A: the constant (tb.b = X) is written in tbs own ON clause, the
+ *           join term (tb.b = tc.b) in tcs -- different ON clauses
+ *   Case B: the constant and the join term are both written in tcs ON
+ *           clause -- same result set as A, only the writing position
+ *           differs
+ *   Case C: Case B wrapped as an inline view with an outer WHERE 1 = 1 --
+ *           the inline views own DISTINCT already blocks view merging, so
+ *           this isolates the effect of the outer WHERE list existing at all
+ *   Case D: same as C but with the outer WHERE 1 = 1 removed -- isolates
+ *           whether an outer WHERE lists mere existence (not its meaning)
+ *           is what blocks propagation inside the view
+ *   Case E: same as D but the outer WHERE is replaced by an outer JOIN ...
+ *           ON instead -- isolates whether it is WHERE syntax specifically,
+ *           or any outer condition list, that matters
+ *   Case F: same as C but the inline view itself is written with an
+ *           old-style comma join and a WHERE clause instead of ON clauses --
+ *           checks the fix also covers a constant that started out written
+ *           directly in a WHERE clause, not an ON clause
+ */
+
+drop table if exists tc, tb, ta;
+create table ta (a int primary key, x int);
+create table tb (a int primary key, b varchar(10));
+create table tc (b varchar(10), c int, primary key (b, c));
+
+insert into ta values (1,1), (2,2), (3,3), (4,4), (5,5);
+insert into tb values (1,'X'), (2,'X'), (3,'Y'), (4,'Y'), (5,'Z');
+insert into tc values ('X',1), ('X',2), ('Y',3), ('Y',4), ('Z',5);
+
+update statistics on all classes;
+
+set trace on;
+
+
+evaluate 'Case A: constant on tb ON clause, join term on tc ON clause -- different ON clauses';
+select /*+ recompile */ distinct ta.a, tb.b, tc.c
+from ta
+  inner join tb on ta.a = tb.a and tb.b = 'X'
+  inner join tc on tb.b = tc.b;
+show trace;
+
+
+evaluate 'Case B: constant and join term both on tc ON clause -- same result set as A, different position';
+select /*+ recompile */ distinct ta.a, tb.b, tc.c
+from ta
+  inner join tb on ta.a = tb.a
+  inner join tc on tb.b = tc.b and tb.b = 'X';
+show trace;
+
+
+evaluate 'Case C: Case B wrapped as an inline view with an outer WHERE 1=1';
+select /*+ recompile */ * from (
+  select distinct ta.a, tb.b, tc.c
+  from ta
+    inner join tb on ta.a = tb.a
+    inner join tc on tb.b = tc.b and tb.b = 'X'
+) z
+where 1 = 1;
+show trace;
+
+
+evaluate 'Case D: same as C with the outer WHERE 1=1 removed';
+select /*+ recompile */ * from (
+  select distinct ta.a, tb.b, tc.c
+  from ta
+    inner join tb on ta.a = tb.a
+    inner join tc on tb.b = tc.b and tb.b = 'X'
+) z;
+show trace;
+
+
+evaluate 'Case E: same as D with an outer JOIN ... ON in place of an outer WHERE';
+select /*+ recompile */ * from (
+  select distinct ta.a, tb.b, tc.c
+  from ta
+    inner join tb on ta.a = tb.a
+    inner join tc on tb.b = tc.b and tb.b = 'X'
+) z
+  inner join ta w on w.a = z.a;
+show trace;
+
+
+evaluate 'Case F: same as C but the inline view itself uses a comma join and a WHERE clause instead of ON clauses';
+select /*+ recompile */ * from (
+  select distinct ta.a, tb.b, tc.c
+  from ta, tb, tc
+  where ta.a = tb.a and tb.b = tc.b and tb.b = 'X'
+) z
+where 1 = 1;
+show trace;
+
+set trace off;
+
+drop table if exists tc, tb, ta;

--- a/sql/_36_guava/cbrd_27169/cases/cbrd_27169.sql
+++ b/sql/_36_guava/cbrd_27169/cases/cbrd_27169.sql
@@ -11,11 +11,11 @@
  * still be pending when the propagation ran, and the propagation itself was
  * one-shot, so:
  *   - a constant term written in one tables ON clause was not propagated to
- *     a join term written in a different tables ON clause (Case A)
+ *     a join term written in a different tables ON clause (Case 1)
  *   - wrapping the query as an inline view with any outer WHERE list forced
  *     the propagation pass to run before the ON-to-WHERE merge happened
  *     inside the view, so it silently missed the propagation entirely
- *     (Cases C and E)
+ *     (Cases 3 and 5)
  *
  * Fix: qo_reduce_equality_terms_post() now performs both prerequisites (the
  * ON-to-WHERE merge and the segment location reset) immediately before the
@@ -32,46 +32,81 @@
  * scan on its join column instead of the direct-b key range CBRD-27169 is
  * about.
  *
- * Coverage (per the original report, before / after this fix, 11.5 basis):
- *              A     B     C     D     E     F
+ * Coverage (per the original report, before / after this fix, 11.5 basis)
+ *              1     2     3     4     5     6
  *   before     no    yes   no    yes   no    yes
  *   after      yes   yes   yes   yes   yes   yes
  *
- *   Case A: the constant (tb.b = X) is written in tbs own ON clause, the
+ *   Case 1: the constant (tb.b = X) is written in tbs own ON clause, the
  *           join term (tb.b = tc.b) in tcs -- different ON clauses
- *   Case B: the constant and the join term are both written in tcs ON
- *           clause -- same result set as A, only the writing position
+ *   Case 2: the constant and the join term are both written in tcs ON
+ *           clause -- same result set as 1, only the writing position
  *           differs
- *   Case C: Case B wrapped as an inline view with an outer WHERE 1 = 1 --
+ *   Case 3: Case 2 wrapped as an inline view with an outer WHERE 1 = 1 --
  *           the inline views own DISTINCT already blocks view merging, so
  *           this isolates the effect of the outer WHERE list existing at all
- *   Case D: same as C but with the outer WHERE 1 = 1 removed -- isolates
+ *   Case 4: same as 3 but with the outer WHERE 1 = 1 removed -- isolates
  *           whether an outer WHERE lists mere existence (not its meaning)
  *           is what blocks propagation inside the view
- *   Case E: same as D but the outer WHERE is replaced by an outer JOIN ...
- *           ON instead -- isolates whether it is WHERE syntax specifically,
- *           or any outer condition list, that matters
- *   Case F: same as C but the inline view itself is written with an
+ *   Case 5: same as 3 but the outer WHERE 1 = 1 is replaced by an outer
+ *           JOIN ... ON instead -- isolates whether it is WHERE syntax
+ *           specifically, or any outer condition list, that matters
+ *   Case 6: same as 3 but the inline view itself is written with an
  *           old-style comma join and a WHERE clause instead of ON clauses --
  *           checks the fix also covers a constant that started out written
  *           directly in a WHERE clause, not an ON clause
+ *   Case 7: the constant on tb is propagated through tc to a table two
+ *           joins away (te) via two separate equality ON terms -- checks
+ *           the propagation is transitive across more than one hop, not
+ *           just the one directly-connected join column
+ *   Case 8: same UNION ALL query as two branches, one constrained to X
+ *           and the other to Y, wrapped with an outer WHERE 1 = 1 --
+ *           checks each branch gets its own constant propagated
+ *           independently instead of one branch leaking into the other
+ *   Case 9: the constant on tb is propagated to two different join
+ *           columns (tc.b and te.b) that both connect directly to tb.b --
+ *           checks propagation fans out to every connected join column,
+ *           not just the first one found
+ *   Case 10: same as 3 but the inline view uses a LEFT OUTER JOIN to tc
+ *           instead of an inner join -- adds row (6,6)/(6,W) with no
+ *           matching tc row, so this checks the propagated constant does
+ *           not turn the preserved (non-matching) outer row into a match
+ *   Case 11: Case 3 nested one level deeper, with an outer condition list
+ *           at each nesting level -- checks the propagation survives more
+ *           than one level of the ON-to-WHERE merge the fix performs
+ *
+ * Note: Cases 10 and 11 add ta row (6,6) and tb row (6,W) right before
+ * they run -- tc has no row with b = W, so this row only matters for the
+ * outer join in Case 10; Cases 1-9 already ran against the original 5-row
+ * data by the time this insert happens.
+ *
+ * Note: Cases 7 and 9 use te, a table shaped like tc (b varchar(10) key
+ * column plus a payload column), instead of reusing td -- td only has a
+ * single unkeyed row and exists solely so Case 5s outer join has a target
+ * whose join condition (1 = 1) does not reference any inline-view column
+ * reusing it as a b-keyed join target here would also multiply the row
+ * count of Case 5s inline-view cross join into it.
  */
 
-drop table if exists tc, tb, ta;
+drop table if exists te, td, tc, tb, ta;
 create table ta (a int primary key, x int);
 create table tb (a int primary key, b varchar(10));
 create table tc (b varchar(10), c int, primary key (b, c));
+create table td (d int primary key);
+create table te (b varchar(10), d int, primary key (b, d));
 
 insert into ta values (1,1), (2,2), (3,3), (4,4), (5,5);
 insert into tb values (1,'X'), (2,'X'), (3,'Y'), (4,'Y'), (5,'Z');
 insert into tc values ('X',1), ('X',2), ('Y',3), ('Y',4), ('Z',5);
+insert into td values (1);
+insert into te values ('X',1), ('X',2), ('Y',3), ('Y',4), ('Z',5);
 
 update statistics on all classes;
 
 set trace on;
 
 
-evaluate 'Case A: constant on tb ON clause, join term on tc ON clause -- different ON clauses';
+evaluate 'Case 1: constant on tb ON clause, join term on tc ON clause -- different ON clauses (= report case 2)';
 select /*+ recompile */ distinct ta.a, tb.b, tc.c
 from ta
   inner join tb on ta.a = tb.a and tb.b = 'X'
@@ -79,7 +114,7 @@ from ta
 show trace;
 
 
-evaluate 'Case B: constant and join term both on tc ON clause -- same result set as A, different position';
+evaluate 'Case 2: constant and join term both on tc ON clause -- same result set as 1, different position (= report case 1)';
 select /*+ recompile */ distinct ta.a, tb.b, tc.c
 from ta
   inner join tb on ta.a = tb.a
@@ -87,7 +122,7 @@ from ta
 show trace;
 
 
-evaluate 'Case C: Case B wrapped as an inline view with an outer WHERE 1=1';
+evaluate 'Case 3: Case 2 wrapped as an inline view with an outer WHERE 1=1 (= report case 3)';
 select /*+ recompile */ * from (
   select distinct ta.a, tb.b, tc.c
   from ta
@@ -98,7 +133,7 @@ where 1 = 1;
 show trace;
 
 
-evaluate 'Case D: same as C with the outer WHERE 1=1 removed';
+evaluate 'Case 4: same as 3 with the outer WHERE 1=1 removed';
 select /*+ recompile */ * from (
   select distinct ta.a, tb.b, tc.c
   from ta
@@ -108,18 +143,18 @@ select /*+ recompile */ * from (
 show trace;
 
 
-evaluate 'Case E: same as D with an outer JOIN ... ON in place of an outer WHERE';
-select /*+ recompile */ * from (
+evaluate 'Case 5: same as 3 with the outer WHERE 1=1 replaced by an outer JOIN ... ON';
+select /*+ recompile */ z.a, z.b, z.c from (
   select distinct ta.a, tb.b, tc.c
   from ta
     inner join tb on ta.a = tb.a
     inner join tc on tb.b = tc.b and tb.b = 'X'
 ) z
-  inner join ta w on w.a = z.a;
+  inner join td w on 1 = 1;
 show trace;
 
 
-evaluate 'Case F: same as C but the inline view itself uses a comma join and a WHERE clause instead of ON clauses';
+evaluate 'Case 6: same as 3 but the inline view itself uses a comma join and a WHERE clause instead of ON clauses';
 select /*+ recompile */ * from (
   select distinct ta.a, tb.b, tc.c
   from ta, tb, tc
@@ -128,6 +163,66 @@ select /*+ recompile */ * from (
 where 1 = 1;
 show trace;
 
+
+evaluate 'Case 7: constant on tb propagated two joins away to te via tc';
+select /*+ recompile */ distinct ta.a, tb.b, tc.c, te.d
+from ta
+  inner join tb on ta.a = tb.a and tb.b = 'X'
+  inner join tc on tb.b = tc.b
+  inner join te on tc.b = te.b;
+show trace;
+
+
+evaluate 'Case 8: UNION ALL of two branches with different constants, wrapped in an outer WHERE 1=1';
+select /*+ recompile */ * from (
+  select distinct ta.a, tb.b, tc.c
+    from ta inner join tb on ta.a = tb.a inner join tc on tb.b = tc.b and tb.b = 'X'
+  union all
+  select distinct ta.a, tb.b, tc.c
+    from ta inner join tb on ta.a = tb.a inner join tc on tb.b = tc.b and tb.b = 'Y'
+) z
+where 1 = 1;
+show trace;
+
+
+evaluate 'Case 9: constant on tb fanned out to two separate join columns, tc.b and te.b';
+select /*+ recompile */ distinct ta.a, tb.b, tc.c, te.d
+from ta
+  inner join tb on ta.a = tb.a and tb.b = 'X'
+  inner join tc on tb.b = tc.b
+  inner join te on tb.b = te.b;
+show trace;
+
+
+insert into ta values (6,6);
+insert into tb values (6,'W');
+
+
+evaluate 'Case 10: same as 3 but the inline view uses a LEFT OUTER JOIN to tc';
+select /*+ recompile */ * from (
+  select distinct ta.a, tb.b, tc.c
+  from ta
+    inner join tb on ta.a = tb.a
+    left outer join tc on tb.b = tc.b and tb.b = 'X'
+) z
+where 1 = 1
+order by z.a, z.c;
+show trace;
+
+
+evaluate 'Case 11: Case 3 nested one level deeper, with an outer condition list at each level';
+select /*+ recompile */ * from (
+  select y.a, y.b, y.c from (
+    select distinct ta.a, tb.b, tc.c
+    from ta
+      inner join tb on ta.a = tb.a
+      inner join tc on tb.b = tc.b and tb.b = 'X'
+  ) y
+  where 1 = 1
+) z
+where 1 = 1;
+show trace;
+
 set trace off;
 
-drop table if exists tc, tb, ta;
+drop table if exists te, td, tc, tb, ta;


### PR DESCRIPTION
…ss joins

to refer : http://jira.cubrid.org/browse/CBRD-27169

### Purpose
ON절에 적힌 상수 조건이, 그 상수와 조인 조건이 서로 다른 테이블의 ON절에 나뉘어 적혀 있거나, 인라인 뷰 안에 있고 바깥 문장에 WHERE절이 있을 때 조인 컬럼으로 전이(propagation)되지 않는 문제.

qo_reduce_equality_terms()가 상수를 전이하려면 그 전에 ON절 조건들이 이미 WHERE로 병합되어 있어야 하고,
inner-join-only 세그먼트의 location도 이미 리셋되어 있어야 합니다.
그런데 이 두 전제 조건이 실제로는 전이 로직이 실행된 "이후에" 충족되는 경우가 있었고, 전이 자체는 1회성이라
그 기회를 놓치면 다시 시도되지 않았습니다.
그 결과:
  - 상수(tb.b = X)가 한 테이블의 ON절에, 조인 조건(tb.b = tc.b)이 다른 테이블의 ON절에 나뉘어 있으면 전이가 안 됨
  - 쿼리를 인라인 뷰로 감싸고 바깥에 WHERE절을 붙이면, 뷰 내부의 ON→WHERE 병합이 일어나기 전에 전이 로직이 먼저 실행되어 버려서 전이가 통째로 누락됨

수정: qo_reduce_equality_terms_post()에서 전이를 실행하기 직전에 두 전제 조건(ON→WHERE 병합, 세그먼트 location 리셋)을 직접 수행하도록 변경.
기존 호출부는 그대로 두되 no-op이 되도록 함. outer join 세그먼트와 계층형 쿼리(hierarchical query)는 영향받지 않음.

관련 커밋: CUBRID/cubrid#7616 (develop, 7c7d70e031, 2026-08-13 머지)
 — src/optimizer/rewriter/query_rewrite.h, query_rewrite_select.c, query_rewrite_term.c. 백포트: #7694 (release/11.4, 2026-08-14 머지).

### Implementation
Case 1~11로 상수가 적히는 위치, 인라인 뷰/바깥 조건 유무, outer join, 뷰 중첩 등 조건별 전이 여부를 확인합니다.
원본 재현 자료의 테이블명 t1/t2/t3는 CTP가 트레이스에서 숫자를 ?로 마스킹해 서로 구분이 안 되므로 ta/tb/tc로 변경했습니다.
(리뷰 과정에서 케이스 라벨을 A~I 문자에서 1~11 숫자로 통일했습니다 — 아래 번호는 최신 기준입니다.)

- Case 1: 상수(tb.b = X)는 tb의 ON절에, 조인 조건(tb.b = tc.b)은 tc의 ON절에 — 서로 다른 ON절에 나뉜 경우
- Case 2: 상수와 조인 조건을 둘 다 tc의 ON절에 — Case 1과 결과셋은 동일하고 작성 위치만 다름
- Case 3: Case 2를 인라인 뷰로 감싸고 바깥에 WHERE 1=1을 붙인 경우
- Case 4: Case 3에서 바깥 WHERE 1=1을 제거 — 조건의 의미가 아니라 바깥에 WHERE절이 "존재하는 것" 자체가 원인인지 격리
- Case 5: Case 3의 바깥 WHERE 대신 바깥 JOIN ... ON을 사용 — WHERE 문법 자체가 아니라 바깥에 어떤 조건 목록이든 있으면 문제가 되는지 격리
- Case 6: Case 3과 동일하되 인라인 뷰 내부를 ON절 대신 콤마 조인 + WHERE절로 작성 — 상수가 애초에 WHERE절에 적힌 경우도 수정이 커버하는지 확인
- Case 7 (ssihil 제안): 상수가 tb→tc→te로 2-hop 떨어진 테이블까지 전이되는지 — 1-hop뿐 아니라 전이가 여러 단계를 거쳐도 되는지 확인
- Case 8 (ssihil 제안): 같은 상수 전이 케이스를 UNION ALL 두 분기(각각 다른 상수값)로 감싼 경우 — 분기끼리 전이가 서로 섞이지 않는지 확인
- Case 9 (ssihil 제안): 하나의 상수가 tc.b, te.b 두 개의 서로 다른 조인 컬럼으로 동시에 전이(fan-out)되는지 확인
- Case 10 (bagus-kim 제안): Case 3의 인라인 뷰 내부 조인을 LEFT OUTER JOIN으로 교체 — 전이된 상수가 outer join의 매칭 안 되는(NULL 확장) 행을 사라지게 만들지 않는지 확인
- Case 11 (bagus-kim 제안): Case 3을 한 단계 더 중첩(뷰 안에 뷰, 각 레벨에 바깥 조건 목록)한 경우에도 전이가 유지되는지 확인

각 케이스는 트레이스의 rewritten query에서 tc.b= ? (Case 7/9는 te.b= ? 도 함께) 항이 자동 생성되는지,
그리고 실행계획이 해당 인덱스의 key range(Case 10은 outer join 특성상 key filter)로 이 조건을 쓰는지로 전이 성공 여부를 확인합니다.

Case 7과 9는 tc와 같은 모양(b 키 컬럼 + payload 컬럼)의 새 테이블 te를 사용합니다. td는 Case 5에서
"뷰 컬럼을 참조하지 않는 자명한(1=1) 조인 대상"으로 쓰는 1행짜리 테이블이라 b 키가 없어 재사용할 수 없었고,
재사용 시 Case 5의 cross join 행 수가 곱해지는 부작용도 있었습니다.

### Remarks
- 검증 도중 서버의 CUBRID빌드가 11.5.0(develop)에서 11.4.6.1932-7654942(release/11.4, Aug 18빌드)로 바뀌어 있었는데
  (공유 서버, 다른 작업자 활동으로 추정), 두 빌드 모두에서 원래 6개 케이스(현재 Case 1~6) 전부 정상적으로 전이가 확인됐습니다.
- 11.4.6 빌드에서 정상 동작한 것은 release/11.4 백포트 PR #7694(2026-08-14 머지)가 이 빌드(Aug 18)에 포함되어 있기 때문으로,
  커밋 이력과 실측 결과가 정확히 일치합니다.
- 리뷰 대응으로 Case 5(구 Case E)의 설명 문구 오류(비교 대상이 D가 아니라 C)와 인라인 뷰 컬럼 참조 문제(뷰 컬럼을
  참조하는 조인이라 WHERE-vs-JOIN 비교에 변수가 하나 더 섞여 있었음 — td를 te로 교체해 해결, 답지의 불필요한
  MEMOIZE 라인도 함께 제거됨)를 수정했습니다. Case 1/2/3에는 원본 지라 리포트의 재현 케이스 번호(1/2/3)와의
  매핑 주석도 추가했습니다.
- Case 7~11 모두 develop 11.5.0.2521-8e355ff 빌드에서 살아있는 서버에 직접 csql로 접속해 실행하고, 자동 마스킹
  스크립트로 원시 출력과 답지를 재대조해 바이트 단위 일치를 확인했습니다 — 전부 회귀 없이 정상 동작합니다.
