### PR TITLE
[CBRD-27158-11.4] Backport from develop to 11.4 - fix query plan trace answer for 11.4's leaner trace output

### DIFF
--- a/sql/_36_guava/cbrd_27158/answers/cbrd_27158.answer
+++ b/sql/_36_guava/cbrd_27158/answers/cbrd_27158.answer
@@ -49,21 +49,18 @@ Query Plan:
 
 Trace Statistics:
   UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
   ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
@@ -104,23 +101,18 @@ Query Plan:
 
 Trace Statistics:
   UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
   ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
@@ -158,21 +150,18 @@ Query Plan:
 
 Trace Statistics:
   INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-               (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
   ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
@@ -209,21 +198,18 @@ Query Plan:
 
 Trace Statistics:
   DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-             (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -274,30 +260,25 @@ Query Plan:
 
 Trace Statistics:
   UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-          (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-        ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
         SUBQUERY (uncorrelated)
           SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
             SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-            GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+            GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-        ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
         SUBQUERY (uncorrelated)
           SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
             SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-            GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+            GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
   ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
@@ -346,21 +327,18 @@ Trace Statistics:
     SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
       UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-            (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
           SUBQUERY (uncorrelated)
             SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
               SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
           SUBQUERY (uncorrelated)
             SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
               SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -397,11 +375,10 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.td), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -437,17 +414,15 @@ Query Plan:
 
 Trace Statistics:
   UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
           SUBQUERY (uncorrelated)
             SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
               SCAN (table: dba.td), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (table: dba.te), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
@@ -492,11 +467,10 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.tf), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -532,17 +506,15 @@ Query Plan:
 
 Trace Statistics:
   UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
           SUBQUERY (uncorrelated)
             SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
               SCAN (table: dba.tf), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (table: dba.tg), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
@@ -573,11 +545,10 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.tf), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -613,17 +584,15 @@ Query Plan:
 
 Trace Statistics:
   UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
           SUBQUERY (uncorrelated)
             SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
               SCAN (table: dba.tf), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (table: dba.tg), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
@@ -654,12 +623,11 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
     ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.tf), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -695,18 +663,16 @@ Query Plan:
 
 Trace Statistics:
   UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
           ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
           SUBQUERY (uncorrelated)
             SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
               SCAN (table: dba.tf), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (table: dba.tg), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
@@ -737,12 +703,10 @@ Query Plan:
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
-    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.tf), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
      
 
 ===================================================
@@ -778,18 +742,15 @@ Query Plan:
 
 Trace Statistics:
   UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
-          ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
           SUBQUERY (uncorrelated)
             SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
               SCAN (table: dba.tf), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (table: dba.tg), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
      
@@ -844,21 +805,18 @@ Query Plan:
 
 Trace Statistics:
   UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (table: dba.tp), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (table: dba.tq), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
   ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
@@ -900,23 +858,18 @@ Query Plan:
 
 Trace Statistics:
   UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (table: dba.tp), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (table: dba.tq), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
   ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 
@@ -954,21 +907,18 @@ Query Plan:
 
 Trace Statistics:
   INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-               (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (table: dba.tp), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
     SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
       SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
       SUBQUERY (uncorrelated)
         SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
           SCAN (table: dba.tp), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, rows: ?)
   ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      
 

