### PR TITLE
[CBRD-27275] Backport from develop to 11.0 - Orphan row remains in db_trigger after CREATE TRIGGER failure

### DIFF
--- a/isolation/_01_ReadCommitted/issues/_26_2h/answer/cbrd_27275_create_trigger.answer
+++ b/isolation/_01_ReadCommitted/issues/_26_2h/answer/cbrd_27275_create_trigger.answer
@@ -1,0 +1,27 @@
+| 1 row affected
+| ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on  SCH_M_LOCK lock on class dba.tbl. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
+|    on statement number: 6
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+| 0 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+| 0 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    'dba.t1'    'NEW'  
+| 1 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    't1'    'DBA'  
+| 1 row selected
+| NEW
+| 1 row affected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+| 0 row selected

--- a/isolation/_01_ReadCommitted/issues/_26_2h/answer/cbrd_27275_create_user_trigger.answer
+++ b/isolation/_01_ReadCommitted/issues/_26_2h/answer/cbrd_27275_create_user_trigger.answer
@@ -1,0 +1,6 @@
+| ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on      S_LOCK lock on instance ?|?|? of class db_root. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
+|    on statement number: 6
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+| 0 row selected

--- a/isolation/_01_ReadCommitted/issues/_26_2h/answer/cbrd_27275_drop_trigger.answer
+++ b/isolation/_01_ReadCommitted/issues/_26_2h/answer/cbrd_27275_drop_trigger.answer
@@ -1,0 +1,16 @@
+| ORIG
+| 1 row affected
+| ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on  SCH_M_LOCK lock on class dba.tbl. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
+|    on statement number: 6
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    'dba.t1'    'ORIG'  
+| 1 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    't1'    'DBA'  
+| 1 row selected
+| ORIG
+| 1 row affected

--- a/isolation/_01_ReadCommitted/issues/_26_2h/answer/cbrd_27275_rename_trigger.answer
+++ b/isolation/_01_ReadCommitted/issues/_26_2h/answer/cbrd_27275_rename_trigger.answer
@@ -1,0 +1,16 @@
+| ORIG
+| 1 row affected
+| ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on      X_LOCK lock on instance ?|?|? of class db_trigger. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
+|    on statement number: 6
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    'dba.t1'    'ORIG'  
+| 1 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    't1'    'DBA'  
+| 1 row selected
+| ORIG
+| 1 row affected

--- a/isolation/_01_ReadCommitted/issues/_26_2h/cbrd_27275_create_trigger.ctl
+++ b/isolation/_01_ReadCommitted/issues/_26_2h/cbrd_27275_create_trigger.ctl
@@ -1,0 +1,79 @@
+/*
+Test Case: related to CBRD-27275
+Priority: 1
+
+Test Plan:
+The fix makes CREATE TRIGGER take a savepoint and roll back to it on failure, regardless of
+isolation level. This file covers the table-trigger CREATE under READ COMMITTED - see the other
+cbrd_27275_*.ctl files under isolation/_01_ReadCommitted, _02_RepeatableRead, and
+_07_serializable/issues/_26_2h for the other scenarios (DROP/RENAME/user trigger) and isolation
+levels.
+
+Test Point:
+1) A failed CREATE TRIGGER leaves no row behind in db_trigger (raw table, no
+   separate view on this branch).
+2) Recreating a trigger under the same name after a failed CREATE leaves exactly one trigger,
+   and only its action fires on INSERT.
+3) The final DROP TRIGGER leaves no row behind either.
+
+NUM_CLIENTS = 2
+C1: hold X-lock on tbl without commit
+C2: force a CREATE TRIGGER failure under lock_timeout=3 -> commit without rollback
+*/
+
+MC: setup NUM_CLIENTS = 2;
+
+C1: login as 'dba';
+C1: set transaction lock timeout INFINITE;
+C1: set transaction isolation level read committed;
+C2: login as 'dba';
+C2: set transaction lock timeout INFINITE;
+C2: set transaction isolation level read committed;
+C2: commit;
+
+/* preparation */
+C1: DROP TABLE IF EXISTS tbl;
+C1: CREATE TABLE tbl(a INT);
+C1: COMMIT;
+MC: wait until C1 ready;
+
+/* test case: check whether a failed CREATE TRIGGER leaves an orphan row in db_trigger */
+C1: INSERT INTO tbl VALUES (1);
+MC: wait until C1 ready;
+
+C2: SET SYSTEM PARAMETERS 'lock_timeout=3';
+C2: CREATE TRIGGER t1 AFTER INSERT ON tbl EXECUTE PRINT 'OLD';
+C2: COMMIT;
+MC: wait until C2 ready;
+
+C1: ROLLBACK;
+MC: wait until C1 ready;
+
+C2: SELECT unique_name, action_definition FROM db_trigger WHERE unique_name = 'dba.t1' ORDER BY 1,2;
+C2: SELECT name, owner.name FROM db_trigger WHERE name = 't1' ORDER BY 1,2;
+MC: wait until C2 ready;
+
+/* recreate under the same name -> without an orphan, exactly one trigger should exist */
+C2: CREATE TRIGGER t1 AFTER INSERT ON tbl EXECUTE PRINT 'NEW';
+C2: COMMIT;
+MC: wait until C2 ready;
+
+C2: SELECT unique_name, action_definition FROM db_trigger WHERE unique_name = 'dba.t1' ORDER BY 1,2;
+C2: SELECT name, owner.name FROM db_trigger WHERE name = 't1' ORDER BY 1,2;
+C2: INSERT INTO tbl VALUES (2);
+C2: COMMIT;
+MC: wait until C2 ready;
+
+/* cleanup, plus confirm the drop itself leaves no leftover row */
+C2: SET SYSTEM PARAMETERS 'lock_timeout=DEFAULT';
+C2: DROP TRIGGER t1;
+C2: COMMIT;
+C2: SELECT unique_name, action_definition FROM db_trigger WHERE unique_name = 'dba.t1' ORDER BY 1,2;
+MC: wait until C2 ready;
+
+C1: DROP TABLE IF EXISTS tbl;
+C1: COMMIT;
+MC: wait until C1 ready;
+
+C1: quit;
+C2: quit;

