### PR TITLE
[CBRD-26707] Add SQL testcase for parallel heap scan::mergeable list with NOT EXISTS / filter subquery

### DIFF
--- a/sql/_36_guava/cbrd_26707/answers/cbrd_26707.answer
+++ b/sql/_36_guava/cbrd_26707/answers/cbrd_26707.answer
@@ -1061,6 +1061,16 @@ count(*)
 ===================================================
 trace    
 
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+
 Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
@@ -1100,6 +1110,34 @@ Trace Statistics:
   SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
     SCAN (table: dba.pl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
          (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+           PARTITION (table: dba.pl__p__pa), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+           PARTITION (table: dba.pl__p__pb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+           PARTITION (table: dba.pl__p__pc), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+39950     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.pl] a where  not  exists (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.pl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
            PARTITION (table: dba.pl__p__pa), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
            PARTITION (table: dba.pl__p__pb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
            PARTITION (table: dba.pl__p__pc), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
@@ -1155,6 +1193,27 @@ count(*)
 ===================================================
 count(*)    
 3500     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
 
 ===================================================
 0

--- a/sql/_36_guava/cbrd_26707/answers/cbrd_26707.answer
+++ b/sql/_36_guava/cbrd_26707/answers/cbrd_26707.answer
@@ -1,0 +1,1414 @@
+===================================================
+0
+===================================================
+0
+===================================================
+4000
+===================================================
+0
+===================================================
+500
+===================================================
+0
+===================================================
+0
+===================================================
+    
+Case 1: NOT EXISTS + correlated subquery -> parallel heap scan (buildvalue)     
+
+===================================================
+count(*)    
+3950     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select count(*) from [dba.ta] a where  not  exists (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+3950     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a where  not  exists (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 2: EXISTS + correlated subquery -> parallel heap scan (buildvalue)     
+
+===================================================
+count(*)    
+500     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select count(*) from [dba.ta] a where  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+500     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a where  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 3: NOT EXISTS + column output -> parallel heap scan (mergeable list)     
+
+===================================================
+cola    colb    
+00000000000000000501     00000000000000000001     
+00000000000000000502     00000000000000000002     
+00000000000000000503     00000000000000000003     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: (select /*+ NO_MERGE */ a.cola, a.colb from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? ))
+
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: select [__t?].cola, [__t?].colb from (select /*+ NO_MERGE */ a.cola, a.colb from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )) [__t?] (cola, colb) order by ? for orderby_num()<= ?:? 
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, topnsort: true)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+             (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
+        SUBQUERY (correlated)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+cola    colb    
+00000000000000000501     00000000000000000001     
+00000000000000000502     00000000000000000002     
+00000000000000000503     00000000000000000003     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: (select /*+ NO_MERGE NO_PARALLEL_SCAN */ a.cola, a.colb from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? ))
+
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: select [__t?].cola, [__t?].colb from (select /*+ NO_MERGE NO_PARALLEL_SCAN */ a.cola, a.colb from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )) [__t?] (cola, colb) order by ? for orderby_num()<= ?:? 
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, topnsort: true)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SUBQUERY (correlated)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 4: NOT EXISTS + extra WHERE condition -> parallel heap scan (buildvalue)     
+
+===================================================
+count(*)    
+350     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select count(*) from [dba.ta] a where a.cola like  ?:?  and  not  exists (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+350     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a where a.cola like  ?:?  and  not  exists (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 5: multiple NOT EXISTS -> parallel heap scan (buildvalue)     
+
+===================================================
+count(*)    
+3900     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? )
+
+  TABLE SCAN (c)
+
+  rewritten query: (select ? from [dba.tb] c where c.id=a.id and (c.colb= ?:? ) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select count(*) from [dba.ta] a where  not  exists (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? ) and  not  exists (select ? from [dba.tb] c where c.id=a.id and (c.colb= ?:? ) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+3900     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? )
+
+  TABLE SCAN (c)
+
+  rewritten query: (select ? from [dba.tb] c where c.id=a.id and (c.colb= ?:? ) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a where  not  exists (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? ) and  not  exists (select ? from [dba.tb] c where c.id=a.id and (c.colb= ?:? ) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 6: filter subquery + min() compare -> parallel heap scan (buildvalue)     
+
+===================================================
+count(*)    
+0     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select min(b.cola) from [dba.tb] b where b.id=a.id)
+
+  TABLE SCAN (a)
+
+  rewritten query: select count(*) from [dba.ta] a where (a.cola>(select min(b.cola) from [dba.tb] b where b.id=a.id))
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+0     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select min(b.cola) from [dba.tb] b where b.id=a.id)
+
+  TABLE SCAN (a)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a where (a.cola>(select min(b.cola) from [dba.tb] b where b.id=a.id))
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 7: filter subquery + max() compare + column output -> parallel heap scan (mergeable list)     
+
+===================================================
+cola    colb    
+00000000000000000001     00000000000000000001     
+00000000000000000002     00000000000000000002     
+00000000000000000003     00000000000000000003     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select max(b.colb) from [dba.tb] b where b.id=a.id)
+
+  TABLE SCAN (a)
+
+  rewritten query: (select /*+ NO_MERGE */ a.cola, a.colb from [dba.ta] a where a.colb=(select max(b.colb) from [dba.tb] b where b.id=a.id))
+
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: select [__t?].cola, [__t?].colb from (select /*+ NO_MERGE */ a.cola, a.colb from [dba.ta] a where a.colb=(select max(b.colb) from [dba.tb] b where b.id=a.id)) [__t?] (cola, colb) order by ? for orderby_num()<= ?:? 
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, topnsort: true)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+             (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
+        SUBQUERY (correlated)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+cola    colb    
+00000000000000000001     00000000000000000001     
+00000000000000000002     00000000000000000002     
+00000000000000000003     00000000000000000003     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select max(b.colb) from [dba.tb] b where b.id=a.id)
+
+  TABLE SCAN (a)
+
+  rewritten query: (select /*+ NO_MERGE NO_PARALLEL_SCAN */ a.cola, a.colb from [dba.ta] a where a.colb=(select max(b.colb) from [dba.tb] b where b.id=a.id))
+
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: select [__t?].cola, [__t?].colb from (select /*+ NO_MERGE NO_PARALLEL_SCAN */ a.cola, a.colb from [dba.ta] a where a.colb=(select max(b.colb) from [dba.tb] b where b.id=a.id)) [__t?] (cola, colb) order by ? for orderby_num()<= ?:? 
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, topnsort: true)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SUBQUERY (correlated)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 8: filter subquery + avg() compare -> parallel heap scan (buildvalue)     
+
+===================================================
+count(*)    
+3749     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select avg(b.id) from [dba.tb] b where b.colb=a.colb)
+
+  TABLE SCAN (a)
+
+  rewritten query: select count(*) from [dba.ta] a where (a.id>(select avg(b.id) from [dba.tb] b where b.colb=a.colb))
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SUBQUERY_CACHE (hit: ?, miss: ?, size: ?, status: enabled)
+     
+
+===================================================
+count(*)    
+3749     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select avg(b.id) from [dba.tb] b where b.colb=a.colb)
+
+  TABLE SCAN (a)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a where (a.id>(select avg(b.id) from [dba.tb] b where b.colb=a.colb))
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SUBQUERY_CACHE (hit: ?, miss: ?, size: ?, status: enabled)
+     
+
+===================================================
+    
+Case 9: NOT IN + subquery -> parallel heap scan (buildvalue)     
+
+===================================================
+count(*)    
+3950     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    TABLE SCAN (b)
+
+  rewritten query: (select distinct b.id from [dba.tb] b where b.colb= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select count(*) from [dba.ta] a where a.id not in (select distinct b.id from [dba.tb] b where b.colb= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+3950     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    TABLE SCAN (b)
+
+  rewritten query: (select distinct b.id from [dba.tb] b where b.colb= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a where a.id not in (select distinct b.id from [dba.tb] b where b.colb= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 10: NOT EXISTS + GROUP BY -> parallel heap scan (mergeable list)     
+
+===================================================
+colb    count(*)    
+00000000000000000000     800     
+00000000000000000001     750     
+00000000000000000002     800     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? )
+
+  SORT (group by)
+    TABLE SCAN (a)
+
+  rewritten query: select a.colb, count(*) from [dba.ta] a where  not  exists (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? ) group by a.colb having groupby_num()<=?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
+    GROUPBY (time: ?, hash: partial, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+colb    count(*)    
+00000000000000000000     800     
+00000000000000000001     750     
+00000000000000000002     800     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? )
+
+  SORT (group by)
+    TABLE SCAN (a)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ a.colb, count(*) from [dba.ta] a where  not  exists (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? ) group by a.colb having groupby_num()<=?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    GROUPBY (time: ?, hash: true, sort: true, page: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 11: NOT EXISTS + DISTINCT -> parallel heap scan (mergeable list)     
+
+===================================================
+colb    
+00000000000000000000     
+00000000000000000001     
+00000000000000000002     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  SORT (distinct)
+    TABLE SCAN (a)
+
+  rewritten query: select distinct a.colb from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? ) order by ? for orderby_num()<= ?:? 
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+colb    
+00000000000000000000     
+00000000000000000001     
+00000000000000000002     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  SORT (distinct)
+    TABLE SCAN (a)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ distinct a.colb from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? ) order by ? for orderby_num()<= ?:? 
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+            (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 12: NOT EXISTS + ORDER BY + LIMIT -> parallel heap scan (mergeable list)     
+
+===================================================
+cola    
+00000000000000000501     
+00000000000000000502     
+00000000000000000503     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  SORT (order by)
+    TABLE SCAN (a)
+
+  rewritten query: select a.cola from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? ) order by ? for orderby_num()<= ?:? 
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, topnsort: true, gather: mergeable list)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+cola    
+00000000000000000501     
+00000000000000000502     
+00000000000000000503     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  SORT (order by)
+    TABLE SCAN (a)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ a.cola from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? ) order by ? for orderby_num()<= ?:? 
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, topnsort: true)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 13: NOT EXISTS + JOIN -> parallel heap scan (buildvalue)     
+
+===================================================
+count(*)    
+450     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (c)
+
+  rewritten query: (select ? from [dba.tb] c where c.id=a.id and (c.colb= ?:? ) and inst_num()<= ?:? )
+
+  NESTED LOOPS (inner join)
+    TABLE SCAN (a)
+    TABLE SCAN (b)
+
+  rewritten query: select count(*) from [dba.ta] a, [dba.tb] b where  not  exists (select ? from [dba.tb] c where c.id=a.id and (c.colb= ?:? ) and inst_num()<= ?:? ) and a.id=b.id
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+      SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+450     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (c)
+
+  rewritten query: (select ? from [dba.tb] c where c.id=a.id and (c.colb= ?:? ) and inst_num()<= ?:? )
+
+  NESTED LOOPS (inner join)
+    TABLE SCAN (a)
+    TABLE SCAN (b)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a, [dba.tb] b where  not  exists (select ? from [dba.tb] c where c.id=a.id and (c.colb= ?:? ) and inst_num()<= ?:? ) and a.id=b.id
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 14: NOT EXISTS + UNION ALL -> parallel heap scan (buildvalue, both sides)     
+
+===================================================
+count(*)    
+3500     
+500     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select count(*) from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select count(*) from [dba.ta] a where  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+           (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+           (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+3500     
+500     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a where  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  UNION (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+      SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SUBQUERY (correlated)
+        SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+          SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 15: SELECT-list correlated subquery + WHERE NOT EXISTS -> parallel heap scan (mergeable list)     
+
+===================================================
+cola    cnt    
+00000000000000000002     1     
+00000000000000000003     1     
+00000000000000000004     1     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select count(*) from [dba.tb] b where b.id=a.id)
+
+  TABLE SCAN (c)
+
+  rewritten query: (select ? from [dba.tb] c where c.id=a.id and (c.colb= ?:? ) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: (select /*+ NO_MERGE */ a.cola, (select count(*) from [dba.tb] b where b.id=a.id) from [dba.ta] a where  not  exists (select ? from [dba.tb] c where c.id=a.id and (c.colb= ?:? ) and inst_num()<= ?:? ))
+
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: select [__t?].cola, [__t?].cnt from (select /*+ NO_MERGE */ a.cola, (select count(*) from [dba.tb] b where b.id=a.id) as [cnt] from [dba.ta] a where  not  exists (select ? from [dba.tb] c where c.id=a.id and (c.colb= ?:? ) and inst_num()<= ?:? )) [__t?] (cola, cnt) order by ? for orderby_num()<= ?:? 
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, topnsort: true)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+             (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
+        SUBQUERY (correlated)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+cola    cnt    
+00000000000000000002     1     
+00000000000000000003     1     
+00000000000000000004     1     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select count(*) from [dba.tb] b where b.id=a.id)
+
+  TABLE SCAN (c)
+
+  rewritten query: (select ? from [dba.tb] c where c.id=a.id and (c.colb= ?:? ) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: (select /*+ NO_MERGE NO_PARALLEL_SCAN */ a.cola, (select count(*) from [dba.tb] b where b.id=a.id) from [dba.ta] a where  not  exists (select ? from [dba.tb] c where c.id=a.id and (c.colb= ?:? ) and inst_num()<= ?:? ))
+
+  SORT (order by)
+    TABLE SCAN (__t?)
+
+  rewritten query: select [__t?].cola, [__t?].cnt from (select /*+ NO_MERGE NO_PARALLEL_SCAN */ a.cola, (select count(*) from [dba.tb] b where b.id=a.id) as [cnt] from [dba.ta] a where  not  exists (select ? from [dba.tb] c where c.id=a.id and (c.colb= ?:? ) and inst_num()<= ?:? )) [__t?] (cola, cnt) order by ? for orderby_num()<= ?:? 
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    ORDERBY (time: ?, topnsort: true)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SUBQUERY (correlated)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 16: NOT EXISTS + PARALLEL(2) hint -> parallel heap scan (buildvalue)     
+
+===================================================
+count(*)    
+3500     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+3500     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 17: NOT EXISTS + NO_PARALLEL_SCAN hint -> not parallelized     
+
+===================================================
+count(*)    
+3500     
+
+===================================================
+trace    
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 18: NOT EXISTS + partitioned table -> parallel heap scan (buildvalue)     
+
+===================================================
+0
+===================================================
+0
+===================================================
+40000
+===================================================
+count(*)    
+39950     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select /*+ PARALLEL(?) */ count(*) from [dba.pl] a where  not  exists (select ? from [dba.tb] b where b.id=a.id and (b.colb= ?:? ) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.pl), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+           PARTITION (table: dba.pl__p__pa), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+           PARTITION (table: dba.pl__p__pb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+           PARTITION (table: dba.pl__p__pc), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+0
+===================================================
+    
+Case 19: INSERT ... SELECT + NOT EXISTS -> parallel heap scan (mergeable list)     
+
+===================================================
+0
+===================================================
+0
+===================================================
+3500
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  SORT (order by)
+    TABLE SCAN (a)
+
+  rewritten query: select a.id, a.cola, a.colb, a.colc, a.cold from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? ) order by ?
+
+
+Trace Statistics:
+  INSERT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+             (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+                (parallel workers: ?, time: ?..?, page: ?..?, ioread: ?..?)
+        SUBQUERY (correlated)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+3500     
+
+===================================================
+count(*)    
+3500     
+
+===================================================
+0
+===================================================
+    
+Case 20: complex AND/OR predicate + NOT EXISTS -> parallel heap scan (buildvalue)     
+
+===================================================
+count(*)    
+1050     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select count(*) from [dba.ta] a where (a.cola like  ?:?  or a.colb like  ?:? ) and  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+1050     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a where (a.cola like  ?:?  or a.colb like  ?:? ) and  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 21: stored procedure in a correlated subquery predicate -> NOT parallelized     
+
+===================================================
+count(*)    
+3500     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where b.id=a.id and ([dba.sp_f](b.id)>?) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select count(*) from [dba.ta] a where  not  exists (select ? from [dba.tb] b where b.id=a.id and ([dba.sp_f](b.id)>?) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 22: session variable in a correlated subquery predicate -> NOT parallelized     
+
+===================================================
+count(*)    
+3500     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where b.id=a.id and ((@v := b.id) is not null ) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: select count(*) from [dba.ta] a where  not  exists (select ? from [dba.tb] b where b.id=a.id and ((@v := b.id) is not null ) and inst_num()<= ?:? )
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 23: SP in a correlated scalar subquery predicate (aptr branch) -> NOT parallelized     
+
+===================================================
+count(*)    
+0     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select min(b.cola) from [dba.tb] b where b.id=a.id and [dba.sp_f](b.id)>?)
+
+  TABLE SCAN (a)
+
+  rewritten query: select count(*) from [dba.ta] a where (a.cola>(select min(b.cola) from [dba.tb] b where b.id=a.id and [dba.sp_f](b.id)>?))
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 24: SP in a correlated IN-subquery predicate -> NOT parallelized     
+
+===================================================
+count(*)    
+250     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    TABLE SCAN (b)
+
+  rewritten query: (select distinct b.id from [dba.tb] b where b.colb=a.colb and [dba.sp_f](b.id)>?)
+
+  TABLE SCAN (a)
+
+  rewritten query: select count(*) from [dba.ta] a where a.id in (select distinct b.id from [dba.tb] b where b.colb=a.colb and [dba.sp_f](b.id)>?)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 25: SP in an uncorrelated IN-subquery predicate -> parallel heap scan (buildvalue)     
+
+===================================================
+count(*)    
+500     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    TABLE SCAN (b)
+
+  rewritten query: (select distinct b.id from [dba.tb] b where [dba.sp_f](b.id)>?)
+
+  NESTED LOOPS (inner join)
+    TABLE SCAN (a)
+    TABLE SCAN (av?)
+
+  rewritten query: select count(*) from [dba.ta] a, (select distinct b.id from [dba.tb] b where [dba.sp_f](b.id)>?) av? (av_?) where a.id=av?.av_?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+      SCAN (hash temp(m), build time: ?, time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+count(*)    
+500     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    TABLE SCAN (b)
+
+  rewritten query: (select distinct b.id from [dba.tb] b where [dba.sp_f](b.id)>?)
+
+  NESTED LOOPS (inner join)
+    TABLE SCAN (a)
+    TABLE SCAN (av?)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a, (select distinct b.id from [dba.tb] b where [dba.sp_f](b.id)>?) av? (av_?) where a.id=av?.av_?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (hash temp(m), build time: ?, time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+0
+===================================================
+0
+===================================================
+0

--- a/sql/_36_guava/cbrd_26707/answers/cbrd_26707.answer
+++ b/sql/_36_guava/cbrd_26707/answers/cbrd_26707.answer
@@ -327,7 +327,7 @@ Case 6: filter subquery + min() compare -> parallel heap scan (buildvalue)
 
 ===================================================
 count(*)    
-0     
+500     
 
 ===================================================
 trace    
@@ -339,7 +339,7 @@ Query Plan:
 
   TABLE SCAN (a)
 
-  rewritten query: select count(*) from [dba.ta] a where (a.cola>(select min(b.cola) from [dba.tb] b where b.id=a.id))
+  rewritten query: select count(*) from [dba.ta] a where (a.cola>=(select min(b.cola) from [dba.tb] b where b.id=a.id))
 
 
 Trace Statistics:
@@ -353,7 +353,7 @@ Trace Statistics:
 
 ===================================================
 count(*)    
-0     
+500     
 
 ===================================================
 trace    
@@ -365,7 +365,7 @@ Query Plan:
 
   TABLE SCAN (a)
 
-  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a where (a.cola>(select min(b.cola) from [dba.tb] b where b.id=a.id))
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a where (a.cola>=(select min(b.cola) from [dba.tb] b where b.id=a.id))
 
 
 Trace Statistics:
@@ -1026,31 +1026,6 @@ Trace Statistics:
      
 
 ===================================================
-count(*)    
-3500     
-
-===================================================
-trace    
-
-Query Plan:
-  TABLE SCAN (b)
-
-  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
-
-  TABLE SCAN (a)
-
-  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
-
-
-Trace Statistics:
-  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-    SUBQUERY (correlated)
-      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
-        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
-     
-
-===================================================
     
 Case 17: NOT EXISTS + NO_PARALLEL_SCAN hint -> not parallelized     
 
@@ -1187,12 +1162,12 @@ Trace Statistics:
      
 
 ===================================================
-count(*)    
-3500     
+count(*)    sum(id)    sum( cast(cola as bigint))    sum( cast(colb as integer))    sum( cast(cold as bigint))    
+3500     7876750     7876750     7000     7876750     
 
 ===================================================
-count(*)    
-3500     
+count(*)    sum(a.id)    sum( cast(a.cola as bigint))    sum( cast(a.colb as integer))    sum( cast(a.cold as bigint))    
+3500     7876750     7876750     7000     7876750     
 
 ===================================================
 trace    
@@ -1204,7 +1179,7 @@ Query Plan:
 
   TABLE SCAN (a)
 
-  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*), sum(a.id), sum( cast(a.cola as bigint)), sum( cast(a.colb as integer)), sum( cast(a.cold as bigint)) from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
 
 
 Trace Statistics:
@@ -1338,7 +1313,7 @@ Case 23: SP in a correlated scalar subquery predicate (aptr branch) -> NOT paral
 
 ===================================================
 count(*)    
-0     
+500     
 
 ===================================================
 trace    
@@ -1350,7 +1325,7 @@ Query Plan:
 
   TABLE SCAN (a)
 
-  rewritten query: select count(*) from [dba.ta] a where (a.cola>(select min(b.cola) from [dba.tb] b where b.id=a.id and [dba.sp_f](b.id)>?))
+  rewritten query: select count(*) from [dba.ta] a where (a.cola>=(select min(b.cola) from [dba.tb] b where b.id=a.id and [dba.sp_f](b.id)>?))
 
 
 Trace Statistics:
@@ -1461,6 +1436,265 @@ Trace Statistics:
     SUBQUERY (uncorrelated)
       SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+     
+
+===================================================
+    
+Case 26: NOT EXISTS + mergeable list folded into per-column sums (no limit) -> parallel heap scan (mergeable list)     
+
+===================================================
+count(*)    sum( cast(cola as bigint))    sum( cast(colb as integer))    sum( cast(colc as bigint))    sum( cast(cold as bigint))    
+3500     7876750     7000     7876750     7876750     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: (select /*+ NO_MERGE */ a.cola, a.colb, a.colc, a.cold from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? ))
+
+  TABLE SCAN (__t?)
+
+  rewritten query: select count(*), sum( cast([__t?].cola as bigint)), sum( cast([__t?].colb as integer)), sum( cast([__t?].colc as bigint)), sum( cast([__t?].cold as bigint)) from (select /*+ NO_MERGE */ a.cola, a.colb, a.colc, a.cold from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )) [__t?] (cola, colb, colc, cold)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+             (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: mergeable list)
+        SUBQUERY (correlated)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    sum( cast(cola as bigint))    sum( cast(colb as integer))    sum( cast(colc as bigint))    sum( cast(cold as bigint))    
+3500     7876750     7000     7876750     7876750     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  TABLE SCAN (a)
+
+  rewritten query: (select /*+ NO_MERGE NO_PARALLEL_SCAN */ a.cola, a.colb, a.colc, a.cold from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? ))
+
+  TABLE SCAN (__t?)
+
+  rewritten query: select count(*), sum( cast([__t?].cola as bigint)), sum( cast([__t?].colb as integer)), sum( cast([__t?].colc as bigint)), sum( cast([__t?].cold as bigint)) from (select /*+ NO_MERGE NO_PARALLEL_SCAN */ a.cola, a.colb, a.colc, a.cold from [dba.ta] a where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )) [__t?] (cola, colb, colc, cold)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (temp time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+        SUBQUERY (correlated)
+          SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+            SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 27: NOT EXISTS + trailing set-scan spec -> parallel heap scan (row by row)     
+
+===================================================
+id    v    
+501     1     
+501     2     
+501     3     
+502     1     
+502     2     
+502     3     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  SORT (order by)
+    NESTED LOOPS (cross join)
+      TABLE SCAN (a)
+      TABLE SCAN (tset)
+
+  rewritten query: select /*+ ORDERED */ a.id, tset.v from [dba.ta] a, table({?, ?, ?}) tset (v) where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? ) and  cast(a.cola as integer)<? order by ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: row by row)
+      SCAN (set time: ?, fetch: ?, ioread: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+id    v    
+501     1     
+501     2     
+501     3     
+502     1     
+502     2     
+502     3     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? )
+
+  SORT (order by)
+    NESTED LOOPS (cross join)
+      TABLE SCAN (a)
+      TABLE SCAN (tset)
+
+  rewritten query: select /*+ ORDERED NO_PARALLEL_SCAN */ a.id, tset.v from [dba.ta] a, table({?, ?, ?}) tset (v) where  not  exists (select ? from [dba.tb] b where (b.id=a.id) and inst_num()<= ?:? ) and  cast(a.cola as integer)<? order by ?, ?
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+      SCAN (set time: ?, fetch: ?, ioread: ?)
+    ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 28: SP in an uncorrelated scalar subquery predicate -> NOT parallelized     
+
+===================================================
+count(*)    
+4000     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select min(b.cola) from [dba.tb] b where b.cola is not null  and [dba.sp_f](b.id)>?)
+
+  TABLE SCAN (a)
+
+  rewritten query: select count(*) from [dba.ta] a where (a.cola>=(select min(b.cola) from [dba.tb] b where b.cola is not null  and [dba.sp_f](b.id)>?))
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        FUNC (time: ?, fetch: ?, ioread: ?, calls: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+4000     
+
+===================================================
+trace    
+
+Query Plan:
+  TABLE SCAN (b)
+
+  rewritten query: (select min(b.cola) from [dba.tb] b)
+
+  TABLE SCAN (a)
+
+  rewritten query: select count(*) from [dba.ta] a where (a.cola>=(select min(b.cola) from [dba.tb] b))
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+    SUBQUERY (uncorrelated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+    
+Case 29: correlated IN-subquery without a blocking element -> parallel heap scan (buildvalue)     
+
+===================================================
+count(*)    
+250     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    TABLE SCAN (b)
+
+  rewritten query: (select distinct b.id from [dba.tb] b where b.colb=a.colb)
+
+  TABLE SCAN (a)
+
+  rewritten query: select count(*) from [dba.ta] a where a.id in (select distinct b.id from [dba.tb] b where b.colb=a.colb)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+         (parallel workers: ?, heap time: ?..?, readrows: ?..?, rows: ?..?, gather: buildvalue)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+        SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+     
+
+===================================================
+count(*)    
+250     
+
+===================================================
+trace    
+
+Query Plan:
+  SORT (distinct)
+    TABLE SCAN (b)
+
+  rewritten query: (select distinct b.id from [dba.tb] b where b.colb=a.colb)
+
+  TABLE SCAN (a)
+
+  rewritten query: select /*+ NO_PARALLEL_SCAN */ count(*) from [dba.ta] a where a.id in (select distinct b.id from [dba.tb] b where b.colb=a.colb)
+
+
+Trace Statistics:
+  SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
+    SCAN (table: dba.ta), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
+    SUBQUERY (correlated)
+      SELECT (time: ?, fetch: ?, fetch_time: ?, ioread: ?)
         SCAN (table: dba.tb), (heap time: ?, fetch: ?, ioread: ?, readrows: ?, rows: ?)
         ORDERBY (time: ?, sort: true, page: ?, ioread: ?)
      

--- a/sql/_36_guava/cbrd_26707/cases/cbrd_26707.sql
+++ b/sql/_36_guava/cbrd_26707/cases/cbrd_26707.sql
@@ -75,10 +75,10 @@ show trace;
 
 
 evaluate 'Case 3: NOT EXISTS + column output -> parallel heap scan (mergeable list)';
-select * from (select /*+ NO_MERGE */ cola, colb from ta a where not exists (select 1 from tb b where b.id = a.id)) order by 1 limit 3;
+select /*+ recompile */ * from (select /*+ NO_MERGE */ cola, colb from ta a where not exists (select 1 from tb b where b.id = a.id)) order by 1 limit 3;
 show trace;
 -- serial reference
-select * from (select /*+ NO_MERGE no_parallel_scan */ cola, colb from ta a where not exists (select 1 from tb b where b.id = a.id)) order by 1 limit 3;
+select /*+ recompile */ * from (select /*+ NO_MERGE no_parallel_scan */ cola, colb from ta a where not exists (select 1 from tb b where b.id = a.id)) order by 1 limit 3;
 show trace;
 
 
@@ -111,10 +111,10 @@ show trace;
 
 
 evaluate 'Case 7: filter subquery + max() compare + column output -> parallel heap scan (mergeable list)';
-select * from (select /*+ NO_MERGE */ cola, colb from ta a where a.colb = (select max(b.colb) from tb b where b.id = a.id)) order by 1 limit 3;
+select /*+ recompile */ * from (select /*+ NO_MERGE */ cola, colb from ta a where a.colb = (select max(b.colb) from tb b where b.id = a.id)) order by 1 limit 3;
 show trace;
 -- serial reference
-select * from (select /*+ NO_MERGE no_parallel_scan */ cola, colb from ta a where a.colb = (select max(b.colb) from tb b where b.id = a.id)) order by 1 limit 3;
+select /*+ recompile */ * from (select /*+ NO_MERGE no_parallel_scan */ cola, colb from ta a where a.colb = (select max(b.colb) from tb b where b.id = a.id)) order by 1 limit 3;
 show trace;
 
 
@@ -135,26 +135,26 @@ show trace;
 
 
 evaluate 'Case 10: NOT EXISTS + GROUP BY -> parallel heap scan (mergeable list)';
-select colb, count(*) from ta a where not exists (select 1 from tb b where b.id = a.id and b.colb = '00000000000000000001') group by colb order by 1 limit 3;
+select /*+ recompile */ colb, count(*) from ta a where not exists (select 1 from tb b where b.id = a.id and b.colb = '00000000000000000001') group by colb order by 1 limit 3;
 show trace;
 -- serial reference
-select /*+ no_parallel_scan */ colb, count(*) from ta a where not exists (select 1 from tb b where b.id = a.id and b.colb = '00000000000000000001') group by colb order by 1 limit 3;
+select /*+ recompile no_parallel_scan */ colb, count(*) from ta a where not exists (select 1 from tb b where b.id = a.id and b.colb = '00000000000000000001') group by colb order by 1 limit 3;
 show trace;
 
 
 evaluate 'Case 11: NOT EXISTS + DISTINCT -> parallel heap scan (mergeable list)';
-select distinct colb from ta a where not exists (select 1 from tb b where b.id = a.id) order by 1 limit 3;
+select /*+ recompile */ distinct colb from ta a where not exists (select 1 from tb b where b.id = a.id) order by 1 limit 3;
 show trace;
 -- serial reference
-select /*+ no_parallel_scan */ distinct colb from ta a where not exists (select 1 from tb b where b.id = a.id) order by 1 limit 3;
+select /*+ recompile no_parallel_scan */ distinct colb from ta a where not exists (select 1 from tb b where b.id = a.id) order by 1 limit 3;
 show trace;
 
 
 evaluate 'Case 12: NOT EXISTS + ORDER BY + LIMIT -> parallel heap scan (mergeable list)';
-select cola from ta a where not exists (select 1 from tb b where b.id = a.id) order by cola limit 3;
+select /*+ recompile */ cola from ta a where not exists (select 1 from tb b where b.id = a.id) order by cola limit 3;
 show trace;
 -- serial reference
-select /*+ no_parallel_scan */ cola from ta a where not exists (select 1 from tb b where b.id = a.id) order by cola limit 3;
+select /*+ recompile no_parallel_scan */ cola from ta a where not exists (select 1 from tb b where b.id = a.id) order by cola limit 3;
 show trace;
 
 
@@ -179,17 +179,17 @@ show trace;
 
 
 evaluate 'Case 15: SELECT-list correlated subquery + WHERE NOT EXISTS -> parallel heap scan (mergeable list)';
-select * from (select /*+ NO_MERGE */ a.cola, (select count(*) from tb b where b.id = a.id) as cnt
+select /*+ recompile */ * from (select /*+ NO_MERGE */ a.cola, (select count(*) from tb b where b.id = a.id) as cnt
 from ta a where not exists (select 1 from tb c where c.id = a.id and c.colb = '00000000000000000001')) order by 1 limit 3;
 show trace;
 -- serial reference
-select * from (select /*+ NO_MERGE no_parallel_scan */ a.cola, (select count(*) from tb b where b.id = a.id) as cnt
+select /*+ recompile */ * from (select /*+ NO_MERGE no_parallel_scan */ a.cola, (select count(*) from tb b where b.id = a.id) as cnt
 from ta a where not exists (select 1 from tb c where c.id = a.id and c.colb = '00000000000000000001')) order by 1 limit 3;
 show trace;
 
 
 evaluate 'Case 16: NOT EXISTS + PARALLEL(2) hint -> parallel heap scan (buildvalue)';
-select /*+ PARALLEL(2) */ count(*) from ta a where not exists (select 1 from tb b where b.id = a.id);
+select /*+ recompile PARALLEL(2) */ count(*) from ta a where not exists (select 1 from tb b where b.id = a.id);
 show trace;
 -- serial reference
 select /*+ recompile no_parallel_scan */ count(*) from ta a where not exists (select 1 from tb b where b.id = a.id);
@@ -197,7 +197,7 @@ show trace;
 
 
 evaluate 'Case 17: NOT EXISTS + NO_PARALLEL_SCAN hint -> not parallelized';
-select /*+ NO_PARALLEL_SCAN */ count(*) from ta a where not exists (select 1 from tb b where b.id = a.id);
+select /*+ recompile NO_PARALLEL_SCAN */ count(*) from ta a where not exists (select 1 from tb b where b.id = a.id);
 show trace;
 
 
@@ -211,7 +211,10 @@ PARTITION BY RANGE (colb) (
 );
 insert into pl select rownum, lpad(rownum, 20, '0'), rownum % 15
 from db_class a, db_class b, db_class c, db_class d limit 40000;
-select /*+ PARALLEL(2) */ count(*) from pl a where not exists (select 1 from tb b where b.id = a.id and b.colb = '00000000000000000001');
+select /*+ recompile PARALLEL(2) */ count(*) from pl a where not exists (select 1 from tb b where b.id = a.id and b.colb = '00000000000000000001');
+show trace;
+-- serial oracle: the count must match the parallel result above
+select /*+ recompile no_parallel_scan */ count(*) from pl a where not exists (select 1 from tb b where b.id = a.id and b.colb = '00000000000000000001');
 show trace;
 drop table if exists pl;
 
@@ -219,11 +222,13 @@ drop table if exists pl;
 evaluate 'Case 19: INSERT ... SELECT + NOT EXISTS -> parallel heap scan (mergeable list)';
 drop table if exists rt;
 create table rt (id int, cola varchar(20), colb varchar(20), colc varchar(20), cold varchar(20));
-insert into rt select * from ta a where not exists (select 1 from tb b where b.id = a.id) order by id;
+insert into rt select /*+ recompile */ * from ta a where not exists (select 1 from tb b where b.id = a.id) order by id;
 show trace;
--- verify the parallel insert produced the same rows a serial scan would
+-- verify the parallel insert produced the same rows an independent serial scan would:
+-- rt row count must equal the serial (no_parallel_scan) NOT EXISTS count.
 select count(*) from rt;
-select count(*) from ta a where not exists (select 1 from tb b where b.id = a.id);
+select /*+ recompile no_parallel_scan */ count(*) from ta a where not exists (select 1 from tb b where b.id = a.id);
+show trace;
 drop table if exists rt;
 
 

--- a/sql/_36_guava/cbrd_26707/cases/cbrd_26707.sql
+++ b/sql/_36_guava/cbrd_26707/cases/cbrd_26707.sql
@@ -1,0 +1,278 @@
+/**
+ *  This test case verifies CBRD-26707: Allow parallel heap scan::mergeable list
+ *  when 'not exists' clause and filter subquery (follow-up of CBRD-25447).
+ *
+ *  Before the fix, a non-EXISTS if_pred or a regu-linked aptr subquery
+ *  (IN / scalar subquery in WHERE) blocked parallel heap scan. The fix inspects
+ *  the predicate and the aptr_list recursively and allows the mergeable-list
+ *  optimization when no truly-unparallelizable element is present. The driving
+ *  heap scan of the outer table then runs in parallel; "show trace" shows the
+ *  (parallel workers ...) line and the "gather:" mode (mergeable list /
+ *  buildvalue for count-only / row by row when topn prevents merging).
+ *
+ *  CTP runs SQL tests with test_mode=yes, which lowers parallel_scan_page_
+ *  threshold to 32 (ta below is 4000 rows, well over 32 heap pages, so its heap
+ *  scan is parallelized) and masks volatile trace values and identifier digits
+ *  to '?'. Table/column names use letters (ta/tb, cola..) so they are not all
+ *  collapsed to 't?'/'col?' by that masking.
+ *
+ *  Correctness: each parallel case is followed by the same query with the
+ *  NO_PARALLEL_SCAN hint (serial); the two result blocks must match, proving the
+ *  parallel mergeable-list/buildvalue gather returns no missing/duplicate rows.
+ *
+ *  Coverage (mirrors the developer's attached scenario, cbrd_26707.sql):
+ *    Case 1-5:  NOT EXISTS / EXISTS correlated subquery in WHERE
+ *    Case 6-8:  filter subquery (regu-linked aptr) with min / max / avg
+ *    Case 9:    NOT IN + subquery
+ *    Case 10-15: combined with GROUP BY / DISTINCT / ORDER BY+LIMIT / JOIN /
+ *               UNION ALL / SELECT-list correlated subquery
+ *    Case 16:   explicit PARALLEL(2) hint
+ *    Case 17:   NO_PARALLEL_SCAN hint -> not parallelized
+ *    Case 18:   NOT EXISTS on a partitioned table (parallelized on this build)
+ *    Case 19:   INSERT ... SELECT + NOT EXISTS
+ *    Case 20:   complex AND/OR predicate + NOT EXISTS
+ *    Case 21-22: an unparallelizable element (stored procedure / session
+ *               variable) inside a correlated subquery predicate -> the fix's
+ *               recursive check still blocks parallel heap scan (NOT parallelized)
+ *    Case 23:   SP inside a correlated scalar (regu-linked aptr) subquery
+ *               predicate -> NOT parallelized (aptr branch; Case 6 is the control)
+ *    Case 24-25: SP inside an IN-subquery predicate, correlated -> NOT parallelized
+ *               vs uncorrelated -> parallel; proves the block is scoped to correlation
+ */
+
+drop table if exists ta, tb;
+
+create table ta (id int, cola varchar(20), colb varchar(20), colc varchar(20), cold varchar(20));
+insert into ta select rownum, lpad(rownum, 20, '0'), lpad(rownum % 5, 20, '0'), lpad(rownum, 20, '0'), lpad(rownum, 20, '0')
+from db_class a, db_class b, db_class c, db_class d, db_class e limit 4000;
+
+create table tb (id int, cola varchar(20), colb varchar(20));
+insert into tb select rownum, lpad(rownum, 20, '0'), lpad(rownum % 10, 20, '0')
+from db_class a, db_class b, db_class c, db_class d limit 500;
+
+create or replace function sp_f(n integer) return integer deterministic is
+begin
+    return n + 1;
+end;
+
+set trace on;
+
+
+evaluate 'Case 1: NOT EXISTS + correlated subquery -> parallel heap scan (buildvalue)';
+select /*+ recompile */ count(*) from ta a where not exists (select 1 from tb b where b.id = a.id and b.colb = '00000000000000000001');
+show trace;
+-- serial reference: result must match the parallel block above
+select /*+ recompile no_parallel_scan */ count(*) from ta a where not exists (select 1 from tb b where b.id = a.id and b.colb = '00000000000000000001');
+show trace;
+
+
+evaluate 'Case 2: EXISTS + correlated subquery -> parallel heap scan (buildvalue)';
+select /*+ recompile */ count(*) from ta a where exists (select 1 from tb b where b.id = a.id);
+show trace;
+-- serial reference
+select /*+ recompile no_parallel_scan */ count(*) from ta a where exists (select 1 from tb b where b.id = a.id);
+show trace;
+
+
+evaluate 'Case 3: NOT EXISTS + column output -> parallel heap scan (mergeable list)';
+select * from (select /*+ NO_MERGE */ cola, colb from ta a where not exists (select 1 from tb b where b.id = a.id)) order by 1 limit 3;
+show trace;
+-- serial reference
+select * from (select /*+ NO_MERGE no_parallel_scan */ cola, colb from ta a where not exists (select 1 from tb b where b.id = a.id)) order by 1 limit 3;
+show trace;
+
+
+evaluate 'Case 4: NOT EXISTS + extra WHERE condition -> parallel heap scan (buildvalue)';
+select /*+ recompile */ count(*) from ta a where a.cola like '%1' and not exists (select 1 from tb b where b.id = a.id and b.colb = '00000000000000000001');
+show trace;
+-- serial reference
+select /*+ recompile no_parallel_scan */ count(*) from ta a where a.cola like '%1' and not exists (select 1 from tb b where b.id = a.id and b.colb = '00000000000000000001');
+show trace;
+
+
+evaluate 'Case 5: multiple NOT EXISTS -> parallel heap scan (buildvalue)';
+select /*+ recompile */ count(*) from ta a
+where not exists (select 1 from tb b where b.id = a.id and b.colb = '00000000000000000001')
+  and not exists (select 1 from tb c where c.id = a.id and c.colb = '00000000000000000002');
+show trace;
+-- serial reference
+select /*+ recompile no_parallel_scan */ count(*) from ta a
+where not exists (select 1 from tb b where b.id = a.id and b.colb = '00000000000000000001')
+  and not exists (select 1 from tb c where c.id = a.id and c.colb = '00000000000000000002');
+show trace;
+
+
+evaluate 'Case 6: filter subquery + min() compare -> parallel heap scan (buildvalue)';
+select /*+ recompile */ count(*) from ta a where a.cola > (select min(b.cola) from tb b where b.id = a.id);
+show trace;
+-- serial reference
+select /*+ recompile no_parallel_scan */ count(*) from ta a where a.cola > (select min(b.cola) from tb b where b.id = a.id);
+show trace;
+
+
+evaluate 'Case 7: filter subquery + max() compare + column output -> parallel heap scan (mergeable list)';
+select * from (select /*+ NO_MERGE */ cola, colb from ta a where a.colb = (select max(b.colb) from tb b where b.id = a.id)) order by 1 limit 3;
+show trace;
+-- serial reference
+select * from (select /*+ NO_MERGE no_parallel_scan */ cola, colb from ta a where a.colb = (select max(b.colb) from tb b where b.id = a.id)) order by 1 limit 3;
+show trace;
+
+
+evaluate 'Case 8: filter subquery + avg() compare -> parallel heap scan (buildvalue)';
+select /*+ recompile */ count(*) from ta a where a.id > (select avg(b.id) from tb b where b.colb = a.colb);
+show trace;
+-- serial reference
+select /*+ recompile no_parallel_scan */ count(*) from ta a where a.id > (select avg(b.id) from tb b where b.colb = a.colb);
+show trace;
+
+
+evaluate 'Case 9: NOT IN + subquery -> parallel heap scan (buildvalue)';
+select /*+ recompile */ count(*) from ta a where a.id not in (select b.id from tb b where b.colb = '00000000000000000001');
+show trace;
+-- serial reference
+select /*+ recompile no_parallel_scan */ count(*) from ta a where a.id not in (select b.id from tb b where b.colb = '00000000000000000001');
+show trace;
+
+
+evaluate 'Case 10: NOT EXISTS + GROUP BY -> parallel heap scan (mergeable list)';
+select colb, count(*) from ta a where not exists (select 1 from tb b where b.id = a.id and b.colb = '00000000000000000001') group by colb order by 1 limit 3;
+show trace;
+-- serial reference
+select /*+ no_parallel_scan */ colb, count(*) from ta a where not exists (select 1 from tb b where b.id = a.id and b.colb = '00000000000000000001') group by colb order by 1 limit 3;
+show trace;
+
+
+evaluate 'Case 11: NOT EXISTS + DISTINCT -> parallel heap scan (mergeable list)';
+select distinct colb from ta a where not exists (select 1 from tb b where b.id = a.id) order by 1 limit 3;
+show trace;
+-- serial reference
+select /*+ no_parallel_scan */ distinct colb from ta a where not exists (select 1 from tb b where b.id = a.id) order by 1 limit 3;
+show trace;
+
+
+evaluate 'Case 12: NOT EXISTS + ORDER BY + LIMIT -> parallel heap scan (mergeable list)';
+select cola from ta a where not exists (select 1 from tb b where b.id = a.id) order by cola limit 3;
+show trace;
+-- serial reference
+select /*+ no_parallel_scan */ cola from ta a where not exists (select 1 from tb b where b.id = a.id) order by cola limit 3;
+show trace;
+
+
+evaluate 'Case 13: NOT EXISTS + JOIN -> parallel heap scan (buildvalue)';
+select /*+ recompile */ count(*) from ta a join tb b on a.id = b.id where not exists (select 1 from tb c where c.id = a.id and c.colb = '00000000000000000001');
+show trace;
+-- serial reference
+select /*+ recompile no_parallel_scan */ count(*) from ta a join tb b on a.id = b.id where not exists (select 1 from tb c where c.id = a.id and c.colb = '00000000000000000001');
+show trace;
+
+
+evaluate 'Case 14: NOT EXISTS + UNION ALL -> parallel heap scan (buildvalue, both sides)';
+select /*+ recompile */ count(*) from ta a where not exists (select 1 from tb b where b.id = a.id)
+union all
+select /*+ recompile */ count(*) from ta a where exists (select 1 from tb b where b.id = a.id);
+show trace;
+-- serial reference
+select /*+ recompile no_parallel_scan */ count(*) from ta a where not exists (select 1 from tb b where b.id = a.id)
+union all
+select /*+ recompile no_parallel_scan */ count(*) from ta a where exists (select 1 from tb b where b.id = a.id);
+show trace;
+
+
+evaluate 'Case 15: SELECT-list correlated subquery + WHERE NOT EXISTS -> parallel heap scan (mergeable list)';
+select * from (select /*+ NO_MERGE */ a.cola, (select count(*) from tb b where b.id = a.id) as cnt
+from ta a where not exists (select 1 from tb c where c.id = a.id and c.colb = '00000000000000000001')) order by 1 limit 3;
+show trace;
+-- serial reference
+select * from (select /*+ NO_MERGE no_parallel_scan */ a.cola, (select count(*) from tb b where b.id = a.id) as cnt
+from ta a where not exists (select 1 from tb c where c.id = a.id and c.colb = '00000000000000000001')) order by 1 limit 3;
+show trace;
+
+
+evaluate 'Case 16: NOT EXISTS + PARALLEL(2) hint -> parallel heap scan (buildvalue)';
+select /*+ PARALLEL(2) */ count(*) from ta a where not exists (select 1 from tb b where b.id = a.id);
+show trace;
+-- serial reference
+select /*+ recompile no_parallel_scan */ count(*) from ta a where not exists (select 1 from tb b where b.id = a.id);
+show trace;
+
+
+evaluate 'Case 17: NOT EXISTS + NO_PARALLEL_SCAN hint -> not parallelized';
+select /*+ NO_PARALLEL_SCAN */ count(*) from ta a where not exists (select 1 from tb b where b.id = a.id);
+show trace;
+
+
+evaluate 'Case 18: NOT EXISTS + partitioned table -> parallel heap scan (buildvalue)';
+drop table if exists pl;
+create table pl (id int, cola varchar(20), colb int)
+PARTITION BY RANGE (colb) (
+  PARTITION pa VALUES LESS THAN (5),
+  PARTITION pb VALUES LESS THAN (10),
+  PARTITION pc VALUES LESS THAN MAXVALUE
+);
+insert into pl select rownum, lpad(rownum, 20, '0'), rownum % 15
+from db_class a, db_class b, db_class c, db_class d limit 40000;
+select /*+ PARALLEL(2) */ count(*) from pl a where not exists (select 1 from tb b where b.id = a.id and b.colb = '00000000000000000001');
+show trace;
+drop table if exists pl;
+
+
+evaluate 'Case 19: INSERT ... SELECT + NOT EXISTS -> parallel heap scan (mergeable list)';
+drop table if exists rt;
+create table rt (id int, cola varchar(20), colb varchar(20), colc varchar(20), cold varchar(20));
+insert into rt select * from ta a where not exists (select 1 from tb b where b.id = a.id) order by id;
+show trace;
+-- verify the parallel insert produced the same rows a serial scan would
+select count(*) from rt;
+select count(*) from ta a where not exists (select 1 from tb b where b.id = a.id);
+drop table if exists rt;
+
+
+evaluate 'Case 20: complex AND/OR predicate + NOT EXISTS -> parallel heap scan (buildvalue)';
+select /*+ recompile */ count(*) from ta a where (a.cola like '%1' or a.colb like '%2') and not exists (select 1 from tb b where b.id = a.id);
+show trace;
+-- serial reference
+select /*+ recompile no_parallel_scan */ count(*) from ta a where (a.cola like '%1' or a.colb like '%2') and not exists (select 1 from tb b where b.id = a.id);
+show trace;
+
+
+evaluate 'Case 21: stored procedure in a correlated subquery predicate -> NOT parallelized';
+-- the fix recursively inspects the predicate; an SP makes the driving heap scan
+-- non-parallelizable, so parallel heap scan must be blocked (no parallel workers).
+select /*+ recompile */ count(*) from ta a where not exists (select 1 from tb b where b.id = a.id and sp_f(b.id) > 0);
+show trace;
+
+
+evaluate 'Case 22: session variable in a correlated subquery predicate -> NOT parallelized';
+-- a session-variable assignment in the correlated predicate likewise blocks the
+-- parallel heap scan on the driving table.
+select /*+ recompile */ count(*) from ta a where not exists (select 1 from tb b where b.id = a.id and (@v:=b.id) is not null);
+show trace;
+
+
+evaluate 'Case 23: SP in a correlated scalar subquery predicate (aptr branch) -> NOT parallelized';
+-- the SP sits in the inner WHERE of a correlated scalar (regu-linked aptr) subquery, so the
+-- fix's sibling_check propagates CANNOT_PARALLEL to the driving heap scan. Case 6 is the same
+-- correlated scalar subquery without the SP and DOES parallelize -> positive control.
+select /*+ recompile */ count(*) from ta a where a.cola > (select min(b.cola) from tb b where b.id = a.id and sp_f(b.id) > 0);
+show trace;
+
+
+evaluate 'Case 24: SP in a correlated IN-subquery predicate -> NOT parallelized';
+select /*+ recompile */ count(*) from ta a where a.id in (select b.id from tb b where b.colb = a.colb and sp_f(b.id) > 0);
+show trace;
+
+
+evaluate 'Case 25: SP in an uncorrelated IN-subquery predicate -> parallel heap scan (buildvalue)';
+-- identical SP-in-predicate as Case 24 but uncorrelated: the block is scoped to correlation
+-- (regu-linked uncorrelated subqueries are exempt), so the driving heap scan parallelizes.
+select /*+ recompile */ count(*) from ta a where a.id in (select b.id from tb b where sp_f(b.id) > 0);
+show trace;
+-- serial reference: result must match the parallel block above
+select /*+ recompile no_parallel_scan */ count(*) from ta a where a.id in (select b.id from tb b where sp_f(b.id) > 0);
+show trace;
+
+
+set trace off;
+
+drop function sp_f;
+drop table if exists ta, tb;

--- a/sql/_36_guava/cbrd_26707/cases/cbrd_26707.sql
+++ b/sql/_36_guava/cbrd_26707/cases/cbrd_26707.sql
@@ -36,8 +36,15 @@
  *               recursive check still blocks parallel heap scan (NOT parallelized)
  *    Case 23:   SP inside a correlated scalar (regu-linked aptr) subquery
  *               predicate -> NOT parallelized (aptr branch; Case 6 is the control)
- *    Case 24-25: SP inside an IN-subquery predicate, correlated -> NOT parallelized
- *               vs uncorrelated -> parallel; proves the block is scoped to correlation
+ *    Case 24:   SP inside a correlated IN-subquery predicate -> NOT parallelized
+ *               (Case 29 is the same query without the SP -> parallel: the SP is the blocker)
+ *    Case 25:   SP inside an UNcorrelated IN-subquery predicate -> parallel (the IN is unnested
+ *               into a join); contrast Case 28 -> the block follows unnesting, not correlation
+ *    Case 26:   NOT EXISTS mergeable list folded into per-column sums (no limit) -> full-row check
+ *    Case 27:   trailing set-scan spec blocks list merge -> parallel heap scan (row by row)
+ *    Case 28:   SP inside an UNcorrelated SCALAR subquery predicate -> NOT parallelized (a scalar
+ *               subquery is not unnested, so the aptr remains and the SP still blocks)
+ *    Case 29:   correlated IN-subquery without a blocking element -> parallel (buildvalue)
  */
 
 drop table if exists ta, tb;
@@ -103,10 +110,10 @@ show trace;
 
 
 evaluate 'Case 6: filter subquery + min() compare -> parallel heap scan (buildvalue)';
-select /*+ recompile */ count(*) from ta a where a.cola > (select min(b.cola) from tb b where b.id = a.id);
+select /*+ recompile */ count(*) from ta a where a.cola >= (select min(b.cola) from tb b where b.id = a.id);
 show trace;
 -- serial reference
-select /*+ recompile no_parallel_scan */ count(*) from ta a where a.cola > (select min(b.cola) from tb b where b.id = a.id);
+select /*+ recompile no_parallel_scan */ count(*) from ta a where a.cola >= (select min(b.cola) from tb b where b.id = a.id);
 show trace;
 
 
@@ -191,9 +198,7 @@ show trace;
 evaluate 'Case 16: NOT EXISTS + PARALLEL(2) hint -> parallel heap scan (buildvalue)';
 select /*+ recompile PARALLEL(2) */ count(*) from ta a where not exists (select 1 from tb b where b.id = a.id);
 show trace;
--- serial reference
-select /*+ recompile no_parallel_scan */ count(*) from ta a where not exists (select 1 from tb b where b.id = a.id);
-show trace;
+-- serial reference: Case 17 runs the identical query with NO_PARALLEL_SCAN
 
 
 evaluate 'Case 17: NOT EXISTS + NO_PARALLEL_SCAN hint -> not parallelized';
@@ -225,9 +230,10 @@ create table rt (id int, cola varchar(20), colb varchar(20), colc varchar(20), c
 insert into rt select /*+ recompile */ * from ta a where not exists (select 1 from tb b where b.id = a.id) order by id;
 show trace;
 -- verify the parallel insert produced the same rows an independent serial scan would:
--- rt row count must equal the serial (no_parallel_scan) NOT EXISTS count.
-select count(*) from rt;
-select /*+ recompile no_parallel_scan */ count(*) from ta a where not exists (select 1 from tb b where b.id = a.id);
+-- per-column sums (not just the row count) must equal the serial NOT EXISTS aggregate, so a value
+-- dropped, duplicated, or corrupted by the parallel gather is caught -- not only a lost row.
+select count(*), sum(id), sum(cast(cola as bigint)), sum(cast(colb as int)), sum(cast(cold as bigint)) from rt;
+select /*+ recompile no_parallel_scan */ count(*), sum(a.id), sum(cast(a.cola as bigint)), sum(cast(a.colb as int)), sum(cast(a.cold as bigint)) from ta a where not exists (select 1 from tb b where b.id = a.id);
 show trace;
 drop table if exists rt;
 
@@ -258,22 +264,79 @@ evaluate 'Case 23: SP in a correlated scalar subquery predicate (aptr branch) ->
 -- the SP sits in the inner WHERE of a correlated scalar (regu-linked aptr) subquery, so the
 -- fix's sibling_check propagates CANNOT_PARALLEL to the driving heap scan. Case 6 is the same
 -- correlated scalar subquery without the SP and DOES parallelize -> positive control.
-select /*+ recompile */ count(*) from ta a where a.cola > (select min(b.cola) from tb b where b.id = a.id and sp_f(b.id) > 0);
+select /*+ recompile */ count(*) from ta a where a.cola >= (select min(b.cola) from tb b where b.id = a.id and sp_f(b.id) > 0);
 show trace;
 
 
 evaluate 'Case 24: SP in a correlated IN-subquery predicate -> NOT parallelized';
+-- correlated IN is not unnested, so the SP in its predicate blocks the driving heap scan.
+-- Case 29 is the same query without the SP and DOES parallelize -> the SP is the blocker.
 select /*+ recompile */ count(*) from ta a where a.id in (select b.id from tb b where b.colb = a.colb and sp_f(b.id) > 0);
 show trace;
 
 
 evaluate 'Case 25: SP in an uncorrelated IN-subquery predicate -> parallel heap scan (buildvalue)';
--- identical SP-in-predicate as Case 24 but uncorrelated: the block is scoped to correlation
--- (regu-linked uncorrelated subqueries are exempt), so the driving heap scan parallelizes.
+-- identical SP-in-predicate as Case 24 but uncorrelated: the optimizer unnests the uncorrelated
+-- IN into a join with a derived table (see the rewritten query in the answer), so no regu-linked
+-- aptr subquery remains and the driving heap scan parallelizes. Contrast Case 28 (uncorrelated
+-- SCALAR + SP), which is NOT unnested and is blocked -> the block follows unnesting, not correlation.
 select /*+ recompile */ count(*) from ta a where a.id in (select b.id from tb b where sp_f(b.id) > 0);
 show trace;
 -- serial reference: result must match the parallel block above
 select /*+ recompile no_parallel_scan */ count(*) from ta a where a.id in (select b.id from tb b where sp_f(b.id) > 0);
+show trace;
+
+
+evaluate 'Case 26: NOT EXISTS + mergeable list folded into per-column sums (no limit) -> parallel heap scan (mergeable list)';
+-- cases 3/7/11/12/15 all carry "limit 3" and case 19 checks only the row count, so a row lost or
+-- corrupted in the middle/tail of the gather is invisible. here the whole 3500-row mergeable gather
+-- is folded into per-column sums, which change if any single gathered value is wrong.
+select /*+ recompile */ count(*), sum(cast(cola as bigint)), sum(cast(colb as int)), sum(cast(colc as bigint)), sum(cast(cold as bigint))
+from (select /*+ NO_MERGE */ cola, colb, colc, cold from ta a where not exists (select 1 from tb b where b.id = a.id));
+show trace;
+-- serial reference: result must match the parallel block above
+select /*+ recompile */ count(*), sum(cast(cola as bigint)), sum(cast(colb as int)), sum(cast(colc as bigint)), sum(cast(cold as bigint))
+from (select /*+ NO_MERGE no_parallel_scan */ cola, colb, colc, cold from ta a where not exists (select 1 from tb b where b.id = a.id));
+show trace;
+
+
+evaluate 'Case 27: NOT EXISTS + trailing set-scan spec -> parallel heap scan (row by row)';
+-- the driving heap scan of ta still parallelizes, but the trailing set spec (table({..})) blocks
+-- list merging, so only CANNOT_LIST_MERGE is raised and the gather falls back to "row by row" --
+-- the intermediate mode between parallel+merged (cases 1-20) and parallel-blocked (cases 21-24).
+select /*+ recompile ordered */ a.id, tset.v
+from ta a, table({1, 2, 3}) as tset(v)
+where not exists (select 1 from tb b where b.id = a.id) and cast(a.cola as int) < 503
+order by 1, 2;
+show trace;
+-- serial reference: result must match the parallel block above
+select /*+ recompile ordered no_parallel_scan */ a.id, tset.v
+from ta a, table({1, 2, 3}) as tset(v)
+where not exists (select 1 from tb b where b.id = a.id) and cast(a.cola as int) < 503
+order by 1, 2;
+show trace;
+
+
+evaluate 'Case 28: SP in an uncorrelated scalar subquery predicate -> NOT parallelized';
+-- a scalar subquery is NOT unnested into a join, so it stays a regu-linked aptr even when
+-- uncorrelated; the SP in its predicate therefore still blocks the driving heap scan. Contrast
+-- Case 25 (uncorrelated IN + SP), which IS unnested and parallelizes.
+select /*+ recompile */ count(*) from ta a where a.cola >= (select min(b.cola) from tb b where sp_f(b.id) > 0);
+show trace;
+-- positive control: the same uncorrelated scalar subquery without the SP parallelizes,
+-- proving the SP -- not the uncorrelated-scalar shape -- is what blocks the case above.
+select /*+ recompile */ count(*) from ta a where a.cola >= (select min(b.cola) from tb b);
+show trace;
+
+
+evaluate 'Case 29: correlated IN-subquery without a blocking element -> parallel heap scan (buildvalue)';
+-- the acceptance criteria names IN (subquery) explicitly, but case 9 is NOT IN and cases 24/25
+-- both carry an SP. this is Case 24 with the SP removed: it parallelizes, which covers the plain-IN
+-- acceptance criterion and confirms the SP is what blocks Case 24.
+select /*+ recompile */ count(*) from ta a where a.id in (select b.id from tb b where b.colb = a.colb);
+show trace;
+-- serial reference: result must match the parallel block above
+select /*+ recompile no_parallel_scan */ count(*) from ta a where a.id in (select b.id from tb b where b.colb = a.colb);
 show trace;
 
 


### PR DESCRIPTION
- Issue: http://jira.cubrid.org/browse/CBRD-26707 (CBRD-25447의 후속)
- Engine PR: https://github.com/CUBRID/cubrid/pull/7040 (`develop`, `4f35a3526`)

## 개요

**CBRD-26707** (*`not exists` 절 및 필터 서브쿼리에서 parallel heap scan::mergeable list 허용*) 에 대한 SQL 회귀 테스트를 추가합니다.

수정 전에는 non-EXISTS `if_pred` 또는 regu-linked `aptr` 서브쿼리(`WHERE`의 `IN` / 스칼라 서브쿼리)가 구동 테이블의 parallel heap scan을 차단했습니다. 수정(엔진 PR #7040)은 술어(predicate)와 `aptr_list`를 **재귀적으로** 검사하여, 진짜로 병렬화 불가능한 요소가 없으면 mergeable-list 최적화를 허용합니다. 그 결과 외부 테이블의 구동 heap scan이 병렬로 수행되며, `show trace`에 `(parallel workers ...)` 라인과 `gather:` 모드가 나타납니다.

- **파일:** `sql/_36_guava/cbrd_26707/cases/cbrd_26707.sql`
- **정답:** `sql/_36_guava/cbrd_26707/answers/cbrd_26707.answer`
- **검증 빌드:** `11.5.0.2513-5f3a30d` (develop; #7040 포함) — CTP `sql` test_mode, **Fail:0 / Success:1** (정답은 이 빌드의 trace 출력 기준으로 생성)

## 설계

- 케이스마다 **`set trace on; <query>; show trace;`**; 판정은 값이 고정된 `(parallel workers: ?, … gather: <mode>)` 라인으로만 하고, 매번 달라지는 시간/페이지 값은 사용하지 않습니다.
- **병렬 케이스마다 직렬 대조 쿼리 추가:** 같은 쿼리에 `NO_PARALLEL_SCAN`을 적용한 쌍을 두어 두 결과 블록이 일치하는지 확인합니다. 이는 병렬 `mergeable list` / `buildvalue` gather가 누락/중복 행 없이 반환됨을 증명하고 정답 재생성을 자체 검증 가능하게 합니다. 단, Case 19(`INSERT … SELECT`)는 INSERT가 결과 집합을 반환하지 않아 같은 쿼리 twin을 만들 수 없으므로, 적재 행 수(`count(*) from rt`)를 독립 직렬 `NOT EXISTS` count와 비교합니다.
- **negative 케이스는 fix 자체의 차단 경로를 사용**(케이스 21–24·28; 케이스 17은 `NO_PARALLEL_SCAN` 힌트 차단). 차단 요소 하나만 빼면 병렬화되는 쿼리(예: 케이스 23↔6, 24↔29, 28의 no-SP 대조)를 두어, 병렬이 안 되는 원인이 그 요소임을 짚습니다. 아무 쿼리에서나 병렬 라인이 없는 것을 확인하는 방식이 아닙니다.

## 커버리지 (29 케이스)

케이스 1–19는 개발자 첨부 시나리오를 전부 반영했고, 20–29는 (#7040 checker 코드에 근거하여) 확장했습니다.

| 케이스 | 시나리오 | 기대 결과 |
|---|---|---|
| 1–2 | `NOT EXISTS` / `EXISTS` correlated 서브쿼리 | 병렬 (buildvalue) |
| 3 | `NOT EXISTS` + 컬럼 출력 | 병렬 (mergeable list) |
| 4–5 | `NOT EXISTS` + 추가 `WHERE` / 다중 `NOT EXISTS` | 병렬 (buildvalue) |
| 6–8 | 필터 서브쿼리 `min`/`max`/`avg` 비교 | 병렬 (buildvalue / mergeable list) |
| 9 | `NOT IN` + 서브쿼리 | 병렬 (buildvalue) |
| 10–15 | `GROUP BY` / `DISTINCT` / `ORDER BY`+`LIMIT` / `JOIN` / `UNION ALL` / SELECT-list correlated 서브쿼리 결합 | 병렬 (mergeable list / buildvalue) |
| 16 | 명시적 `PARALLEL(2)` 힌트 | 병렬 (buildvalue) |
| 17 | `NO_PARALLEL_SCAN` 힌트 | **병렬화 안 됨** |
| 18 | 파티션 테이블 대상 `NOT EXISTS` | 병렬 (buildvalue) |
| 19 | `INSERT … SELECT` + `NOT EXISTS` | 병렬 (mergeable list) |
| 20 | 복합 AND/OR 술어 + `NOT EXISTS` | 병렬 (buildvalue) |
| 21 | correlated `NOT EXISTS`(if_pred) 술어 내 **저장 프로시저** | **병렬화 안 됨** |
| 22 | correlated `NOT EXISTS`(if_pred) 술어 내 **세션 변수** | **병렬화 안 됨** |
| 23 | correlated **scalar 서브쿼리**(aptr) 내부 술어 내 SP | **병렬화 안 됨** |
| 24 | correlated **IN 서브쿼리** 내부 술어 내 SP | **병렬화 안 됨** |
| 25 | **비상관 IN** 서브쿼리 내부 술어 내 SP (join으로 unnest됨) | 병렬 (buildvalue) |
| 26 | mergeable list 전체 행을 컬럼별 `sum`으로 접음 (`limit` 없음) | 병렬 (mergeable list) |
| 27 | 후행 set-scan spec으로 list merge 차단 | 병렬 (**row by row**) |
| 28 | **비상관 scalar** 서브쿼리 내부 술어 내 SP (unnest 안 됨) | **병렬화 안 됨** |
| 29 | 방해 요소 없는 correlated **IN** 서브쿼리 | 병렬 (buildvalue) |

병렬 케이스의 `gather:` 분포: **buildvalue 16 + mergeable list 8 + row by row 1** (세 모드 모두 커버).

## 문서-vs-빌드 정정

개발자 시나리오(#7040 기준) 이후 후속 머지로 동작이 바뀐 두 케이스는 실제 빌드 기준으로 정정했습니다:

- **케이스 12** (`ORDER BY … LIMIT`) — 작성 당시엔 top-N이 mergeable list를 막아 "row by row"였으나, **CBRD-26848(#7223, `9c38448ad`)** 이 워커별 topnsort로 최적화하면서 **mergeable list**로 바뀜.
- **케이스 18** (파티션 테이블) — 작성 당시엔 단일 스레드 폴백으로 "미지원"이었으나, **CBRD-26722(#7062, `0c6088ab3`)** 가 개별 파티션(`DB_PARTITION_CLASS`) 병렬 스캔을 도입해 **병렬화됨**(buildvalue).

## 확장 케이스(20–29) 선정 근거

개발자 첨부 시나리오에 없던 추가 케이스. #7040 checker 코드 기준으로 설계하고 빌드에서 실측했습니다.

- **20** — 복합 AND/OR + `NOT EXISTS` → 병렬. positive breadth 확장.
- **21/22** — correlated `NOT EXISTS`(if_pred) 술어 내 SP / 세션 변수 → 차단. `if_pred` 분기 negative.
- **23** — correlated scalar 서브쿼리(aptr) 내부 술어 내 SP → 차단. `aptr_list` 분기 negative (양성 대조 = Case 6).
- **24 vs 29** — correlated IN 서브쿼리, SP 유무만 차이: 24(SP)→차단 ↔ 29(SP 없음)→병렬. **SP가 차단 원인**임을 증명하고, 29는 AC가 명시한 "방해 요소 없는 `IN`"도 충족.
- **25 vs 28** — 비상관 서브쿼리, IN vs scalar만 차이: 25(IN, join으로 unnest됨)→병렬 ↔ 28(scalar, aptr 잔존)→차단. **차단은 상관성이 아니라 unnest 여부에 스코프됨**을 증명.
- **26** — mergeable list 전체 행을 컬럼별 `sum`으로 접어(`limit` 없음) 중간/뒤쪽 행 손실·값 손상까지 검출. 기존 mergeable 케이스(3/7/11/12/15)는 `limit 3`, Case 19는 행 수만 비교하는 한계 보완.
- **27** — 후행 set-scan spec이 list merge를 막아 `CANNOT_LIST_MERGE`만 서는 중간 상태 → `gather: row by row`. 세 번째 gather 모드 커버.

실측 결과 차단은 SP·세션 변수 같은 병렬화 불가 요소가 **옵티마이저가 join으로 unnest하지 않고 regu-linked aptr/dptr로 남긴 서브쿼리의 내부 술어(WHERE)** 에 있을 때 성립합니다 — 상관 서브쿼리(전부)와 비상관 **scalar** 서브쿼리가 여기 해당하고, 비상관 **IN**만 join으로 unnest되어 병렬화됩니다(상관성 자체가 기준이 아님, Case 25 vs 28).