--- a/sql/_36_guava/cbrd_27158/answers/cbrd_27158.answer
+++ b/sql/_36_guava/cbrd_27158/answers/cbrd_27158.answer
@@ -1,0 +1,982 @@
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+5
+===================================================
+3
+===================================================
+0
+===================================================
+0
+===================================================
+    
+Case 1: GROUP BY + window function in two UNION ALL branches -> correct values and unique hidden column names     
+
+===================================================
+grp    sum(val)    running_total    
+g1     30     30     
+g1     300     300     
+g2     70     100     
+g2     300     600     
+g3     50     150     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.ta)
+
+  rewritten query: (select [dba.ta].grp, sum([dba.ta].val), sum([dba.ta].val) from [dba.ta] [dba.ta] group by [dba.ta].grp)
+
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select a_?, a_?, sum(a_?) over (order by ?) from (select [dba.ta].grp, sum([dba.ta].val), sum([dba.ta].val) from [dba.ta] [dba.ta] group by [dba.ta].grp) [dba.ta] (a_?, a_?, a_?)
+
+  SORT (group by)
+    TABLE SCAN (dba.tb)
+
+  rewritten query: (select [dba.tb].grp, sum([dba.tb].val), sum([dba.tb].val) from [dba.tb] [dba.tb] group by [dba.tb].grp)
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select a_?, a_?, sum(a_?) over (order by ?) from (select [dba.tb].grp, sum([dba.tb].val), sum([dba.tb].val) from [dba.tb] [dba.tb] group by [dba.tb].grp) [dba.tb] (a_?, a_?, a_?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+  ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 2: two window functions in the same branch (row_number, rank) -> each must get its own unique hidden column     
+
+===================================================
+grp    s    rn    rk    
+g1     30     1     3     
+g1     300     1     1     
+g2     70     3     1     
+g2     300     2     2     
+g3     50     2     2     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.ta)
+
+  rewritten query: (select [dba.ta].grp, sum([dba.ta].val) from [dba.ta] [dba.ta] group by [dba.ta].grp)
+
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select a_?, a_?, row_number() over (order by ?, ?), rank() over (order by ? desc , ?) from (select [dba.ta].grp, sum([dba.ta].val) as [s] from [dba.ta] [dba.ta] group by [dba.ta].grp) [dba.ta] (a_?, a_?)
+
+  SORT (group by)
+    TABLE SCAN (dba.tb)
+
+  rewritten query: (select [dba.tb].grp, sum([dba.tb].val) from [dba.tb] [dba.tb] group by [dba.tb].grp)
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select a_?, a_?, row_number() over (order by ?, ?), rank() over (order by ? desc , ?) from (select [dba.tb].grp, sum([dba.tb].val) as [s] from [dba.tb] [dba.tb] group by [dba.tb].grp) [dba.tb] (a_?, a_?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+  ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 3: GROUP BY + window function combined via INTERSECT -> the fix must cover INTERSECT too     
+
+===================================================
+grp    sum(val)    running_total    
+g1     30     30     
+g2     70     100     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.ta)
+
+  rewritten query: (select [dba.ta].grp, sum([dba.ta].val), sum([dba.ta].val) from [dba.ta] [dba.ta] group by [dba.ta].grp)
+
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select a_?, a_?, sum(a_?) over (order by ?) from (select [dba.ta].grp, sum([dba.ta].val), sum([dba.ta].val) from [dba.ta] [dba.ta] group by [dba.ta].grp) [dba.ta] (a_?, a_?, a_?)
+
+  SORT (group by)
+    TABLE SCAN (dba.ta)
+
+  rewritten query: (select [dba.ta].grp, sum([dba.ta].val), sum([dba.ta].val) from [dba.ta] [dba.ta] where [dba.ta].grp<>'g?' group by [dba.ta].grp)
+
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select a_?, a_?, sum(a_?) over (order by ?) from (select [dba.ta].grp, sum([dba.ta].val), sum([dba.ta].val) from [dba.ta] [dba.ta] where [dba.ta].grp<>'g?' group by [dba.ta].grp) [dba.ta] (a_?, a_?, a_?)
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+               (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+  ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 4: GROUP BY + window function combined via EXCEPT -> the fix must cover EXCEPT too     
+
+===================================================
+grp    sum(val)    running_total    
+g3     50     150     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.ta)
+
+  rewritten query: (select [dba.ta].grp, sum([dba.ta].val), sum([dba.ta].val) from [dba.ta] [dba.ta] group by [dba.ta].grp)
+
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select a_?, a_?, sum(a_?) over (order by ?) from (select [dba.ta].grp, sum([dba.ta].val), sum([dba.ta].val) from [dba.ta] [dba.ta] group by [dba.ta].grp) [dba.ta] (a_?, a_?, a_?)
+
+  SORT (group by)
+    TABLE SCAN (dba.ta)
+
+  rewritten query: (select [dba.ta].grp, sum([dba.ta].val), sum([dba.ta].val) from [dba.ta] [dba.ta] where [dba.ta].grp<>'g?' group by [dba.ta].grp)
+
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select a_?, a_?, sum(a_?) over (order by ?) from (select [dba.ta].grp, sum([dba.ta].val), sum([dba.ta].val) from [dba.ta] [dba.ta] where [dba.ta].grp<>'g?' group by [dba.ta].grp) [dba.ta] (a_?, a_?, a_?)
+
+
+Trace Statistics:
+  DIFFERENCE (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+             (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 5: 3-way UNION ALL, GROUP BY + window function in every branch -> hidden column uniqueness must hold across 3+ branches     
+
+===================================================
+grp    sum(val)    running_total    
+g1     30     30     
+g1     300     300     
+g2     70     70     
+g2     70     100     
+g2     300     600     
+g3     50     120     
+g3     50     150     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.ta)
+
+  rewritten query: (select [dba.ta].grp, sum([dba.ta].val), sum([dba.ta].val) from [dba.ta] [dba.ta] group by [dba.ta].grp)
+
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select a_?, a_?, sum(a_?) over (order by ?) from (select [dba.ta].grp, sum([dba.ta].val), sum([dba.ta].val) from [dba.ta] [dba.ta] group by [dba.ta].grp) [dba.ta] (a_?, a_?, a_?)
+
+  SORT (group by)
+    TABLE SCAN (dba.tb)
+
+  rewritten query: (select [dba.tb].grp, sum([dba.tb].val), sum([dba.tb].val) from [dba.tb] [dba.tb] group by [dba.tb].grp)
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select a_?, a_?, sum(a_?) over (order by ?) from (select [dba.tb].grp, sum([dba.tb].val), sum([dba.tb].val) from [dba.tb] [dba.tb] group by [dba.tb].grp) [dba.tb] (a_?, a_?, a_?)
+
+  SORT (group by)
+    TABLE SCAN (dba.ta)
+
+  rewritten query: (select [dba.ta].grp, sum([dba.ta].val), sum([dba.ta].val) from [dba.ta] [dba.ta] where ([dba.ta].val> ?:? ) group by [dba.ta].grp)
+
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select a_?, a_?, sum(a_?) over (order by ?) from (select [dba.ta].grp, sum([dba.ta].val), sum([dba.ta].val) from [dba.ta] [dba.ta] where ([dba.ta].val> ?:? ) group by [dba.ta].grp) [dba.ta] (a_?, a_?, a_?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+        SUBQUERY (uncorrelated)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+            GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+        SUBQUERY (uncorrelated)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+            GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+  ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 6: ORDER BY on the whole set-operation result must bind to the correct (renamed) window-function column     
+
+===================================================
+grp    s    running_total    
+g2     300     600     
+g1     300     300     
+g3     50     150     
+g2     70     100     
+g1     30     30     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.ta)
+
+  rewritten query: (select [dba.ta].grp, sum([dba.ta].val), sum([dba.ta].val) from [dba.ta] [dba.ta] group by [dba.ta].grp)
+
+  TABLE SCAN (dba.ta)
+
+  rewritten query: select a_?, a_?, sum(a_?) over (order by ?) from (select [dba.ta].grp, sum([dba.ta].val) as [s], sum([dba.ta].val) from [dba.ta] [dba.ta] group by [dba.ta].grp) [dba.ta] (a_?, a_?, a_?)
+
+  SORT (group by)
+    TABLE SCAN (dba.tb)
+
+  rewritten query: (select [dba.tb].grp, sum([dba.tb].val), sum([dba.tb].val) from [dba.tb] [dba.tb] group by [dba.tb].grp)
+
+  TABLE SCAN (dba.tb)
+
+  rewritten query: select a_?, a_?, sum(a_?) over (order by ?) from (select [dba.tb].grp, sum([dba.tb].val) as [s], sum([dba.tb].val) from [dba.tb] [dba.tb] group by [dba.tb].grp) [dba.tb] (a_?, a_?, a_?)
+
+  SORT (order by)
+    TABLE SCAN (x)
+
+  rewritten query: select x.grp, x.s, x.running_total from (select a_?, a_?, sum(a_?) over (order by ?) as [running_total] from (select [dba.ta].grp, sum([dba.ta].val) as [s], sum([dba.ta].val) from [dba.ta] [dba.ta] group by [dba.ta].grp) [dba.ta] (a_?, a_?, a_?) union all select a_?, a_?, sum(a_?) over (order by ?) as [running_total] from (select [dba.tb].grp, sum([dba.tb].val) as [s], sum([dba.tb].val) from [dba.tb] [dba.tb] group by [dba.tb].grp) [dba.tb] (a_?, a_?, a_?)) x (grp, s, running_total) order by ? desc 
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+      UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+          SUBQUERY (uncorrelated)
+            SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+              SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+          SUBQUERY (uncorrelated)
+            SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+              SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+1
+===================================================
+    
+Case 7: original report repro, standalone - branch-level ORDER BY on the grouped column, no set operation yet     
+
+===================================================
+out_a    out_b    out_c    
+1     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.td)
+
+  rewritten query: (select count([dba.td].ts), [dba.td].id, count([dba.td].id) from [dba.td] [dba.td] group by [dba.td].id)
+
+  SORT (order by)
+    TABLE SCAN (dba.td)
+
+  rewritten query: select a_?, dense_rank() over (order by ?), a_?, a_? from (select count([dba.td].ts) as [out_a], [dba.td].id, count([dba.td].id) as [out_c] from [dba.td] [dba.td] group by [dba.td].id) [dba.td] (a_?, a_?, a_?) order by ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.td), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 8: Case 7 combined via UNION with an always-empty second branch     
+
+===================================================
+out_a    out_b    out_c    
+1     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.td)
+
+  rewritten query: (select count([dba.td].ts), [dba.td].id, count([dba.td].id) from [dba.td] [dba.td] group by [dba.td].id)
+
+  SORT (order by)
+    TABLE SCAN (dba.td)
+
+  rewritten query: (select a_?, dense_rank() over (order by ?), a_?, a_? from (select count([dba.td].ts) as [out_a], [dba.td].id, count([dba.td].id) as [out_c] from [dba.td] [dba.td] group by [dba.td].id) [dba.td] (a_?, a_?, a_?) order by ?)
+
+  TABLE SCAN (d?)
+
+  rewritten query: select d?.a_?, d?.a_?, d?.a_? from (select a_?, dense_rank() over (order by ?) as [out_b], a_?, a_? from (select count([dba.td].ts) as [out_a], [dba.td].id, count([dba.td].id) as [out_c] from [dba.td] [dba.td] group by [dba.td].id) [dba.td] (a_?, a_?, a_?) order by ?) d? (a_?, a_?, a_?, a_?)
+
+  TABLE SCAN (dba.te)
+
+  rewritten query: select  cast([dba.te].val as bigint), [dba.te].val,  cast([dba.te].val as bigint) from [dba.te] [dba.te] where ([dba.te].val< ?:? )
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+          SUBQUERY (uncorrelated)
+            SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+              SCAN (table: dba.td), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.te), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+1
+===================================================
+4
+===================================================
+0
+===================================================
+    
+Case 9: hidden column from an expression ORDER BY key (ca + 1), standalone     
+
+===================================================
+out_a    out_b    out_c    
+1     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.tf)
+
+  rewritten query: (select count([dba.tf].cb), [dba.tf].ca, count([dba.tf].ca) from [dba.tf] [dba.tf] group by [dba.tf].ca)
+
+  SORT (order by)
+    TABLE SCAN (dba.tf)
+
+  rewritten query: select a_?, dense_rank() over (order by ?), a_?, a_?+? from (select count([dba.tf].cb) as [out_a], [dba.tf].ca, count([dba.tf].ca) as [out_c] from [dba.tf] [dba.tf] group by [dba.tf].ca) [dba.tf] (a_?, a_?, a_?) order by ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tf), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 10: Case 9 combined via UNION with an always-empty second branch     
+
+===================================================
+out_a    out_b    out_c    
+1     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.tf)
+
+  rewritten query: (select count([dba.tf].cb), [dba.tf].ca, count([dba.tf].ca) from [dba.tf] [dba.tf] group by [dba.tf].ca)
+
+  SORT (order by)
+    TABLE SCAN (dba.tf)
+
+  rewritten query: (select a_?, dense_rank() over (order by ?), a_?, a_?+? from (select count([dba.tf].cb) as [out_a], [dba.tf].ca, count([dba.tf].ca) as [out_c] from [dba.tf] [dba.tf] group by [dba.tf].ca) [dba.tf] (a_?, a_?, a_?) order by ?)
+
+  TABLE SCAN (d?)
+
+  rewritten query: select d?.a_?, d?.a_?, d?.a_? from (select a_?, dense_rank() over (order by ?) as [out_b], a_?, a_?+? from (select count([dba.tf].cb) as [out_a], [dba.tf].ca, count([dba.tf].ca) as [out_c] from [dba.tf] [dba.tf] group by [dba.tf].ca) [dba.tf] (a_?, a_?, a_?) order by ?) d? (a_?, a_?, a_?, a_?)
+
+  TABLE SCAN (dba.tg)
+
+  rewritten query: select  cast([dba.tg].cd as bigint), [dba.tg].cd,  cast([dba.tg].cd as bigint) from [dba.tg] [dba.tg] where ([dba.tg].cd< ?:? )
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+          SUBQUERY (uncorrelated)
+            SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+              SCAN (table: dba.tf), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tg), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 11: two expression ORDER BY keys (ca + 1, ca * 2) in the same branch, standalone     
+
+===================================================
+out_a    out_b    out_c    
+1     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.tf)
+
+  rewritten query: (select count([dba.tf].cb), [dba.tf].ca, count([dba.tf].ca) from [dba.tf] [dba.tf] group by [dba.tf].ca)
+
+  SORT (order by)
+    TABLE SCAN (dba.tf)
+
+  rewritten query: select a_?, dense_rank() over (order by ?), a_?, a_?+?, a_?*? from (select count([dba.tf].cb) as [out_a], [dba.tf].ca, count([dba.tf].ca) as [out_c] from [dba.tf] [dba.tf] group by [dba.tf].ca) [dba.tf] (a_?, a_?, a_?) order by ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tf), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 12: Case 11 combined via UNION with an always-empty second branch     
+
+===================================================
+out_a    out_b    out_c    
+1     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.tf)
+
+  rewritten query: (select count([dba.tf].cb), [dba.tf].ca, count([dba.tf].ca) from [dba.tf] [dba.tf] group by [dba.tf].ca)
+
+  SORT (order by)
+    TABLE SCAN (dba.tf)
+
+  rewritten query: (select a_?, dense_rank() over (order by ?), a_?, a_?+?, a_?*? from (select count([dba.tf].cb) as [out_a], [dba.tf].ca, count([dba.tf].ca) as [out_c] from [dba.tf] [dba.tf] group by [dba.tf].ca) [dba.tf] (a_?, a_?, a_?) order by ?, ?)
+
+  TABLE SCAN (d?)
+
+  rewritten query: select d?.a_?, d?.a_?, d?.a_? from (select a_?, dense_rank() over (order by ?) as [out_b], a_?, a_?+?, a_?*? from (select count([dba.tf].cb) as [out_a], [dba.tf].ca, count([dba.tf].ca) as [out_c] from [dba.tf] [dba.tf] group by [dba.tf].ca) [dba.tf] (a_?, a_?, a_?) order by ?, ?) d? (a_?, a_?, a_?, a_?, a_?)
+
+  TABLE SCAN (dba.tg)
+
+  rewritten query: select  cast([dba.tg].cd as bigint), [dba.tg].cd,  cast([dba.tg].cd as bigint) from [dba.tg] [dba.tg] where ([dba.tg].cd< ?:? )
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+          SUBQUERY (uncorrelated)
+            SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+              SCAN (table: dba.tf), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tg), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 13: branch-level ORDER BY combined with LIMIT, standalone     
+
+===================================================
+out_a    out_b    out_c    
+1     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.tf)
+
+  rewritten query: (select count([dba.tf].cb), [dba.tf].ca, count([dba.tf].ca) from [dba.tf] [dba.tf] group by [dba.tf].ca)
+
+  SORT (order by)
+    TABLE SCAN (dba.tf)
+
+  rewritten query: select a_?, dense_rank() over (order by ?), a_?, a_? from (select count([dba.tf].cb) as [out_a], [dba.tf].ca, count([dba.tf].ca) as [out_c] from [dba.tf] [dba.tf] group by [dba.tf].ca) [dba.tf] (a_?, a_?, a_?) order by ? for orderby_num()<= ?:? 
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tf), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 14: Case 13 combined via UNION with an always-empty second branch     
+
+===================================================
+out_a    out_b    out_c    
+1     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.tf)
+
+  rewritten query: (select count([dba.tf].cb), [dba.tf].ca, count([dba.tf].ca) from [dba.tf] [dba.tf] group by [dba.tf].ca)
+
+  SORT (order by)
+    TABLE SCAN (dba.tf)
+
+  rewritten query: (select a_?, dense_rank() over (order by ?), a_?, a_? from (select count([dba.tf].cb) as [out_a], [dba.tf].ca, count([dba.tf].ca) as [out_c] from [dba.tf] [dba.tf] group by [dba.tf].ca) [dba.tf] (a_?, a_?, a_?) order by ? for orderby_num()<= ?:? )
+
+  TABLE SCAN (d?)
+
+  rewritten query: select d?.a_?, d?.a_?, d?.a_? from (select a_?, dense_rank() over (order by ?) as [out_b], a_?, a_? from (select count([dba.tf].cb) as [out_a], [dba.tf].ca, count([dba.tf].ca) as [out_c] from [dba.tf] [dba.tf] group by [dba.tf].ca) [dba.tf] (a_?, a_?, a_?) order by ? for orderby_num()<= ?:? ) d? (a_?, a_?, a_?, a_?)
+
+  TABLE SCAN (dba.tg)
+
+  rewritten query: select  cast([dba.tg].cd as bigint), [dba.tg].cd,  cast([dba.tg].cd as bigint) from [dba.tg] [dba.tg] where ([dba.tg].cd< ?:? )
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+          ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+          SUBQUERY (uncorrelated)
+            SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+              SCAN (table: dba.tf), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tg), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 15: branch-level ORDER BY plus two window functions in the same branch, standalone     
+
+===================================================
+out_a    out_b    out_c    out_d    
+1     1     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.tf)
+
+  rewritten query: (select count([dba.tf].cb), [dba.tf].ca, count([dba.tf].ca) from [dba.tf] [dba.tf] group by [dba.tf].ca)
+
+  SORT (order by)
+    TABLE SCAN (dba.tf)
+
+  rewritten query: select a_?, row_number() over (order by ?), dense_rank() over (order by ? desc ), a_?, a_? from (select count([dba.tf].cb) as [out_a], [dba.tf].ca, count([dba.tf].ca) as [out_d] from [dba.tf] [dba.tf] group by [dba.tf].ca) [dba.tf] (a_?, a_?, a_?) order by ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tf), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 16: Case 15 combined via UNION with an always-empty second branch     
+
+===================================================
+out_a    out_b    out_c    out_d    
+1     1     1     1     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.tf)
+
+  rewritten query: (select count([dba.tf].cb), [dba.tf].ca, count([dba.tf].ca) from [dba.tf] [dba.tf] group by [dba.tf].ca)
+
+  SORT (order by)
+    TABLE SCAN (dba.tf)
+
+  rewritten query: (select a_?, row_number() over (order by ?), dense_rank() over (order by ? desc ), a_?, a_? from (select count([dba.tf].cb) as [out_a], [dba.tf].ca, count([dba.tf].ca) as [out_d] from [dba.tf] [dba.tf] group by [dba.tf].ca) [dba.tf] (a_?, a_?, a_?) order by ?)
+
+  TABLE SCAN (d?)
+
+  rewritten query: select d?.a_?, d?.a_?, d?.a_?, d?.a_? from (select a_?, row_number() over (order by ?) as [out_b], dense_rank() over (order by ? desc ) as [out_c], a_?, a_? from (select count([dba.tf].cb) as [out_a], [dba.tf].ca, count([dba.tf].ca) as [out_d] from [dba.tf] [dba.tf] group by [dba.tf].ca) [dba.tf] (a_?, a_?, a_?) order by ?) d? (a_?, a_?, a_?, a_?, a_?)
+
+  TABLE SCAN (dba.tg)
+
+  rewritten query: select  cast([dba.tg].cd as bigint), [dba.tg].cd, [dba.tg].cd,  cast([dba.tg].cd as bigint) from [dba.tg] [dba.tg] where ([dba.tg].cd< ?:? )
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+          ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+          SUBQUERY (uncorrelated)
+            SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+              SCAN (table: dba.tf), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+              GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.tg), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+6
+===================================================
+2
+===================================================
+0
+===================================================
+    
+Case 17: PARTITION BY window in two UNION ALL branches -- partition-key hidden column stays unique per branch     
+
+===================================================
+cat    grp    sum(val)    rt    
+A     g1     5     5     
+A     g1     30     30     
+A     g2     30     60     
+B     g1     100     100     
+B     g2     7     7     
+B     g2     250     350     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.tp)
+
+  rewritten query: (select [dba.tp].cat, [dba.tp].grp, sum([dba.tp].val), sum([dba.tp].val) from [dba.tp] [dba.tp] group by [dba.tp].cat, [dba.tp].grp)
+
+  TABLE SCAN (dba.tp)
+
+  rewritten query: select a_?, a_?, a_?, sum(a_?) over (partition by ? order by ?) from (select [dba.tp].cat, [dba.tp].grp, sum([dba.tp].val), sum([dba.tp].val) from [dba.tp] [dba.tp] group by [dba.tp].cat, [dba.tp].grp) [dba.tp] (a_?, a_?, a_?, a_?)
+
+  SORT (group by)
+    TABLE SCAN (dba.tq)
+
+  rewritten query: (select [dba.tq].cat, [dba.tq].grp, sum([dba.tq].val), sum([dba.tq].val) from [dba.tq] [dba.tq] group by [dba.tq].cat, [dba.tq].grp)
+
+  TABLE SCAN (dba.tq)
+
+  rewritten query: select a_?, a_?, a_?, sum(a_?) over (partition by ? order by ?) from (select [dba.tq].cat, [dba.tq].grp, sum([dba.tq].val), sum([dba.tq].val) from [dba.tq] [dba.tq] group by [dba.tq].cat, [dba.tq].grp) [dba.tq] (a_?, a_?, a_?, a_?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tp), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tq), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+  ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 18: two PARTITION BY window functions in the same branch (row_number, rank) -- each partition window gets its own unique hidden columns     
+
+===================================================
+cat    grp    s    rn    rk    
+A     g1     5     1     1     
+A     g1     30     1     1     
+A     g2     30     2     2     
+B     g1     100     1     2     
+B     g2     7     1     1     
+B     g2     250     2     1     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.tp)
+
+  rewritten query: (select [dba.tp].cat, [dba.tp].grp, sum([dba.tp].val) from [dba.tp] [dba.tp] group by [dba.tp].cat, [dba.tp].grp)
+
+  TABLE SCAN (dba.tp)
+
+  rewritten query: select a_?, a_?, a_?, row_number() over (partition by ? order by ?, ?), rank() over (partition by ? order by ? desc , ?) from (select [dba.tp].cat, [dba.tp].grp, sum([dba.tp].val) as [s] from [dba.tp] [dba.tp] group by [dba.tp].cat, [dba.tp].grp) [dba.tp] (a_?, a_?, a_?)
+
+  SORT (group by)
+    TABLE SCAN (dba.tq)
+
+  rewritten query: (select [dba.tq].cat, [dba.tq].grp, sum([dba.tq].val) from [dba.tq] [dba.tq] group by [dba.tq].cat, [dba.tq].grp)
+
+  TABLE SCAN (dba.tq)
+
+  rewritten query: select a_?, a_?, a_?, row_number() over (partition by ? order by ?, ?), rank() over (partition by ? order by ? desc , ?) from (select [dba.tq].cat, [dba.tq].grp, sum([dba.tq].val) as [s] from [dba.tq] [dba.tq] group by [dba.tq].cat, [dba.tq].grp) [dba.tq] (a_?, a_?, a_?)
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tp), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tq), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+  ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 19: PARTITION BY window combined via INTERSECT -- partition-key hidden columns unique across set-op branches     
+
+===================================================
+cat    grp    sum(val)    rt    
+A     g1     30     30     
+A     g2     30     60     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (group by)
+    TABLE SCAN (dba.tp)
+
+  rewritten query: (select [dba.tp].cat, [dba.tp].grp, sum([dba.tp].val), sum([dba.tp].val) from [dba.tp] [dba.tp] group by [dba.tp].cat, [dba.tp].grp)
+
+  TABLE SCAN (dba.tp)
+
+  rewritten query: select a_?, a_?, a_?, sum(a_?) over (partition by ? order by ?) from (select [dba.tp].cat, [dba.tp].grp, sum([dba.tp].val), sum([dba.tp].val) from [dba.tp] [dba.tp] group by [dba.tp].cat, [dba.tp].grp) [dba.tp] (a_?, a_?, a_?, a_?)
+
+  SORT (group by)
+    TABLE SCAN (dba.tp)
+
+  rewritten query: (select [dba.tp].cat, [dba.tp].grp, sum([dba.tp].val), sum([dba.tp].val) from [dba.tp] [dba.tp] where [dba.tp].cat= ?:?  group by [dba.tp].cat, [dba.tp].grp)
+
+  TABLE SCAN (dba.tp)
+
+  rewritten query: select a_?, a_?, a_?, sum(a_?) over (partition by ? order by ?) from (select [dba.tp].cat, [dba.tp].grp, sum([dba.tp].val), sum([dba.tp].val) from [dba.tp] [dba.tp] where [dba.tp].cat= ?:?  group by [dba.tp].cat, [dba.tp].grp) [dba.tp] (a_?, a_?, a_?, a_?)
+
+
+Trace Statistics:
+  INTERSECTION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+               (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tp), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?)
+      SUBQUERY (uncorrelated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tp), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+  ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0