--- a/isolation/_01_ReadCommitted/issues/_26_2h/cbrd_27275_create_user_trigger.ctl
+++ b/isolation/_01_ReadCommitted/issues/_26_2h/cbrd_27275_create_user_trigger.ctl
@@ -1,0 +1,55 @@
+/*
+Test Case: related to CBRD-27275
+Priority: 1
+
+Test Plan:
+The fix makes CREATE TRIGGER take a savepoint and roll back to it on failure, regardless of
+isolation level. This file covers the user-trigger CREATE (AFTER COMMIT) under READ COMMITTED --
+step 3 (register_user_trigger for a non-table trigger) locks a db_root row instead of a class,
+so this exercises a different lock path than the table-trigger case. See the other
+cbrd_27275_*.ctl files under isolation/_01_ReadCommitted, _02_RepeatableRead, and
+_07_serializable/issues/_26_2h for the other scenarios (CREATE table trigger, DROP, RENAME) and
+isolation levels.
+
+Test Point:
+1) A failed user-trigger CREATE leaves no row behind in db_trigger, and neither does the
+   holder's own uncommitted CREATE once it is rolled back.
+
+NUM_CLIENTS = 2
+C1: hold the write lock a user-trigger CREATE takes, without commit
+C2: force a user-trigger CREATE failure under lock_timeout=3 -> commit without rollback
+*/
+
+MC: setup NUM_CLIENTS = 2;
+
+C1: login as 'dba';
+C1: set transaction lock timeout INFINITE;
+C1: set transaction isolation level read committed;
+C2: login as 'dba';
+C2: set transaction lock timeout INFINITE;
+C2: set transaction isolation level read committed;
+C2: commit;
+
+/* C1 holds the write lock a user-trigger CREATE takes, via an uncommitted CREATE */
+C1: CREATE TRIGGER user_trg_holder AFTER COMMIT EXECUTE PRINT 'HOLDER';
+MC: wait until C1 ready;
+
+/* C2 fails registering another user trigger under the same owner and commits the failure */
+C2: SET SYSTEM PARAMETERS 'lock_timeout=3';
+C2: CREATE TRIGGER user_trg_victim AFTER COMMIT EXECUTE PRINT 'VICTIM';
+C2: COMMIT;
+MC: wait until C2 ready;
+
+/* C1 rolls back, so user_trg_holder is never committed either */
+C1: ROLLBACK;
+MC: wait until C1 ready;
+
+/* neither name should have an orphan row */
+C2: SELECT unique_name, action_definition FROM db_trigger WHERE unique_name IN ('dba.user_trg_holder', 'dba.user_trg_victim') ORDER BY 1,2;
+MC: wait until C2 ready;
+
+C2: SET SYSTEM PARAMETERS 'lock_timeout=DEFAULT';
+MC: wait until C2 ready;
+
+C1: quit;
+C2: quit;

--- a/isolation/_01_ReadCommitted/issues/_26_2h/cbrd_27275_drop_trigger.ctl
+++ b/isolation/_01_ReadCommitted/issues/_26_2h/cbrd_27275_drop_trigger.ctl
@@ -1,0 +1,68 @@
+/*
+Test Case: related to CBRD-27275
+Priority: 1
+
+Test Plan:
+The fix makes DROP TRIGGER take a savepoint and roll back to it on failure, regardless of
+isolation level. This file covers DROP TRIGGER under READ COMMITTED - see the other
+cbrd_27275_*.ctl files under isolation/_01_ReadCommitted, _02_RepeatableRead, and
+_07_serializable/issues/_26_2h for the other scenarios (CREATE table/user trigger, RENAME) and
+isolation levels.
+
+Test Point:
+1) A failed DROP TRIGGER leaves the trigger fully intact (not partially removed) and functional.
+
+NUM_CLIENTS = 2
+C1: hold X-lock on tbl without commit
+C2: force a DROP TRIGGER failure under lock_timeout=3 -> commit without rollback
+*/
+
+MC: setup NUM_CLIENTS = 2;
+
+C1: login as 'dba';
+C1: set transaction lock timeout INFINITE;
+C1: set transaction isolation level read committed;
+C2: login as 'dba';
+C2: set transaction lock timeout INFINITE;
+C2: set transaction isolation level read committed;
+C2: commit;
+
+/* preparation: the trigger is created successfully up front */
+C1: DROP TABLE IF EXISTS tbl;
+C1: CREATE TABLE tbl(a INT);
+C1: CREATE TRIGGER t1 AFTER INSERT ON tbl EXECUTE PRINT 'ORIG';
+C1: COMMIT;
+MC: wait until C1 ready;
+
+/* test case: check whether a failed DROP TRIGGER leaves the trigger partially removed */
+C1: INSERT INTO tbl VALUES (1);
+MC: wait until C1 ready;
+
+C2: SET SYSTEM PARAMETERS 'lock_timeout=3';
+C2: DROP TRIGGER t1;
+C2: COMMIT;
+MC: wait until C2 ready;
+
+/* commit (not rollback) here on purpose - releasing the lock via commit works too */
+C1: COMMIT;
+MC: wait until C1 ready;
+
+/* the trigger must still be fully intact: exactly one row, still resolvable by name */
+C2: SELECT unique_name, action_definition FROM db_trigger WHERE unique_name = 'dba.t1' ORDER BY 1,2;
+C2: SELECT name, owner.name FROM db_trigger WHERE name = 't1' ORDER BY 1,2;
+C2: INSERT INTO tbl VALUES (2);
+C2: COMMIT;
+MC: wait until C2 ready;
+
+/* cleanup: DROP TRIGGER must succeed now that no other session holds the lock */
+C2: SET SYSTEM PARAMETERS 'lock_timeout=DEFAULT';
+C2: DROP TRIGGER t1;
+C2: COMMIT;
+MC: wait until C2 ready;
+
+C1: DROP TABLE IF EXISTS tbl;
+C1: COMMIT;
+MC: wait until C1 ready;
+
+C1: quit;
+C2: quit;

