### PR TITLE
[CBRD-27176] Revise testcase for answer_cci Re-baselining (GROUP BY c…

### DIFF
--- a/sql/_18_index_enhancement_qa/_02_full_test/_09_grouping/answers/_05_first_column_primary_key.answer_cci
+++ b/sql/_18_index_enhancement_qa/_02_full_test/_09_grouping/answers/_05_first_column_primary_key.answer_cci
@@ -31,7 +31,7 @@ iscan
     sort:  ? asc, ? asc, ? asc, ? asc
     cost:  ? card ?
 Query stmt:
-select t.a, t.b, t.c, t.d from t t group by t.a, t.b, t.c, t.d
+select t.a, t.b, t.c, t.d from t t group by t.a
 /* ---> skip GROUP BY */
 ===================================================
 0
@@ -52,7 +52,7 @@ iscan
     sort:  ? desc, ? desc, ? desc, ? desc
     cost:  ? card ?
 Query stmt:
-select t.a, t.b, t.c, t.d from t t group by t.a desc , t.b desc , t.c desc , t.d desc 
+select t.a, t.b, t.c, t.d from t t group by t.a desc 
 /* ---> skip GROUP BY */
 ===================================================
 0
@@ -71,7 +71,7 @@ iscan
     sort:  ? desc, ? desc, ? desc, ? desc
     cost:  ? card ?
 Query stmt:
-select t.a, t.b, t.c, t.d from t t group by t.a desc , t.b desc , t.c desc , t.d desc  having groupby_num()<=?
+select t.a, t.b, t.c, t.d from t t group by t.a desc  having groupby_num()<=?
 /* ---> skip GROUP BY */
 ===================================================
 0
@@ -87,7 +87,7 @@ iscan
     sort:  ? desc, ? desc, ? desc, ? desc
     cost:  ? card ?
 Query stmt:
-select t.a, t.b, t.c, t.d, count(*) from t t group by t.a desc , t.b desc , t.c desc , t.d desc  having count(*)>?
+select t.a, t.b, t.c, t.d, count(*) from t t group by t.a desc  having count(*)>?
 /* ---> skip GROUP BY */
 ===================================================
 0
@@ -106,7 +106,7 @@ iscan
     sort:  ? desc, ? desc, ? desc, ? desc
     cost:  ? card ?
 Query stmt:
-select t.a, t.b, t.c, t.d, count(*) from t t group by t.a desc , t.b desc , t.c desc , t.d desc  having groupby_num()<? and count(*)=?
+select t.a, t.b, t.c, t.d, count(*) from t t group by t.a desc  having groupby_num()<? and count(*)=?
 /* ---> skip GROUP BY */
 ===================================================
 0
@@ -122,7 +122,7 @@ iscan
     sort:  ? desc, ? desc, ? desc, ? desc
     cost:  ? card ?
 Query stmt:
-select t.a, t.b, t.c, t.d, count(*) from t t group by t.a desc , t.b desc , t.c desc , t.d desc  having count(*)> ?:? 
+select t.a, t.b, t.c, t.d, count(*) from t t group by t.a desc  having count(*)> ?:? 
 /* ---> skip GROUP BY */
 ===================================================
 0


### PR DESCRIPTION
…ontinuous baseline)

- regression test 버전 : 11.5.0.2521-8e355ff에서 https://github.com/CUBRID/cubrid/pull/7673 (CBRD-27176 — PK/UNIQUE 키에 함수적으로 종속된 GROUP BY 컬럼 제거) 반영됨.
- http://jira.cubrid.org/browse/CBRD-27176

## Purpose

`sql/_18_index_enhancement_qa/_02_full_test/_09_grouping/cases/_05_first_column_primary_key.sql`은
`t(a int primary key, b, c, d, e)`에서 `group by a,b,c,d` 형태의 쿼리를 PREPARE/EXECUTE로 검증하는
케이스다. CBRD-27176(CUBRID/cubrid#7673, 2026-09-03 머지)로 GROUP BY 절에 어떤 테이블의 PK(또는
전 컬럼 NOT NULL인 UNIQUE) 컬럼이 전부 포함되면, 같은 테이블의 나머지 GROUP BY 컬럼은 그 키에
함수적으로 종속되어 그룹 분할에 기여하지 않으므로 자동 제거하는 최적화가 추가됐다. 이 케이스는
바로 이 리라이트의 대상이라 CCI 답지(`.answer_cci`)의 plan-trace에 찍히는 `Query stmt:` 텍스트
6곳이 예전(전체 컬럼 나열) 형태로 낡아 SQL_BY_CCI 카테고리에서 계속 실패하고 있었다.

group by t.a, t.b, t.c, t.d          ->  group by t.a
group by t.a desc, t.b desc, ...     ->  group by t.a desc

## Implementation

develop `11.5.0.2521-8e355ff` 빌드에서 CTP `sql_by_cci` sql_by_cci테스트(`CTP/sql_by_cci/execute`)로
직접 실행해 `_05_first_column_primary_key.answer_cci`의 `Query stmt:` 라인 6곳을 재작성된
GROUP BY 목록으로 갱신했다. 다른 내용은 변경하지 않았다.

## Remarks

엔진 회귀가 아니라 답지만 낡은 상태였다. `a`가 PRIMARY KEY이므로 `group by a`와
`group by a,b,c,d`는 그룹 분할이 수학적으로 동일하며, 실제 쿼리 결과 행/값은 이번 diff에서
전혀 변경되지 않았다(plan-trace 텍스트만 다름) — CBRD-27176 PR 저자도 TPC-H 벤치마크에서
결과가 바이트 단위로 동일함을 확인한 바 있다.

검증:

- develop `11.5.0.2521-8e355ff`에서 새로 실행해 이 PR의 답지와 바이트 단위로 일치함을 확인했다
  (`diff` exit 0).