--- a/sql/_36_guava/cbrd_27158/cases/cbrd_27158.sql
+++ b/sql/_36_guava/cbrd_27158/cases/cbrd_27158.sql
@@ -1,0 +1,315 @@
+/*
+ * This test case verifies CBRD-27158 : set operations (UNION/INTERSECT/EXCEPT)
+ * corrupt rows produced by a GROUP BY query combined with a window function.
+ *
+ * Bug: when a query mixing GROUP BY aggregates and a window function (OVER
+ * clause) participates in a set operation, CUBRID rewrites it internally as
+ * a derived table (mq_rewrite_aggregate_as_derived) so the window function
+ * can be evaluated on top of the grouped result. The hidden column names
+ * generated for that derived table were not guaranteed unique, so when
+ * multiple such rewrites occurred (multiple window functions in one branch,
+ * or multiple branches of a set operation), the hidden columns could
+ * collide -- corrupting which value ends up in which output column/row.
+ *
+ * Fix: mq_rewrite_aggregate_as_derived now generates unique hidden column
+ * names for every rewrite.
+ *
+ * Note: the existing CBRD-27158 coverage merged via PR #3190 (develop) and
+ * backported via PR #3296 (release/11.4) only exercises CUBRIDs own
+ * pseudocolumns (rownum / orderby_num() / groupby_num() / inst_num())
+ * combined with GROUP BY and set operators. It does not exercise a genuine
+ * ANSI window function (OVER clause), which is what this test case adds.
+ *
+ * Note: table/column names use letters (ta/tb), not digits, because CTP
+ * masks digits in the trace output to ?, same convention as
+ * CBRD-26571 cbrd_26571.sql and CBRD-26522s cbrd_26522.sql.
+ *
+ * Note: Cases 1, 2, 3, 4, 5 add an explicit trailing ORDER BY over the whole
+ * set-operation result (by ordinal position). Without it the row order
+ * across UNION/UNION ALL branches is not guaranteed -- the trace shows the
+ * UNION node can use parallel workers, same non-determinism risk seen in
+ * CBRD-26522 cbrd_26522.sql -- so a byte-for-byte answer comparison could
+ * fail even when every value is correct.
+ *
+ * Coverage:
+ *   Case 1: GROUP BY + a window function in two UNION ALL branches
+ *           -> result values must be correct and the trace rewritten
+ *              query must show unique hidden column names per branch
+ *   Case 2: two window functions in the SAME branch (row_number(), rank())
+ *           -> each window function hidden column must get its own unique
+ *              name, not collide with the other one in the same branch.
+ *              grp is added as a tiebreak inside each OVER clause because
+ *              tb has two groups with an equal sum(val) (g1 and g2, both
+ *              300) -- without a tiebreak, row_number() over such a tie is
+ *              not deterministic by SQL semantics, regardless of this fix
+ *   Case 3: the same GROUP BY + window pattern combined via INTERSECT
+ *           -> the fix must also cover INTERSECT, not only UNION. The
+ *              second branch excludes grp g3 so the two branches actually
+ *              differ -- intersecting a branch with an identical copy of
+ *              itself would match even if both sides were corrupted the
+ *              same way, proving nothing
+ *   Case 4: the same GROUP BY + window pattern combined via EXCEPT
+ *           -> the fix must also cover EXCEPT, not only UNION. Mirrors
+ *              Case 3: the second branch is ta itself with grp g3 excluded,
+ *              so EXCEPT has a real, known row (g3) to remove -- the
+ *              original ta-vs-tb branches shared no matching rows at all,
+ *              so nothing was ever actually being subtracted
+ *   Case 5: 3-way UNION ALL, GROUP BY + window function in every branch
+ *           -> hidden column uniqueness must hold across 3+ branches, not
+ *              just the first two
+ *   Case 6: ORDER BY applied to the whole set-operation result, referencing
+ *           the window-function column by its exposed alias
+ *           -> if hidden columns collided internally, ORDER BY could bind to
+ *              the wrong column and silently produce the wrong row order.
+ *              this is the most direct way "corrupted rows" would surface
+ *   Case 7: the original CBRD-27158 report repro (table td here), standalone
+ *           -- a branch-level trailing ORDER BY on the grouped column itself,
+ *           not just the window functions own OVER clause, with no set
+ *           operation at all yet
+ *           -> baseline: this is a different hidden-column source than
+ *              Cases 1-6 (the branch ORDER BY needs its own hidden column,
+ *              separate from the ones the window function rewrite creates),
+ *              and must produce correct values on its own before Case 8
+ *              adds a set operation around it
+ *   Case 8: the same query as Case 7, now combined via UNION with a second,
+ *           always-empty branch (tables td/te) -- the exact shape the bug
+ *           was originally reported against
+ *           -> must produce the same values as Case 7s standalone result,
+ *              since the second branch never contributes any rows
+ *   Cases 9-16 (tables tf/tg): a PR review round proposed four more
+ *           branch-level-ORDER BY shapes beyond Case 7/8s single window
+ *           function. Each is given as a standalone baseline followed by
+ *           its UNION form, same pairing as Case 7/8, so the set operation
+ *           is checked against a known-correct baseline rather than in
+ *           isolation.
+ *   Case 9/10: the branch ORDER BY key is an expression (ca + 1), not a
+ *           plain column, so it needs its own hidden column distinct from
+ *           the ones the window function and GROUP BY rewrites create
+ *   Case 11/12: two expression ORDER BY keys (ca + 1, ca * 2) in the same
+ *           branch, so the hidden-column counter must advance twice
+ *           without collision
+ *   Case 13/14: the branch ORDER BY is combined with LIMIT, bringing the
+ *           limit-push-down path into the same rewrite
+ *   Case 15/16: two window functions (row_number(), dense_rank()) plus a
+ *           plain-column branch ORDER BY all in the same branch -- the
+ *           most hidden columns generated for a single branch across this
+ *           file
+ *   Cases 17-19 (tables tp/tq): every OVER clause above is ORDER BY only --
+ *           none use PARTITION BY. A PARTITION BY key becomes its own
+ *           extra hidden column in the derived-table rewrite (separate
+ *           from the ORDER BY keys hidden column), so it widens the
+ *           hidden-column-uniqueness surface this file checks.
+ *   Case 17: PARTITION BY window (running sum per cat, ordered by grp) in
+ *           two UNION ALL branches
+ *           -> the partition-key hidden column must stay unique per branch
+ *   Case 18: two PARTITION BY window functions in the same branch
+ *           (row_number(), rank(), both partitioned by cat)
+ *           -> each partitioned window needs its own unique hidden
+ *              columns, not just each plain ORDER BY window as in Case 2
+ *   Case 19: the Case 17 pattern combined via INTERSECT, second branch
+ *           filtered to cat = A so the two branches genuinely differ
+ *           -> partition-key hidden columns must stay unique across
+ *              set-op branches too, not only within UNION ALL
+ */
+
+drop table if exists ta, tb;
+create table ta (id int primary key, grp varchar(10), val int);
+create table tb (id int primary key, grp varchar(10), val int);
+
+insert into ta values (1,'g1',10), (2,'g1',20), (3,'g2',30), (4,'g2',40), (5,'g3',50);
+insert into tb values (1,'g1',100), (2,'g1',200), (3,'g2',300);
+commit;
+
+set trace on;
+
+evaluate 'Case 1: GROUP BY + window function in two UNION ALL branches -> correct values and unique hidden column names';
+select /*+ recompile */ grp, sum(val), sum(sum(val)) over (order by grp) as running_total from ta group by grp
+union all
+select grp, sum(val), sum(sum(val)) over (order by grp) as running_total from tb group by grp
+order by 1, 2, 3;
+show trace;
+
+
+evaluate 'Case 2: two window functions in the same branch (row_number, rank) -> each must get its own unique hidden column';
+select /*+ recompile */ grp, sum(val) as s, row_number() over (order by sum(val), grp) as rn, rank() over (order by sum(val) desc, grp) as rk from ta group by grp
+union all
+select grp, sum(val) as s, row_number() over (order by sum(val), grp) as rn, rank() over (order by sum(val) desc, grp) as rk from tb group by grp
+order by 1, 2, 3, 4;
+show trace;
+
+
+evaluate 'Case 3: GROUP BY + window function combined via INTERSECT -> the fix must cover INTERSECT too';
+select /*+ recompile */ grp, sum(val), sum(sum(val)) over (order by grp) as running_total from ta group by grp
+intersect
+select grp, sum(val), sum(sum(val)) over (order by grp) as running_total from ta where grp <> 'g3' group by grp
+order by 1, 2, 3;
+show trace;
+
+
+evaluate 'Case 4: GROUP BY + window function combined via EXCEPT -> the fix must cover EXCEPT too';
+select /*+ recompile */ grp, sum(val), sum(sum(val)) over (order by grp) as running_total from ta group by grp
+except
+select grp, sum(val), sum(sum(val)) over (order by grp) as running_total from ta where grp <> 'g3' group by grp
+order by 1, 2, 3;
+show trace;
+
+
+evaluate 'Case 5: 3-way UNION ALL, GROUP BY + window function in every branch -> hidden column uniqueness must hold across 3+ branches';
+select /*+ recompile */ grp, sum(val), sum(sum(val)) over (order by grp) as running_total from ta group by grp
+union all
+select grp, sum(val), sum(sum(val)) over (order by grp) as running_total from tb group by grp
+union all
+select grp, sum(val), sum(sum(val)) over (order by grp) as running_total from ta where val > 20 group by grp
+order by 1, 2, 3;
+show trace;
+
+
+evaluate 'Case 6: ORDER BY on the whole set-operation result must bind to the correct (renamed) window-function column';
+select * from (
+  select /*+ recompile */ grp, sum(val) as s, sum(sum(val)) over (order by grp) as running_total from ta group by grp
+  union all
+  select grp, sum(val) as s, sum(sum(val)) over (order by grp) as running_total from tb group by grp
+) x order by running_total desc;
+show trace;
+
+
+drop table if exists te, td;
+create table td (id int, ts datetime);
+create table te (val int);
+
+insert into td values (1, '2026-01-01 00:00:00');
+
+evaluate 'Case 7: original report repro, standalone - branch-level ORDER BY on the grouped column, no set operation yet';
+select /*+ recompile */ count(ts) as out_a, dense_rank() over (order by id asc) as out_b, count(id) as out_c
+from td
+group by id
+order by id;
+show trace;
+
+
+evaluate 'Case 8: Case 7 combined via UNION with an always-empty second branch';
+(select /*+ recompile */ count(ts) as out_a, dense_rank() over (order by id asc) as out_b, count(id) as out_c
+from td group by id order by id)
+union
+select val as out_a, val as out_b, val as out_c from te where val < 0;
+show trace;
+
+drop table if exists te, td;
+
+
+drop table if exists tg, tf;
+create table tf (ca int, cb datetime);
+create table tg (cd int);
+
+insert into tf values (1, '2026-01-01 00:00:00');
+insert into tg values (0), (1), (2), (3);
+commit;
+
+
+evaluate 'Case 9: hidden column from an expression ORDER BY key (ca + 1), standalone';
+select /*+ recompile */ count(cb) as out_a, dense_rank() over (order by ca asc) as out_b, count(ca) as out_c
+from tf group by ca order by ca + 1;
+show trace;
+
+
+evaluate 'Case 10: Case 9 combined via UNION with an always-empty second branch';
+(select /*+ recompile */ count(cb) as out_a, dense_rank() over (order by ca asc) as out_b, count(ca) as out_c
+ from tf group by ca order by ca + 1)
+union
+select cd as out_a, cd as out_b, cd as out_c from tg where cd < 0;
+show trace;
+
+
+evaluate 'Case 11: two expression ORDER BY keys (ca + 1, ca * 2) in the same branch, standalone';
+select /*+ recompile */ count(cb) as out_a, dense_rank() over (order by ca asc) as out_b, count(ca) as out_c
+from tf group by ca order by ca + 1, ca * 2;
+show trace;
+
+
+evaluate 'Case 12: Case 11 combined via UNION with an always-empty second branch';
+(select /*+ recompile */ count(cb) as out_a, dense_rank() over (order by ca asc) as out_b, count(ca) as out_c
+ from tf group by ca order by ca + 1, ca * 2)
+union
+select cd as out_a, cd as out_b, cd as out_c from tg where cd < 0;
+show trace;
+
+
+evaluate 'Case 13: branch-level ORDER BY combined with LIMIT, standalone';
+select /*+ recompile */ count(cb) as out_a, dense_rank() over (order by ca asc) as out_b, count(ca) as out_c
+from tf group by ca order by ca limit 1;
+show trace;
+
+
+evaluate 'Case 14: Case 13 combined via UNION with an always-empty second branch';
+(select /*+ recompile */ count(cb) as out_a, dense_rank() over (order by ca asc) as out_b, count(ca) as out_c
+ from tf group by ca order by ca limit 1)
+union
+select cd as out_a, cd as out_b, cd as out_c from tg where cd < 0;
+show trace;
+
+
+evaluate 'Case 15: branch-level ORDER BY plus two window functions in the same branch, standalone';
+select /*+ recompile */ count(cb) as out_a, row_number() over (order by ca asc) as out_b,
+       dense_rank() over (order by ca desc) as out_c, count(ca) as out_d
+from tf group by ca order by ca;
+show trace;
+
+
+evaluate 'Case 16: Case 15 combined via UNION with an always-empty second branch';
+(select /*+ recompile */ count(cb) as out_a, row_number() over (order by ca asc) as out_b,
+        dense_rank() over (order by ca desc) as out_c, count(ca) as out_d
+ from tf group by ca order by ca)
+union
+select cd as out_a, cd as out_b, cd as out_c, cd as out_d from tg where cd < 0;
+show trace;
+
+drop table if exists tq, tp;
+create table tp (id int primary key, cat varchar(10), grp varchar(10), val int);
+create table tq (id int primary key, cat varchar(10), grp varchar(10), val int);
+
+insert into tp values (1,'A','g1',10), (2,'A','g1',20), (3,'A','g2',30),
+                      (4,'B','g1',100), (5,'B','g2',200), (6,'B','g2',50);
+insert into tq values (1,'A','g1',5), (2,'B','g2',7);
+commit;
+
+
+evaluate 'Case 17: PARTITION BY window in two UNION ALL branches -- partition-key hidden column stays unique per branch';
+select /*+ recompile */ cat, grp, sum(val), sum(sum(val)) over (partition by cat order by grp) as rt
+from tp group by cat, grp
+union all
+select cat, grp, sum(val), sum(sum(val)) over (partition by cat order by grp) as rt
+from tq group by cat, grp
+order by 1, 2, 3, 4;
+show trace;
+
+
+evaluate 'Case 18: two PARTITION BY window functions in the same branch (row_number, rank) -- each partition window gets its own unique hidden columns';
+select /*+ recompile */ cat, grp, sum(val) as s,
+       row_number() over (partition by cat order by sum(val), grp) as rn,
+       rank() over (partition by cat order by sum(val) desc, grp) as rk
+from tp group by cat, grp
+union all
+select cat, grp, sum(val) as s,
+       row_number() over (partition by cat order by sum(val), grp) as rn,
+       rank() over (partition by cat order by sum(val) desc, grp) as rk
+from tq group by cat, grp
+order by 1, 2, 3, 4, 5;
+show trace;
+
+
+evaluate 'Case 19: PARTITION BY window combined via INTERSECT -- partition-key hidden columns unique across set-op branches';
+select /*+ recompile */ cat, grp, sum(val), sum(sum(val)) over (partition by cat order by grp) as rt
+from tp group by cat, grp
+intersect
+select cat, grp, sum(val), sum(sum(val)) over (partition by cat order by grp) as rt
+from tp where cat = 'A' group by cat, grp
+order by 1, 2, 3;
+show trace;
+
+set trace off;
+
+drop table if exists tq, tp;
+
+drop table if exists tg, tf;
+
+drop table if exists ta, tb;