--- a/isolation/_01_ReadCommitted/issues/_26_2h/cbrd_27275_rename_trigger.ctl
+++ b/isolation/_01_ReadCommitted/issues/_26_2h/cbrd_27275_rename_trigger.ctl
@@ -1,0 +1,68 @@
+/*
+Test Case: related to CBRD-27275
+Priority: 1
+
+Test Plan:
+The fix makes RENAME TRIGGER take a savepoint and roll back to it on failure, regardless of
+isolation level. This file covers RENAME TRIGGER under READ COMMITTED - see the other
+cbrd_27275_*.ctl files under isolation/_01_ReadCommitted, _02_RepeatableRead, and
+_07_serializable/issues/_26_2h for the other scenarios (CREATE table/user trigger, DROP) and
+isolation levels.
+
+Test Point:
+1) A failed RENAME TRIGGER leaves the trigger under its original name only (no half-renamed or
+   duplicate state), still functional.
+
+NUM_CLIENTS = 2
+C1: hold X-lock on tbl without commit
+C2: force a RENAME TRIGGER failure under lock_timeout=3 -> commit without rollback
+*/
+
+MC: setup NUM_CLIENTS = 2;
+
+C1: login as 'dba';
+C1: set transaction lock timeout INFINITE;
+C1: set transaction isolation level read committed;
+C2: login as 'dba';
+C2: set transaction lock timeout INFINITE;
+C2: set transaction isolation level read committed;
+C2: commit;
+
+/* preparation: trigger created successfully up front */
+C1: DROP TABLE IF EXISTS tbl;
+C1: CREATE TABLE tbl(a INT);
+C1: CREATE TRIGGER t1 AFTER INSERT ON tbl EXECUTE PRINT 'ORIG';
+C1: COMMIT;
+MC: wait until C1 ready;
+
+/* test case: check whether a failed RENAME TRIGGER leaves a half-renamed/duplicate state */
+C1: INSERT INTO tbl VALUES (1);
+MC: wait until C1 ready;
+
+C2: SET SYSTEM PARAMETERS 'lock_timeout=3';
+C2: RENAME TRIGGER t1 AS t1_renamed;
+C2: COMMIT;
+MC: wait until C2 ready;
+
+C1: ROLLBACK;
+MC: wait until C1 ready;
+
+/* only the original name must exist - no leftover row under the new name */
+C2: SELECT unique_name, action_definition FROM db_trigger WHERE unique_name IN ('dba.t1', 'dba.t1_renamed') ORDER BY 1,2;
+C2: SELECT name, owner.name FROM db_trigger WHERE name IN ('t1', 't1_renamed') ORDER BY 1,2;
+C2: INSERT INTO tbl VALUES (2);
+C2: COMMIT;
+MC: wait until C2 ready;
+
+/* cleanup */
+C2: SET SYSTEM PARAMETERS 'lock_timeout=DEFAULT';
+C2: DROP TRIGGER t1;
+C2: COMMIT;
+MC: wait until C2 ready;
+
+C1: DROP TABLE IF EXISTS tbl;
+C1: COMMIT;
+MC: wait until C1 ready;
+
+C1: quit;
+C2: quit;

--- a/isolation/_02_RepeatableRead/issues/_26_2h/answer/cbrd_27275_create_trigger.answer
+++ b/isolation/_02_RepeatableRead/issues/_26_2h/answer/cbrd_27275_create_trigger.answer
@@ -1,0 +1,27 @@
+| 1 row affected
+| ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on  SCH_M_LOCK lock on class dba.tbl. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
+|    on statement number: 6
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+| 0 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+| 0 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    'dba.t1'    'NEW'  
+| 1 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    't1'    'DBA'  
+| 1 row selected
+| NEW
+| 1 row affected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+| 0 row selected

--- a/isolation/_02_RepeatableRead/issues/_26_2h/answer/cbrd_27275_create_user_trigger.answer
+++ b/isolation/_02_RepeatableRead/issues/_26_2h/answer/cbrd_27275_create_user_trigger.answer
@@ -1,0 +1,6 @@
+| ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on      S_LOCK lock on instance ?|?|? of class db_root. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
+|    on statement number: 6
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+| 0 row selected

--- a/isolation/_02_RepeatableRead/issues/_26_2h/answer/cbrd_27275_drop_trigger.answer
+++ b/isolation/_02_RepeatableRead/issues/_26_2h/answer/cbrd_27275_drop_trigger.answer
@@ -1,0 +1,16 @@
+| ORIG
+| 1 row affected
+| ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on  SCH_M_LOCK lock on class dba.tbl. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
+|    on statement number: 6
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    'dba.t1'    'ORIG'  
+| 1 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    't1'    'DBA'  
+| 1 row selected
+| ORIG
+| 1 row affected

--- a/isolation/_02_RepeatableRead/issues/_26_2h/answer/cbrd_27275_rename_trigger.answer
+++ b/isolation/_02_RepeatableRead/issues/_26_2h/answer/cbrd_27275_rename_trigger.answer
@@ -1,0 +1,16 @@
+| ORIG
+| 1 row affected
+| ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on      X_LOCK lock on instance ?|?|? of class db_trigger. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
+|    on statement number: 6
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    'dba.t1'    'ORIG'  
+| 1 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    't1'    'DBA'  
+| 1 row selected
+| ORIG
+| 1 row affected

--- a/isolation/_02_RepeatableRead/issues/_26_2h/cbrd_27275_create_trigger.ctl
+++ b/isolation/_02_RepeatableRead/issues/_26_2h/cbrd_27275_create_trigger.ctl
@@ -1,0 +1,79 @@
+/*
+Test Case: related to CBRD-27275
+Priority: 1
+
+Test Plan:
+The fix makes CREATE TRIGGER take a savepoint and roll back to it on failure, regardless of
+isolation level. This file covers the table-trigger CREATE under REPEATABLE READ - see the other
+cbrd_27275_*.ctl files under isolation/_01_ReadCommitted, _02_RepeatableRead, and
+_07_serializable/issues/_26_2h for the other scenarios (DROP/RENAME/user trigger) and isolation
+levels.
+
+Test Point:
+1) A failed CREATE TRIGGER leaves no row behind in db_trigger (raw table, no
+   separate view on this branch).
+2) Recreating a trigger under the same name after a failed CREATE leaves exactly one trigger,
+   and only its action fires on INSERT.
+3) The final DROP TRIGGER leaves no row behind either.
+
+NUM_CLIENTS = 2
+C1: hold X-lock on tbl without commit
+C2: force a CREATE TRIGGER failure under lock_timeout=3 -> commit without rollback
+*/
+
+MC: setup NUM_CLIENTS = 2;
+
+C1: login as 'dba';
+C1: set transaction lock timeout INFINITE;
+C1: set transaction isolation level repeatable read;
+C2: login as 'dba';
+C2: set transaction lock timeout INFINITE;
+C2: set transaction isolation level repeatable read;
+C2: commit;
+
+/* preparation */
+C1: DROP TABLE IF EXISTS tbl;
+C1: CREATE TABLE tbl(a INT);
+C1: COMMIT;
+MC: wait until C1 ready;
+
+/* test case: check whether a failed CREATE TRIGGER leaves an orphan row in db_trigger */
+C1: INSERT INTO tbl VALUES (1);
+MC: wait until C1 ready;
+
+C2: SET SYSTEM PARAMETERS 'lock_timeout=3';
+C2: CREATE TRIGGER t1 AFTER INSERT ON tbl EXECUTE PRINT 'OLD';
+C2: COMMIT;
+MC: wait until C2 ready;
+
+C1: ROLLBACK;
+MC: wait until C1 ready;
+
+C2: SELECT unique_name, action_definition FROM db_trigger WHERE unique_name = 'dba.t1' ORDER BY 1,2;
+C2: SELECT name, owner.name FROM db_trigger WHERE name = 't1' ORDER BY 1,2;
+MC: wait until C2 ready;
+
+/* recreate under the same name -> without an orphan, exactly one trigger should exist */
+C2: CREATE TRIGGER t1 AFTER INSERT ON tbl EXECUTE PRINT 'NEW';
+C2: COMMIT;
+MC: wait until C2 ready;
+
+C2: SELECT unique_name, action_definition FROM db_trigger WHERE unique_name = 'dba.t1' ORDER BY 1,2;
+C2: SELECT name, owner.name FROM db_trigger WHERE name = 't1' ORDER BY 1,2;
+C2: INSERT INTO tbl VALUES (2);
+C2: COMMIT;
+MC: wait until C2 ready;
+
+/* cleanup, plus confirm the drop itself leaves no leftover row */
+C2: SET SYSTEM PARAMETERS 'lock_timeout=DEFAULT';
+C2: DROP TRIGGER t1;
+C2: COMMIT;
+C2: SELECT unique_name, action_definition FROM db_trigger WHERE unique_name = 'dba.t1' ORDER BY 1,2;
+MC: wait until C2 ready;
+
+C1: DROP TABLE IF EXISTS tbl;
+C1: COMMIT;
+MC: wait until C1 ready;
+
+C1: quit;
+C2: quit;

--- a/isolation/_02_RepeatableRead/issues/_26_2h/cbrd_27275_create_user_trigger.ctl
+++ b/isolation/_02_RepeatableRead/issues/_26_2h/cbrd_27275_create_user_trigger.ctl
@@ -1,0 +1,55 @@
+/*
+Test Case: related to CBRD-27275
+Priority: 1
+
+Test Plan:
+The fix makes CREATE TRIGGER take a savepoint and roll back to it on failure, regardless of
+isolation level. This file covers the user-trigger CREATE (AFTER COMMIT) under REPEATABLE READ --
+step 3 (register_user_trigger for a non-table trigger) locks a db_root row instead of a class,
+so this exercises a different lock path than the table-trigger case. See the other
+cbrd_27275_*.ctl files under isolation/_01_ReadCommitted, _02_RepeatableRead, and
+_07_serializable/issues/_26_2h for the other scenarios (CREATE table trigger, DROP, RENAME) and
+isolation levels.
+
+Test Point:
+1) A failed user-trigger CREATE leaves no row behind in db_trigger, and neither does the
+   holder's own uncommitted CREATE once it is rolled back.
+
+NUM_CLIENTS = 2
+C1: hold the write lock a user-trigger CREATE takes, without commit
+C2: force a user-trigger CREATE failure under lock_timeout=3 -> commit without rollback
+*/
+
+MC: setup NUM_CLIENTS = 2;
+
+C1: login as 'dba';
+C1: set transaction lock timeout INFINITE;
+C1: set transaction isolation level repeatable read;
+C2: login as 'dba';
+C2: set transaction lock timeout INFINITE;
+C2: set transaction isolation level repeatable read;
+C2: commit;
+
+/* C1 holds the write lock a user-trigger CREATE takes, via an uncommitted CREATE */
+C1: CREATE TRIGGER user_trg_holder AFTER COMMIT EXECUTE PRINT 'HOLDER';
+MC: wait until C1 ready;
+
+/* C2 fails registering another user trigger under the same owner and commits the failure */
+C2: SET SYSTEM PARAMETERS 'lock_timeout=3';
+C2: CREATE TRIGGER user_trg_victim AFTER COMMIT EXECUTE PRINT 'VICTIM';
+C2: COMMIT;
+MC: wait until C2 ready;
+
+/* C1 rolls back, so user_trg_holder is never committed either */
+C1: ROLLBACK;
+MC: wait until C1 ready;
+
+/* neither name should have an orphan row */
+C2: SELECT unique_name, action_definition FROM db_trigger WHERE unique_name IN ('dba.user_trg_holder', 'dba.user_trg_victim') ORDER BY 1,2;
+MC: wait until C2 ready;
+
+C2: SET SYSTEM PARAMETERS 'lock_timeout=DEFAULT';
+MC: wait until C2 ready;
+
+C1: quit;
+C2: quit;