### PR DESCRIPTION
Backport #3314

Purpose
develop에서 작성된 CBRD-27158 TC(cbrd_27158.sql)를 11.4 브랜치로 백포트(cherry-pick)했으나, 11.4 엔진의 query trace 출력 포맷이 develop과 달라 답지(cbrd_27158.answer)가 그대로는 맞지 않는 문제를 수정.

Implementation
cherry-pick된 cbrd_27158.sql은 그대로 두고, cbrd_27158.answer만 11.4에서 실제로 출력되는 trace 포맷에 맞게 수정:

UNION/INTERSECTION/DIFFERENCE 아래에 있던 (parallel workers: ?, time: ?, fetch: ?, fetch_time: ?, ioread: ?) 라인 전체 삭제 — 11.4에서는 parallel worker trace 라인이 출력되지 않음.
ANALYTIC #? (time: ?, sort: true, page: ?, ioread: ?, rows: ?) 라인 전체 삭제 — 11.4 trace에는 ANALYTIC 연산자 라인이 없음.
GROUPBY (..., readrows: ?, rows: ?) → GROUPBY (..., rows: ?) — readrows: 필드가 11.4 GROUPBY trace 출력에 없음.
전체 답지 파일 전반(약 20곳 이상의 trace 블록)에 걸쳐 동일한 3가지 패턴을 일관되게 반영함.

Remarks
쿼리 실행 로직/검증 대상 자체는 변경 없음 — 순수하게 11.4와 develop 간 trace 출력 포맷 차이를 답지에 반영한 것.
형제 백포트 커밋들([CBRD-27200], [CBRD-27216], [CBRD-27189], [CBRD-27159])과 동일하게 develop→11.4 backport 과정에서 발생하는 엔진 버전 차이 보정 작업.