--- a/isolation/_02_RepeatableRead/issues/_26_2h/cbrd_27275_drop_trigger.ctl
+++ b/isolation/_02_RepeatableRead/issues/_26_2h/cbrd_27275_drop_trigger.ctl
@@ -1,0 +1,68 @@
+/*
+Test Case: related to CBRD-27275
+Priority: 1
+
+Test Plan:
+The fix makes DROP TRIGGER take a savepoint and roll back to it on failure, regardless of
+isolation level. This file covers DROP TRIGGER under REPEATABLE READ - see the other
+cbrd_27275_*.ctl files under isolation/_01_ReadCommitted, _02_RepeatableRead, and
+_07_serializable/issues/_26_2h for the other scenarios (CREATE table/user trigger, RENAME) and
+isolation levels.
+
+Test Point:
+1) A failed DROP TRIGGER leaves the trigger fully intact (not partially removed) and functional.
+
+NUM_CLIENTS = 2
+C1: hold X-lock on tbl without commit
+C2: force a DROP TRIGGER failure under lock_timeout=3 -> commit without rollback
+*/
+
+MC: setup NUM_CLIENTS = 2;
+
+C1: login as 'dba';
+C1: set transaction lock timeout INFINITE;
+C1: set transaction isolation level repeatable read;
+C2: login as 'dba';
+C2: set transaction lock timeout INFINITE;
+C2: set transaction isolation level repeatable read;
+C2: commit;
+
+/* preparation: the trigger is created successfully up front */
+C1: DROP TABLE IF EXISTS tbl;
+C1: CREATE TABLE tbl(a INT);
+C1: CREATE TRIGGER t1 AFTER INSERT ON tbl EXECUTE PRINT 'ORIG';
+C1: COMMIT;
+MC: wait until C1 ready;
+
+/* test case: check whether a failed DROP TRIGGER leaves the trigger partially removed */
+C1: INSERT INTO tbl VALUES (1);
+MC: wait until C1 ready;
+
+C2: SET SYSTEM PARAMETERS 'lock_timeout=3';
+C2: DROP TRIGGER t1;
+C2: COMMIT;
+MC: wait until C2 ready;
+
+/* commit (not rollback) here on purpose - releasing the lock via commit works too */
+C1: COMMIT;
+MC: wait until C1 ready;
+
+/* the trigger must still be fully intact: exactly one row, still resolvable by name */
+C2: SELECT unique_name, action_definition FROM db_trigger WHERE unique_name = 'dba.t1' ORDER BY 1,2;
+C2: SELECT name, owner.name FROM db_trigger WHERE name = 't1' ORDER BY 1,2;
+C2: INSERT INTO tbl VALUES (2);
+C2: COMMIT;
+MC: wait until C2 ready;
+
+/* cleanup: DROP TRIGGER must succeed now that no other session holds the lock */
+C2: SET SYSTEM PARAMETERS 'lock_timeout=DEFAULT';
+C2: DROP TRIGGER t1;
+C2: COMMIT;
+MC: wait until C2 ready;
+
+C1: DROP TABLE IF EXISTS tbl;
+C1: COMMIT;
+MC: wait until C1 ready;
+
+C1: quit;
+C2: quit;

--- a/isolation/_02_RepeatableRead/issues/_26_2h/cbrd_27275_rename_trigger.ctl
+++ b/isolation/_02_RepeatableRead/issues/_26_2h/cbrd_27275_rename_trigger.ctl
@@ -1,0 +1,68 @@
+/*
+Test Case: related to CBRD-27275
+Priority: 1
+
+Test Plan:
+The fix makes RENAME TRIGGER take a savepoint and roll back to it on failure, regardless of
+isolation level. This file covers RENAME TRIGGER under REPEATABLE READ - see the other
+cbrd_27275_*.ctl files under isolation/_01_ReadCommitted, _02_RepeatableRead, and
+_07_serializable/issues/_26_2h for the other scenarios (CREATE table/user trigger, DROP) and
+isolation levels.
+
+Test Point:
+1) A failed RENAME TRIGGER leaves the trigger under its original name only (no half-renamed or
+   duplicate state), still functional.
+
+NUM_CLIENTS = 2
+C1: hold X-lock on tbl without commit
+C2: force a RENAME TRIGGER failure under lock_timeout=3 -> commit without rollback
+*/
+
+MC: setup NUM_CLIENTS = 2;
+
+C1: login as 'dba';
+C1: set transaction lock timeout INFINITE;
+C1: set transaction isolation level repeatable read;
+C2: login as 'dba';
+C2: set transaction lock timeout INFINITE;
+C2: set transaction isolation level repeatable read;
+C2: commit;
+
+/* preparation: trigger created successfully up front */
+C1: DROP TABLE IF EXISTS tbl;
+C1: CREATE TABLE tbl(a INT);
+C1: CREATE TRIGGER t1 AFTER INSERT ON tbl EXECUTE PRINT 'ORIG';
+C1: COMMIT;
+MC: wait until C1 ready;
+
+/* test case: check whether a failed RENAME TRIGGER leaves a half-renamed/duplicate state */
+C1: INSERT INTO tbl VALUES (1);
+MC: wait until C1 ready;
+
+C2: SET SYSTEM PARAMETERS 'lock_timeout=3';
+C2: RENAME TRIGGER t1 AS t1_renamed;
+C2: COMMIT;
+MC: wait until C2 ready;
+
+C1: ROLLBACK;
+MC: wait until C1 ready;
+
+/* only the original name must exist - no leftover row under the new name */
+C2: SELECT unique_name, action_definition FROM db_trigger WHERE unique_name IN ('dba.t1', 'dba.t1_renamed') ORDER BY 1,2;
+C2: SELECT name, owner.name FROM db_trigger WHERE name IN ('t1', 't1_renamed') ORDER BY 1,2;
+C2: INSERT INTO tbl VALUES (2);
+C2: COMMIT;
+MC: wait until C2 ready;
+
+/* cleanup */
+C2: SET SYSTEM PARAMETERS 'lock_timeout=DEFAULT';
+C2: DROP TRIGGER t1;
+C2: COMMIT;
+MC: wait until C2 ready;
+
+C1: DROP TABLE IF EXISTS tbl;
+C1: COMMIT;
+MC: wait until C1 ready;
+
+C1: quit;
+C2: quit;

--- a/isolation/_07_serializable/issues/_26_2h/answer/cbrd_27275_create_trigger.answer
+++ b/isolation/_07_serializable/issues/_26_2h/answer/cbrd_27275_create_trigger.answer
@@ -1,0 +1,27 @@
+| 1 row affected
+| ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on  SCH_M_LOCK lock on class dba.tbl. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
+|    on statement number: 6
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+| 0 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+| 0 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    'dba.t1'    'NEW'  
+| 1 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    't1'    'DBA'  
+| 1 row selected
+| NEW
+| 1 row affected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+| 0 row selected

--- a/isolation/_07_serializable/issues/_26_2h/answer/cbrd_27275_create_user_trigger.answer
+++ b/isolation/_07_serializable/issues/_26_2h/answer/cbrd_27275_create_user_trigger.answer
@@ -1,0 +1,6 @@
+| ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on      S_LOCK lock on instance ?|?|? of class db_root. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
+|    on statement number: 6
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+| 0 row selected

--- a/isolation/_07_serializable/issues/_26_2h/answer/cbrd_27275_drop_trigger.answer
+++ b/isolation/_07_serializable/issues/_26_2h/answer/cbrd_27275_drop_trigger.answer
@@ -1,0 +1,16 @@
+| ORIG
+| 1 row affected
+| ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on  SCH_M_LOCK lock on class dba.tbl. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
+|    on statement number: 6
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    'dba.t1'    'ORIG'  
+| 1 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    't1'    'DBA'  
+| 1 row selected
+| ORIG
+| 1 row affected

--- a/isolation/_07_serializable/issues/_26_2h/answer/cbrd_27275_rename_trigger.answer
+++ b/isolation/_07_serializable/issues/_26_2h/answer/cbrd_27275_rename_trigger.answer
@@ -1,0 +1,16 @@
+| ORIG
+| 1 row affected
+| ERROR RETURNED: Your transaction (index ?, PUBLIC@localhost|?) timed out waiting on      X_LOCK lock on instance ?|?|? of class db_trigger. You are waiting for user(s) PUBLIC@localhost|qacsql(?) to finish. 
+|    on statement number: 6
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    'dba.t1'    'ORIG'  
+| 1 row selected
+| =================   Q U E R Y   R E S U L T S   =================
+| 
+| 
+|    't1'    'DBA'  
+| 1 row selected
+| ORIG
+| 1 row affected

--- a/isolation/_07_serializable/issues/_26_2h/cbrd_27275_create_trigger.ctl
+++ b/isolation/_07_serializable/issues/_26_2h/cbrd_27275_create_trigger.ctl
@@ -1,0 +1,79 @@
+/*
+Test Case: related to CBRD-27275
+Priority: 1
+
+Test Plan:
+The fix makes CREATE TRIGGER take a savepoint and roll back to it on failure, regardless of
+isolation level. This file covers the table-trigger CREATE under SERIALIZABLE - see the other
+cbrd_27275_*.ctl files under isolation/_01_ReadCommitted, _02_RepeatableRead, and
+_07_serializable/issues/_26_2h for the other scenarios (DROP/RENAME/user trigger) and isolation
+levels.
+
+Test Point:
+1) A failed CREATE TRIGGER leaves no row behind in db_trigger (raw table, no
+   separate view on this branch).
+2) Recreating a trigger under the same name after a failed CREATE leaves exactly one trigger,
+   and only its action fires on INSERT.
+3) The final DROP TRIGGER leaves no row behind either.
+
+NUM_CLIENTS = 2
+C1: hold X-lock on tbl without commit
+C2: force a CREATE TRIGGER failure under lock_timeout=3 -> commit without rollback
+*/
+
+MC: setup NUM_CLIENTS = 2;
+
+C1: login as 'dba';
+C1: set transaction lock timeout INFINITE;
+C1: set transaction isolation level serializable;
+C2: login as 'dba';
+C2: set transaction lock timeout INFINITE;
+C2: set transaction isolation level serializable;
+C2: commit;
+
+/* preparation */
+C1: DROP TABLE IF EXISTS tbl;
+C1: CREATE TABLE tbl(a INT);
+C1: COMMIT;
+MC: wait until C1 ready;
+
+/* test case: check whether a failed CREATE TRIGGER leaves an orphan row in db_trigger */
+C1: INSERT INTO tbl VALUES (1);
+MC: wait until C1 ready;
+
+C2: SET SYSTEM PARAMETERS 'lock_timeout=3';
+C2: CREATE TRIGGER t1 AFTER INSERT ON tbl EXECUTE PRINT 'OLD';
+C2: COMMIT;
+MC: wait until C2 ready;
+
+C1: ROLLBACK;
+MC: wait until C1 ready;
+
+C2: SELECT unique_name, action_definition FROM db_trigger WHERE unique_name = 'dba.t1' ORDER BY 1,2;
+C2: SELECT name, owner.name FROM db_trigger WHERE name = 't1' ORDER BY 1,2;
+MC: wait until C2 ready;
+
+/* recreate under the same name -> without an orphan, exactly one trigger should exist */
+C2: CREATE TRIGGER t1 AFTER INSERT ON tbl EXECUTE PRINT 'NEW';
+C2: COMMIT;
+MC: wait until C2 ready;
+
+C2: SELECT unique_name, action_definition FROM db_trigger WHERE unique_name = 'dba.t1' ORDER BY 1,2;
+C2: SELECT name, owner.name FROM db_trigger WHERE name = 't1' ORDER BY 1,2;
+C2: INSERT INTO tbl VALUES (2);
+C2: COMMIT;
+MC: wait until C2 ready;
+
+/* cleanup, plus confirm the drop itself leaves no leftover row */
+C2: SET SYSTEM PARAMETERS 'lock_timeout=DEFAULT';
+C2: DROP TRIGGER t1;
+C2: COMMIT;
+C2: SELECT unique_name, action_definition FROM db_trigger WHERE unique_name = 'dba.t1' ORDER BY 1,2;
+MC: wait until C2 ready;
+
+C1: DROP TABLE IF EXISTS tbl;
+C1: COMMIT;
+MC: wait until C1 ready;
+
+C1: quit;
+C2: quit;

--- a/isolation/_07_serializable/issues/_26_2h/cbrd_27275_create_user_trigger.ctl
+++ b/isolation/_07_serializable/issues/_26_2h/cbrd_27275_create_user_trigger.ctl
@@ -1,0 +1,55 @@
+/*
+Test Case: related to CBRD-27275
+Priority: 1
+
+Test Plan:
+The fix makes CREATE TRIGGER take a savepoint and roll back to it on failure, regardless of
+isolation level. This file covers the user-trigger CREATE (AFTER COMMIT) under SERIALIZABLE --
+step 3 (register_user_trigger for a non-table trigger) locks a db_root row instead of a class,
+so this exercises a different lock path than the table-trigger case. See the other
+cbrd_27275_*.ctl files under isolation/_01_ReadCommitted, _02_RepeatableRead, and
+_07_serializable/issues/_26_2h for the other scenarios (CREATE table trigger, DROP, RENAME) and
+isolation levels.
+
+Test Point:
+1) A failed user-trigger CREATE leaves no row behind in db_trigger, and neither does the
+   holder's own uncommitted CREATE once it is rolled back.
+
+NUM_CLIENTS = 2
+C1: hold the write lock a user-trigger CREATE takes, without commit
+C2: force a user-trigger CREATE failure under lock_timeout=3 -> commit without rollback
+*/
+
+MC: setup NUM_CLIENTS = 2;
+
+C1: login as 'dba';
+C1: set transaction lock timeout INFINITE;
+C1: set transaction isolation level serializable;
+C2: login as 'dba';
+C2: set transaction lock timeout INFINITE;
+C2: set transaction isolation level serializable;
+C2: commit;
+
+/* C1 holds the write lock a user-trigger CREATE takes, via an uncommitted CREATE */
+C1: CREATE TRIGGER user_trg_holder AFTER COMMIT EXECUTE PRINT 'HOLDER';
+MC: wait until C1 ready;
+
+/* C2 fails registering another user trigger under the same owner and commits the failure */
+C2: SET SYSTEM PARAMETERS 'lock_timeout=3';
+C2: CREATE TRIGGER user_trg_victim AFTER COMMIT EXECUTE PRINT 'VICTIM';
+C2: COMMIT;
+MC: wait until C2 ready;
+
+/* C1 rolls back, so user_trg_holder is never committed either */
+C1: ROLLBACK;
+MC: wait until C1 ready;
+
+/* neither name should have an orphan row */
+C2: SELECT unique_name, action_definition FROM db_trigger WHERE unique_name IN ('dba.user_trg_holder', 'dba.user_trg_victim') ORDER BY 1,2;
+MC: wait until C2 ready;
+
+C2: SET SYSTEM PARAMETERS 'lock_timeout=DEFAULT';
+MC: wait until C2 ready;
+
+C1: quit;
+C2: quit;

--- a/isolation/_07_serializable/issues/_26_2h/cbrd_27275_drop_trigger.ctl
+++ b/isolation/_07_serializable/issues/_26_2h/cbrd_27275_drop_trigger.ctl
@@ -1,0 +1,68 @@
+/*
+Test Case: related to CBRD-27275
+Priority: 1
+
+Test Plan:
+The fix makes DROP TRIGGER take a savepoint and roll back to it on failure, regardless of
+isolation level. This file covers DROP TRIGGER under SERIALIZABLE - see the other
+cbrd_27275_*.ctl files under isolation/_01_ReadCommitted, _02_RepeatableRead, and
+_07_serializable/issues/_26_2h for the other scenarios (CREATE table/user trigger, RENAME) and
+isolation levels.
+
+Test Point:
+1) A failed DROP TRIGGER leaves the trigger fully intact (not partially removed) and functional.
+
+NUM_CLIENTS = 2
+C1: hold X-lock on tbl without commit
+C2: force a DROP TRIGGER failure under lock_timeout=3 -> commit without rollback
+*/
+
+MC: setup NUM_CLIENTS = 2;
+
+C1: login as 'dba';
+C1: set transaction lock timeout INFINITE;
+C1: set transaction isolation level serializable;
+C2: login as 'dba';
+C2: set transaction lock timeout INFINITE;
+C2: set transaction isolation level serializable;
+C2: commit;
+
+/* preparation: the trigger is created successfully up front */
+C1: DROP TABLE IF EXISTS tbl;
+C1: CREATE TABLE tbl(a INT);
+C1: CREATE TRIGGER t1 AFTER INSERT ON tbl EXECUTE PRINT 'ORIG';
+C1: COMMIT;
+MC: wait until C1 ready;
+
+/* test case: check whether a failed DROP TRIGGER leaves the trigger partially removed */
+C1: INSERT INTO tbl VALUES (1);
+MC: wait until C1 ready;
+
+C2: SET SYSTEM PARAMETERS 'lock_timeout=3';
+C2: DROP TRIGGER t1;
+C2: COMMIT;
+MC: wait until C2 ready;
+
+/* commit (not rollback) here on purpose - releasing the lock via commit works too */
+C1: COMMIT;
+MC: wait until C1 ready;
+
+/* the trigger must still be fully intact: exactly one row, still resolvable by name */
+C2: SELECT unique_name, action_definition FROM db_trigger WHERE unique_name = 'dba.t1' ORDER BY 1,2;
+C2: SELECT name, owner.name FROM db_trigger WHERE name = 't1' ORDER BY 1,2;
+C2: INSERT INTO tbl VALUES (2);
+C2: COMMIT;
+MC: wait until C2 ready;
+
+/* cleanup: DROP TRIGGER must succeed now that no other session holds the lock */
+C2: SET SYSTEM PARAMETERS 'lock_timeout=DEFAULT';
+C2: DROP TRIGGER t1;
+C2: COMMIT;
+MC: wait until C2 ready;
+
+C1: DROP TABLE IF EXISTS tbl;
+C1: COMMIT;
+MC: wait until C1 ready;
+
+C1: quit;
+C2: quit;

--- a/isolation/_07_serializable/issues/_26_2h/cbrd_27275_rename_trigger.ctl
+++ b/isolation/_07_serializable/issues/_26_2h/cbrd_27275_rename_trigger.ctl
@@ -1,0 +1,68 @@
+/*
+Test Case: related to CBRD-27275
+Priority: 1
+
+Test Plan:
+The fix makes RENAME TRIGGER take a savepoint and roll back to it on failure, regardless of
+isolation level. This file covers RENAME TRIGGER under SERIALIZABLE - see the other
+cbrd_27275_*.ctl files under isolation/_01_ReadCommitted, _02_RepeatableRead, and
+_07_serializable/issues/_26_2h for the other scenarios (CREATE table/user trigger, DROP) and
+isolation levels.
+
+Test Point:
+1) A failed RENAME TRIGGER leaves the trigger under its original name only (no half-renamed or
+   duplicate state), still functional.
+
+NUM_CLIENTS = 2
+C1: hold X-lock on tbl without commit
+C2: force a RENAME TRIGGER failure under lock_timeout=3 -> commit without rollback
+*/
+
+MC: setup NUM_CLIENTS = 2;
+
+C1: login as 'dba';
+C1: set transaction lock timeout INFINITE;
+C1: set transaction isolation level serializable;
+C2: login as 'dba';
+C2: set transaction lock timeout INFINITE;
+C2: set transaction isolation level serializable;
+C2: commit;
+
+/* preparation: trigger created successfully up front */
+C1: DROP TABLE IF EXISTS tbl;
+C1: CREATE TABLE tbl(a INT);
+C1: CREATE TRIGGER t1 AFTER INSERT ON tbl EXECUTE PRINT 'ORIG';
+C1: COMMIT;
+MC: wait until C1 ready;
+
+/* test case: check whether a failed RENAME TRIGGER leaves a half-renamed/duplicate state */
+C1: INSERT INTO tbl VALUES (1);
+MC: wait until C1 ready;
+
+C2: SET SYSTEM PARAMETERS 'lock_timeout=3';
+C2: RENAME TRIGGER t1 AS t1_renamed;
+C2: COMMIT;
+MC: wait until C2 ready;
+
+C1: ROLLBACK;
+MC: wait until C1 ready;
+
+/* only the original name must exist - no leftover row under the new name */
+C2: SELECT unique_name, action_definition FROM db_trigger WHERE unique_name IN ('dba.t1', 'dba.t1_renamed') ORDER BY 1,2;
+C2: SELECT name, owner.name FROM db_trigger WHERE name IN ('t1', 't1_renamed') ORDER BY 1,2;
+C2: INSERT INTO tbl VALUES (2);
+C2: COMMIT;
+MC: wait until C2 ready;
+
+/* cleanup */
+C2: SET SYSTEM PARAMETERS 'lock_timeout=DEFAULT';
+C2: DROP TRIGGER t1;
+C2: COMMIT;
+MC: wait until C2 ready;
+
+C1: DROP TABLE IF EXISTS tbl;
+C1: COMMIT;
+MC: wait until C1 ready;
+
+C1: quit;
+C2: quit;


### PR DESCRIPTION
11.4 backport(#3390, 커밋 `29993b490`)를 그대로 포팅했습니다 
### Remarks

- **이 PR은 로컬 빌드로 검증하지 못했습니다.** 이 fix가 포함된 11.0 nightly 빌드가 아직 퍼블릭 아카이브에 없습니다(최신 nightly `10.2.18.9024-01b54fa`는 fix 커밋 `a59b83ef6`를 포함하지 않음, `git merge-base --is-ancestor`로 확인). 빌드가 나오는 대로 검증 후 머지 예정이며, 지금은 사전 준비 차원에서 올려둡니다.