### PR TITLE
[CBRD-25531] Add SQL testcase for analytic-function select-list pruning in non-mergeable inline views

### DIFF
--- a/sql/_13_issues/_26_2h/answers/cbrd_25531.answer
+++ b/sql/_13_issues/_26_2h/answers/cbrd_25531.answer
@@ -20,16 +20,16 @@ count(*)
 
 Query plan:
 sscan
-    class: t? node[?]
+    class: tbla node[?]
     cost:  ? card ?
 Query stmt:
-(select ? from t? t?)
+(select ? from tbla tbla)
 Query plan:
 sscan
     class: __t? node[?]
     cost:  ? card ?
 Query stmt:
-select count(*) from (select ? from t? t?) [__t?] (?)
+select count(*) from (select ? from tbla tbla) [__t?] (?)
 ===================================================
 0
 ===================================================
@@ -38,16 +38,16 @@ count(*)
 
 Query plan:
 sscan
-    class: v? node[?]
+    class: va node[?]
     cost:  ? card ?
 Query stmt:
-(select ? from t? v?)
+(select ? from tbla va)
 Query plan:
 sscan
-    class: v? node[?]
+    class: va node[?]
     cost:  ? card ?
 Query stmt:
-select count(*) from (select ? from t? v?) v? (?)
+select count(*) from (select ? from tbla va) va (?)
 ===================================================
     
 Case 2: the analytic column is referenced by the main query     
@@ -61,13 +61,13 @@ rn
 
 Query plan:
 sscan
-    class: t? node[?]
+    class: tbla node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key ()
            func[?]: row_number partition by () order by ()
 Query stmt:
-(select row_number() over () from t? t?)
+(select row_number() over () from tbla tbla)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -76,7 +76,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select [__t?].rn from (select row_number() over () as [rn] from t? t?) [__t?] (rn) order by ?
+select [__t?].rn from (select row_number() over () as [rn] from tbla tbla) [__t?] (rn) order by ?
 ===================================================
 0
 ===================================================
@@ -88,28 +88,28 @@ rn
 
 Query plan:
 sscan
-    class: v? node[?]
+    class: vb node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key ()
            func[?]: row_number partition by () order by ()
 Query stmt:
-(select row_number() over () from t? v?)
+(select row_number() over () from tbla vb)
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vb node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select v?.rn from (select row_number() over () from t? v?) v? (rn) order by ?
+select vb.rn from (select row_number() over () from tbla vb) vb (rn) order by ?
 ===================================================
     
 Case 3: the OVER-clause column is also referenced by the main query     
 
 ===================================================
-rn    c3    
+rn    colc    
 1     1     
 1     2     
 2     1     
@@ -117,13 +117,13 @@ rn    c3
 
 Query plan:
 sscan
-    class: t? node[?]
+    class: tbla node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), t?.c? from t? t?)
+(select row_number() over (partition by ?), tbla.colc from tbla tbla)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -132,11 +132,11 @@ temp(order by)
     sort:  ? asc, ? asc
     cost:  ? card ?
 Query stmt:
-select [__t?].rn, [__t?].c? from (select row_number() over (partition by ?) as [rn], t?.c? from t? t?) [__t?] (rn, c?) order by ?, ?
+select [__t?].rn, [__t?].colc from (select row_number() over (partition by ?) as [rn], tbla.colc from tbla tbla) [__t?] (rn, colc) order by ?, ?
 ===================================================
 0
 ===================================================
-rn    c3    
+rn    colc    
 1     1     
 1     2     
 2     1     
@@ -144,22 +144,22 @@ rn    c3
 
 Query plan:
 sscan
-    class: v? node[?]
+    class: vc node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), v?.c? from t? v?)
+(select row_number() over (partition by ?), vc.colc from tbla vc)
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vc node[?]
                  cost:  ? card ?
     sort:  ? asc, ? asc
     cost:  ? card ?
 Query stmt:
-select v?.rn, v?.c? from (select row_number() over (partition by ?), v?.c? from t? v?) v? (rn, c?) order by ?, ?
+select vc.rn, vc.colc from (select row_number() over (partition by ?), vc.colc from tbla vc) vc (rn, colc) order by ?, ?
 ===================================================
     
 Case 4: the OVER-clause column is referenced by ordinal, not by the main query     
@@ -173,13 +173,13 @@ rn
 
 Query plan:
 sscan
-    class: t? node[?]
+    class: tbla node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), t?.c? from t? t?)
+(select row_number() over (partition by ?), tbla.colc from tbla tbla)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -188,7 +188,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select [__t?].rn from (select row_number() over (partition by ?) as [rn], t?.c? from t? t?) [__t?] (rn) order by ?
+select [__t?].rn from (select row_number() over (partition by ?) as [rn], tbla.colc from tbla tbla) [__t?] (rn) order by ?
 ===================================================
 0
 ===================================================
@@ -200,22 +200,22 @@ rn
 
 Query plan:
 sscan
-    class: v? node[?]
+    class: vd node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), v?.c? from t? v?)
+(select row_number() over (partition by ?), vd.colc from tbla vd)
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vd node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select v?.rn from (select row_number() over (partition by ?), v?.c? from t? v?) v? (rn) order by ?
+select vd.rn from (select row_number() over (partition by ?), vd.colc from tbla vd) vd (rn) order by ?
 ===================================================
     
 Case 5: the OVER-clause column is missing from the view select list     
@@ -229,13 +229,13 @@ rn
 
 Query plan:
 sscan
-    class: t? node[?]
+    class: tbla node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?) from t? t?)
+(select row_number() over (partition by ?) from tbla tbla)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -244,7 +244,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select [__t?].rn from (select row_number() over (partition by ?) as [rn] from t? t?) [__t?] (rn) order by ?
+select [__t?].rn from (select row_number() over (partition by ?) as [rn] from tbla tbla) [__t?] (rn) order by ?
 ===================================================
 0
 ===================================================
@@ -256,22 +256,22 @@ rn
 
 Query plan:
 sscan
-    class: v? node[?]
+    class: ve node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?) from t? v?)
+(select row_number() over (partition by ?) from tbla ve)
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: ve node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select v?.rn from (select row_number() over (partition by ?) from t? v?) v? (rn) order by ?
+select ve.rn from (select row_number() over (partition by ?) from tbla ve) ve (rn) order by ?
 ===================================================
     
 Case 6: the OVER-clause column is an expression over another column     
@@ -285,13 +285,13 @@ rn
 
 Query plan:
 sscan
-    class: t? node[?]
+    class: tbla node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), nvl(t?.c?, ?) from t? t?)
+(select row_number() over (partition by ?), nvl(tbla.colc, ?) from tbla tbla)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -300,7 +300,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select [__t?].rn from (select row_number() over (partition by ?) as [rn], nvl(t?.c?, ?) as [nvl_c?] from t? t?) [__t?] (rn) order by ?
+select [__t?].rn from (select row_number() over (partition by ?) as [rn], nvl(tbla.colc, ?) as [nvl_colc] from tbla tbla) [__t?] (rn) order by ?
 ===================================================
 0
 ===================================================
@@ -312,22 +312,22 @@ rn
 
 Query plan:
 sscan
-    class: v? node[?]
+    class: vf node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), (nvl(v?.c?, ?)) from t? v?)
+(select row_number() over (partition by ?), (nvl(vf.colc, ?)) from tbla vf)
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vf node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select v?.rn from (select row_number() over (partition by ?), (nvl(v?.c?, ?)) from t? v?) v? (rn) order by ?
+select vf.rn from (select row_number() over (partition by ?), (nvl(vf.colc, ?)) from tbla vf) vf (rn) order by ?
 ===================================================
     
 Case 7: the OVER-clause column is a scalar subquery     
@@ -341,19 +341,19 @@ rn
 
 Query plan:
 sscan
-    class: t? node[?]
+    class: tbla node[?]
     cost:  ? card ?
 Query stmt:
-(select max(t?.c?) from t? t?)
+(select max(tbla.colc) from tbla tbla)
 Query plan:
 sscan
-    class: t? node[?]
+    class: tbla node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), (select max(t?.c?) from t? t?) from t? t?)
+(select row_number() over (partition by ?), (select max(tbla.colc) from tbla tbla) from tbla tbla)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -362,7 +362,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select [__t?].rn from (select row_number() over (partition by ?) as [rn], (select max(t?.c?) from t? t?) as [max_c?] from t? t?) [__t?] (rn) order by ?
+select [__t?].rn from (select row_number() over (partition by ?) as [rn], (select max(tbla.colc) from tbla tbla) as [max_colc] from tbla tbla) [__t?] (rn) order by ?
 ===================================================
 0
 ===================================================
@@ -374,28 +374,28 @@ rn
 
 Query plan:
 sscan
-    class: t? node[?]
+    class: tbla node[?]
     cost:  ? card ?
 Query stmt:
-(select max(t?.c?) from t? t?)
+(select max(tbla.colc) from tbla tbla)
 Query plan:
 sscan
-    class: v? node[?]
+    class: vg node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), (select max(t?.c?) from t? t?) from t? v?)
+(select row_number() over (partition by ?), (select max(tbla.colc) from tbla tbla) from tbla vg)
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vg node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select v?.rn from (select row_number() over (partition by ?), (select max(t?.c?) from t? t?) from t? v?) v? (rn) order by ?
+select vg.rn from (select row_number() over (partition by ?), (select max(tbla.colc) from tbla tbla) from tbla vg) vg (rn) order by ?
 ===================================================
     
 Case 8: outer ORDER BY column is also referenced by the analytic function     
@@ -410,7 +410,7 @@ rn
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: t? node[?]
+                 class: tbla node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -418,7 +418,7 @@ Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), t?.c? from t? t? order by ?)
+(select row_number() over (partition by ?), tbla.colc from tbla tbla order by ?)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -427,7 +427,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select [__t?].rn from (select row_number() over (partition by ?) as [rn], t?.c? from t? t? order by ?) [__t?] (rn, c?) order by ?
+select [__t?].rn from (select row_number() over (partition by ?) as [rn], tbla.colc from tbla tbla order by ?) [__t?] (rn, colc) order by ?
 ===================================================
 0
 ===================================================
@@ -440,7 +440,7 @@ rn
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vh node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -448,16 +448,16 @@ Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), v?.c? from t? v? order by ?)
+(select row_number() over (partition by ?), vh.colc from tbla vh order by ?)
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vh node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select v?.rn from (select row_number() over (partition by ?), v?.c? from t? v? order by ?) v? (rn) order by ?
+select vh.rn from (select row_number() over (partition by ?), vh.colc from tbla vh order by ?) vh (rn) order by ?
 ===================================================
     
 Case 9: outer ORDER BY column is not referenced by the analytic function     
@@ -472,7 +472,7 @@ rn
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: t? node[?]
+                 class: tbla node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -480,7 +480,7 @@ Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), t?.c?, t?.c? from t? t? order by ?)
+(select row_number() over (partition by ?), tbla.cola, tbla.colc from tbla tbla order by ?)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -489,7 +489,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select [__t?].rn from (select row_number() over (partition by ?) as [rn], t?.c?, t?.c? from t? t? order by ?) [__t?] (rn, c?) order by ?
+select [__t?].rn from (select row_number() over (partition by ?) as [rn], tbla.cola, tbla.colc from tbla tbla order by ?) [__t?] (rn, cola) order by ?
 ===================================================
 0
 ===================================================
@@ -502,7 +502,7 @@ rn
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vi node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
@@ -510,16 +510,16 @@ Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), v?.c?, v?.c? from t? v? order by ?)
+(select row_number() over (partition by ?), vi.cola, vi.colc from tbla vi order by ?)
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vi node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select v?.rn from (select row_number() over (partition by ?), v?.c?, v?.c? from t? v? order by ?) v? (rn) order by ?
+select vi.rn from (select row_number() over (partition by ?), vi.cola, vi.colc from tbla vi order by ?) vi (rn) order by ?
 ===================================================
     
 Case 10: outer GROUP BY column is also referenced by the analytic function     
@@ -532,21 +532,21 @@ rn
 Query plan:
 temp(group by)
     subplan: sscan
-                 class: t? node[?]
+                 class: tbla node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-(select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?)
+(select tbla.cola, tbla.colb, tbla.colc, tbla.cold from tbla tbla group by tbla.colc)
 Query plan:
 sscan
-    class: t? node[?]
+    class: tbla node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), a_? from (select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?) t? (a_?, a_?, a_?, a_?))
+(select row_number() over (partition by ?), a_? from (select tbla.cola, tbla.colb, tbla.colc, tbla.cold from tbla tbla group by tbla.colc) tbla (a_?, a_?, a_?, a_?))
 Query plan:
 temp(order by)
     subplan: sscan
@@ -555,7 +555,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select [__t?].rn from (select row_number() over (partition by ?) as [rn], a_? from (select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?) t? (a_?, a_?, a_?, a_?)) [__t?] (rn) order by ?
+select [__t?].rn from (select row_number() over (partition by ?) as [rn], a_? from (select tbla.cola, tbla.colb, tbla.colc, tbla.cold from tbla tbla group by tbla.colc) tbla (a_?, a_?, a_?, a_?)) [__t?] (rn) order by ?
 ===================================================
 0
 ===================================================
@@ -566,30 +566,30 @@ rn
 Query plan:
 temp(group by)
     subplan: sscan
-                 class: t? node[?]
+                 class: tbla node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-(select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?)
+(select tbla.cola, tbla.colb, tbla.colc, tbla.cold from tbla tbla group by tbla.colc)
 Query plan:
 sscan
-    class: v? node[?]
+    class: vj node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), a_? from (select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?) v? (a_?, a_?, a_?, a_?))
+(select row_number() over (partition by ?), a_? from (select tbla.cola, tbla.colb, tbla.colc, tbla.cold from tbla tbla group by tbla.colc) vj (a_?, a_?, a_?, a_?))
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vj node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select v?.rn from (select row_number() over (partition by ?), a_? from (select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?) v? (a_?, a_?, a_?, a_?)) v? (rn) order by ?
+select vj.rn from (select row_number() over (partition by ?), a_? from (select tbla.cola, tbla.colb, tbla.colc, tbla.cold from tbla tbla group by tbla.colc) vj (a_?, a_?, a_?, a_?)) vj (rn) order by ?
 ===================================================
     
 Case 11: outer GROUP BY column is not referenced by the analytic function     
@@ -604,21 +604,21 @@ rn
 Query plan:
 temp(group by)
     subplan: sscan
-                 class: t? node[?]
+                 class: tbla node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-(select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?)
+(select tbla.cola, tbla.colb, tbla.colc, tbla.cold from tbla tbla group by tbla.cola)
 Query plan:
 sscan
-    class: t? node[?]
+    class: tbla node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), a_? from (select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?) t? (a_?, a_?, a_?, a_?))
+(select row_number() over (partition by ?), a_? from (select tbla.cola, tbla.colb, tbla.colc, tbla.cold from tbla tbla group by tbla.cola) tbla (a_?, a_?, a_?, a_?))
 Query plan:
 temp(order by)
     subplan: sscan
@@ -627,7 +627,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select [__t?].rn from (select row_number() over (partition by ?) as [rn], a_? from (select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?) t? (a_?, a_?, a_?, a_?)) [__t?] (rn) order by ?
+select [__t?].rn from (select row_number() over (partition by ?) as [rn], a_? from (select tbla.cola, tbla.colb, tbla.colc, tbla.cold from tbla tbla group by tbla.cola) tbla (a_?, a_?, a_?, a_?)) [__t?] (rn) order by ?
 ===================================================
 0
 ===================================================
@@ -640,30 +640,30 @@ rn
 Query plan:
 temp(group by)
     subplan: sscan
-                 class: t? node[?]
+                 class: tbla node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-(select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?)
+(select tbla.cola, tbla.colb, tbla.colc, tbla.cold from tbla tbla group by tbla.cola)
 Query plan:
 sscan
-    class: v? node[?]
+    class: vk node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), a_? from (select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?) v? (a_?, a_?, a_?, a_?))
+(select row_number() over (partition by ?), a_? from (select tbla.cola, tbla.colb, tbla.colc, tbla.cold from tbla tbla group by tbla.cola) vk (a_?, a_?, a_?, a_?))
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vk node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select v?.rn from (select row_number() over (partition by ?), a_? from (select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?) v? (a_?, a_?, a_?, a_?)) v? (rn) order by ?
+select vk.rn from (select row_number() over (partition by ?), a_? from (select tbla.cola, tbla.colb, tbla.colc, tbla.cold from tbla tbla group by tbla.cola) vk (a_?, a_?, a_?, a_?)) vk (rn) order by ?
 ===================================================
     
 Case 12: join query     
@@ -679,10 +679,10 @@ Query plan:
 nl-join (inner join)
     edge:  term[?]
     outer: sscan
-               class: t? node[?]
+               class: tbla node[?]
                cost:  ? card ?
     inner: sscan
-               class: t? node[?]
+               class: tblb node[?]
                sargs: term[?]
                cost:  ? card ?
     cost:  ? card ?
@@ -690,7 +690,7 @@ Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?) from t? t?, t? t? where t?.c?=t?.c?)
+(select row_number() over (partition by ?) from tbla tbla, tblb tblb where tbla.cola=tblb.cola)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -699,7 +699,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select [__t?].rn from (select row_number() over (partition by ?) as [rn] from t? t?, t? t? where t?.c?=t?.c?) [__t?] (rn) order by ?
+select [__t?].rn from (select row_number() over (partition by ?) as [rn] from tbla tbla, tblb tblb where tbla.cola=tblb.cola) [__t?] (rn) order by ?
 ===================================================
 0
 ===================================================
@@ -713,10 +713,10 @@ Query plan:
 nl-join (inner join)
     edge:  term[?]
     outer: sscan
-               class: v? node[?]
+               class: vl node[?]
                cost:  ? card ?
     inner: sscan
-               class: t? node[?]
+               class: tblb node[?]
                sargs: term[?]
                cost:  ? card ?
     cost:  ? card ?
@@ -724,22 +724,22 @@ Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?) from t? v?, t? t? where (v?.c?=t?.c?))
+(select row_number() over (partition by ?) from tbla vl, tblb tblb where (vl.cola=tblb.cola))
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vl node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select v?.rn from (select row_number() over (partition by ?) from t? v?, t? t? where (v?.c?=t?.c?)) v? (rn) order by ?
+select vl.rn from (select row_number() over (partition by ?) from tbla vl, tblb tblb where (vl.cola=tblb.cola)) vl (rn) order by ?
 ===================================================
     
 Case 13: no_merge hint, view contains an analytic function     
 
 ===================================================
-rn    c3    
+rn    colc    
 1     1     
 1     2     
 2     1     
@@ -747,13 +747,13 @@ rn    c3
 
 Query plan:
 sscan
-    class: t? node[?]
+    class: tbla node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select /*+ NO_MERGE */ t?.c?, t?.c?, t?.c?, row_number() over (partition by ?), t?.c? from t? t?)
+(select /*+ NO_MERGE */ tbla.cola, tbla.colb, tbla.colc, row_number() over (partition by ?), tbla.cold from tbla tbla)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -762,11 +762,11 @@ temp(order by)
     sort:  ? asc, ? asc
     cost:  ? card ?
 Query stmt:
-select [__t?].rn, [__t?].c? from (select /*+ NO_MERGE */ t?.c?, t?.c?, t?.c?, row_number() over (partition by ?) as [rn], t?.c? from t? t?) [__t?] (c?, c?, c?, rn, c?) order by ?, ?
+select [__t?].rn, [__t?].colc from (select /*+ NO_MERGE */ tbla.cola, tbla.colb, tbla.colc, row_number() over (partition by ?) as [rn], tbla.cold from tbla tbla) [__t?] (cola, colb, colc, rn, cold) order by ?, ?
 ===================================================
 0
 ===================================================
-rn    c3    
+rn    colc    
 1     1     
 1     2     
 2     1     
@@ -774,28 +774,28 @@ rn    c3
 
 Query plan:
 sscan
-    class: v? node[?]
+    class: vm node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select /*+ NO_MERGE */ row_number() over (partition by ?), v?.c?, v?.c?, v?.c?, v?.c? from t? v?)
+(select /*+ NO_MERGE */ row_number() over (partition by ?), vm.colc, vm.cola, vm.colb, vm.cold from tbla vm)
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vm node[?]
                  cost:  ? card ?
     sort:  ? asc, ? asc
     cost:  ? card ?
 Query stmt:
-select v?.rn, v?.c? from (select /*+ NO_MERGE */ row_number() over (partition by ?), v?.c?, v?.c?, v?.c?, v?.c? from t? v?) v? (rn, c?, c?, c?, c?) order by ?, ?
+select vm.rn, vm.colc from (select /*+ NO_MERGE */ row_number() over (partition by ?), vm.colc, vm.cola, vm.colb, vm.cold from tbla vm) vm (rn, colc, cola, colb, cold) order by ?, ?
 ===================================================
     
 Case 14: no_merge hint, view has no analytic function -- no_merge disables list pruning outright, with or without an analytic function     
 
 ===================================================
-c1    
+cola    
 1     
 2     
 3     
@@ -803,10 +803,10 @@ c1
 
 Query plan:
 sscan
-    class: t? node[?]
+    class: tbla node[?]
     cost:  ? card ?
 Query stmt:
-(select /*+ NO_MERGE */ t?.c?, t?.c?, t?.c?, t?.c? from t? t?)
+(select /*+ NO_MERGE */ tbla.cola, tbla.colb, tbla.colc, tbla.cold from tbla tbla)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -815,11 +815,11 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select [__t?].c? from (select /*+ NO_MERGE */ t?.c?, t?.c?, t?.c?, t?.c? from t? t?) [__t?] (c?, c?, c?, c?) order by ?
+select [__t?].cola from (select /*+ NO_MERGE */ tbla.cola, tbla.colb, tbla.colc, tbla.cold from tbla tbla) [__t?] (cola, colb, colc, cold) order by ?
 ===================================================
 0
 ===================================================
-c1    
+cola    
 1     
 2     
 3     
@@ -827,19 +827,19 @@ c1
 
 Query plan:
 sscan
-    class: v? node[?]
+    class: vn node[?]
     cost:  ? card ?
 Query stmt:
-(select /*+ NO_MERGE */ v?.c?, v?.c?, v?.c?, v?.c? from t? v?)
+(select /*+ NO_MERGE */ vn.cola, vn.colb, vn.colc, vn.cold from tbla vn)
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vn node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select v?.c? from (select /*+ NO_MERGE */ v?.c?, v?.c?, v?.c?, v?.c? from t? v?) v? (c?, c?, c?, c?) order by ?
+select vn.cola from (select /*+ NO_MERGE */ vn.cola, vn.colb, vn.colc, vn.cold from tbla vn) vn (cola, colb, colc, cold) order by ?
 ===================================================
 0
 ===================================================
@@ -896,22 +896,22 @@ rn
 
 Query plan:
 sscan
-    class: v? node[?]
+    class: vo node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), v?.c? from t? v?)
+(select row_number() over (partition by ?), vo.colc from tblc vo)
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vo node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select v?.rn from (select row_number() over (partition by ?), v?.c? from t? v?) v? (rn) order by ?
+select vo.rn from (select row_number() over (partition by ?), vo.colc from tblc vo) vo (rn) order by ?
 ===================================================
 rn    
 1     
@@ -926,13 +926,13 @@ rn
 
 Query plan:
 sscan
-    class: t? node[?]
+    class: tblc node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), t?.c? from t? t?)
+(select row_number() over (partition by ?), tblc.colc from tblc tblc)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -941,7 +941,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select [__t?].rn from (select row_number() over (partition by ?) as [rn], t?.c? from t? t?) [__t?] (rn) order by ?
+select [__t?].rn from (select row_number() over (partition by ?) as [rn], tblc.colc from tblc tblc) [__t?] (rn) order by ?
 ===================================================
 0
 ===================================================
@@ -973,7 +973,7 @@ rn
 Case 17: two analytic functions in the view, only one referenced by the main query     
 
 ===================================================
-rn1    
+rna    
 1     
 1     
 2     
@@ -982,13 +982,13 @@ rn1
 
 Query plan:
 sscan
-    class: t? node[?]
+    class: tbld node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), t?.c? from t? t?)
+(select row_number() over (partition by ?), tbld.colc from tbld tbld)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -997,11 +997,11 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select [__t?].rn? from (select row_number() over (partition by ?) as [rn?], t?.c? from t? t?) [__t?] (rn?) order by ?
+select [__t?].rna from (select row_number() over (partition by ?) as [rna], tbld.colc from tbld tbld) [__t?] (rna) order by ?
 ===================================================
 0
 ===================================================
-rn1    
+rna    
 1     
 1     
 2     
@@ -1010,28 +1010,28 @@ rn1
 
 Query plan:
 sscan
-    class: v? node[?]
+    class: vq node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first)
            func[?]: row_number partition by (? asc nulls first) order by ()
 Query stmt:
-(select row_number() over (partition by ?), v?.c? from t? v?)
+(select row_number() over (partition by ?), vq.colc from tbld vq)
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vq node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select v?.rn? from (select row_number() over (partition by ?), v?.c? from t? v?) v? (rn?) order by ?
+select vq.rna from (select row_number() over (partition by ?), vq.colc from tbld vq) vq (rna) order by ?
 ===================================================
     
 Case 18: ORDER BY inside the OVER clause, referenced by ordinal -- ROW_NUMBER would not catch a wrong ordinal (its value set is order-invariant), so use a running SUM whose value depends on the actual row order     
 
 ===================================================
-c1    s    
+cola    s    
 1     1     
 2     3     
 3     6     
@@ -1040,13 +1040,13 @@ c1    s
 
 Query plan:
 sscan
-    class: t? node[?]
+    class: tbld node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first, ? asc nulls first)
            func[?]: sum partition by (? asc nulls first) order by (? asc nulls first)
 Query stmt:
-(select t?.c?, sum(t?.c?) over (partition by ? order by ?), t?.c? from t? t?)
+(select tbld.cola, sum(tbld.cold) over (partition by ? order by ?), tbld.colc from tbld tbld)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -1055,11 +1055,11 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select [__t?].c?, [__t?].s from (select t?.c?, sum(t?.c?) over (partition by ? order by ?) as [s], t?.c? from t? t?) [__t?] (c?, s) order by ?
+select [__t?].cola, [__t?].s from (select tbld.cola, sum(tbld.cold) over (partition by ? order by ?) as [s], tbld.colc from tbld tbld) [__t?] (cola, s) order by ?
 ===================================================
 0
 ===================================================
-c1    s    
+cola    s    
 1     1     
 2     3     
 3     6     
@@ -1068,22 +1068,22 @@ c1    s
 
 Query plan:
 sscan
-    class: v? node[?]
+    class: vr node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first, ? asc nulls first)
            func[?]: sum partition by (? asc nulls first) order by (? asc nulls first)
 Query stmt:
-(select v?.c?, sum(v?.c?) over (partition by ? order by ?), v?.c? from t? v?)
+(select vr.cola, sum(vr.cold) over (partition by ? order by ?), vr.colc from tbld vr)
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vr node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select v?.c?, v?.s from (select v?.c?, sum(v?.c?) over (partition by ? order by ?), v?.c? from t? v?) v? (c?, s) order by ?
+select vr.cola, vr.s from (select vr.cola, sum(vr.cold) over (partition by ? order by ?), vr.colc from tbld vr) vr (cola, s) order by ?
 ===================================================
     
 Case 19: regression -- the running SUM must match between a view and its equivalent inline view     
@@ -1091,7 +1091,7 @@ Case 19: regression -- the running SUM must match between a view and its equival
 ===================================================
 0
 ===================================================
-c1    s    
+cola    s    
 1     6     
 2     5     
 3     3     
@@ -1100,24 +1100,24 @@ c1    s
 
 Query plan:
 sscan
-    class: v? node[?]
+    class: vs node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first, ? desc nulls last)
            func[?]: sum partition by (? asc nulls first) order by (? desc nulls last)
 Query stmt:
-(select v?.c?, sum(v?.c?) over (partition by ? order by ? desc ), v?.c? from t? v?)
+(select vs.cola, sum(vs.cold) over (partition by ? order by ? desc ), vs.colc from tbld vs)
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vs node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select v?.c?, v?.s from (select v?.c?, sum(v?.c?) over (partition by ? order by ? desc ), v?.c? from t? v?) v? (c?, s) order by ?
+select vs.cola, vs.s from (select vs.cola, sum(vs.cold) over (partition by ? order by ? desc ), vs.colc from tbld vs) vs (cola, s) order by ?
 ===================================================
-c1    s    
+cola    s    
 1     6     
 2     5     
 3     3     
@@ -1126,13 +1126,13 @@ c1    s
 
 Query plan:
 sscan
-    class: t? node[?]
+    class: tbld node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first, ? desc nulls last)
            func[?]: sum partition by (? asc nulls first) order by (? desc nulls last)
 Query stmt:
-(select t?.c?, sum(t?.c?) over (partition by ? order by ? desc ), t?.c? from t? t?)
+(select tbld.cola, sum(tbld.cold) over (partition by ? order by ? desc ), tbld.colc from tbld tbld)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -1141,7 +1141,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select [__t?].c?, [__t?].s from (select t?.c?, sum(t?.c?) over (partition by ? order by ? desc ) as [s], t?.c? from t? t?) [__t?] (c?, s) order by ?
+select [__t?].cola, [__t?].s from (select tbld.cola, sum(tbld.cold) over (partition by ? order by ? desc ) as [s], tbld.colc from tbld tbld) [__t?] (cola, s) order by ?
 ===================================================
     
 Case 20: both the PARTITION BY and ORDER BY ordinals reference columns the main query does not select -- both must be re-added as hidden columns at once     
@@ -1156,13 +1156,13 @@ s
 
 Query plan:
 sscan
-    class: t? node[?]
+    class: tbld node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first, ? asc nulls first)
            func[?]: sum partition by (? asc nulls first) order by (? asc nulls first)
 Query stmt:
-(select sum(t?.c?) over (partition by ? order by ?), t?.c?, t?.c? from t? t?)
+(select sum(tbld.cold) over (partition by ? order by ?), tbld.colc, tbld.cola from tbld tbld)
 Query plan:
 temp(order by)
     subplan: sscan
@@ -1171,7 +1171,7 @@ temp(order by)
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select [__t?].s from (select sum(t?.c?) over (partition by ? order by ?) as [s], t?.c?, t?.c? from t? t?) [__t?] (s) order by ?
+select [__t?].s from (select sum(tbld.cold) over (partition by ? order by ?) as [s], tbld.colc, tbld.cola from tbld tbld) [__t?] (s) order by ?
 ===================================================
 0
 ===================================================
@@ -1184,22 +1184,22 @@ s
 
 Query plan:
 sscan
-    class: v? node[?]
+    class: vt node[?]
     cost:  ? card ?
 Analytic functions:
     run[?]: sort with key (? asc nulls first, ? asc nulls first)
            func[?]: sum partition by (? asc nulls first) order by (? asc nulls first)
 Query stmt:
-(select sum(v?.c?) over (partition by ? order by ?), v?.c?, v?.c? from t? v?)
+(select sum(vt.cold) over (partition by ? order by ?), vt.colc, vt.cola from tbld vt)
 Query plan:
 temp(order by)
     subplan: sscan
-                 class: v? node[?]
+                 class: vt node[?]
                  cost:  ? card ?
     sort:  ? asc
     cost:  ? card ?
 Query stmt:
-select v?.s from (select sum(v?.c?) over (partition by ? order by ?), v?.c?, v?.c? from t? v?) v? (s) order by ?
+select vt.s from (select sum(vt.cold) over (partition by ? order by ?), vt.colc, vt.cola from tbld vt) vt (s) order by ?
 ===================================================
 0
 ===================================================

--- a/sql/_13_issues/_26_2h/answers/cbrd_25531.answer
+++ b/sql/_13_issues/_26_2h/answers/cbrd_25531.answer
@@ -966,6 +966,25 @@ rn
 2     
 3     
 
+Query plan:
+sscan
+    class: tbld node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), tbld.colc from tbld tbld)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 sargs: term[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].rn from (select row_number() over (partition by ?) as [rn], tbld.colc from tbld tbld) [__t?] (rn) where ([__t?].rn> ?:? ) order by ?
 ===================================================
 0
 ===================================================

--- a/sql/_13_issues/_26_2h/answers/cbrd_25531.answer
+++ b/sql/_13_issues/_26_2h/answers/cbrd_25531.answer
@@ -1229,3 +1229,243 @@ select vt.s from (select sum(vt.cold) over (partition by ? order by ?), vt.colc,
 0
 ===================================================
 0
+===================================================
+0
+===================================================
+0
+===================================================
+5
+===================================================
+    
+Case 21: LAG(cold) referenced -- the argument column cold and the OVER order column cola must be re-added as hidden columns; the LAG value is order-sensitive     
+
+===================================================
+cola    lg    
+1     null     
+2     10     
+3     20     
+4     null     
+5     40     
+
+Query plan:
+sscan
+    class: tble node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first, ? asc nulls first)
+           func[?]: lag partition by (? asc nulls first) order by (? asc nulls first)
+Query stmt:
+(select tble.cola, lag(tble.cold, ?, null) over (partition by ? order by ?), tble.colc from tble tble)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].cola, [__t?].lg from (select tble.cola, lag(tble.cold, ?, null) over (partition by ? order by ?) as [lg], tble.colc from tble tble) [__t?] (cola, lg) order by ?
+===================================================
+0
+===================================================
+cola    lg    
+1     null     
+2     10     
+3     20     
+4     null     
+5     40     
+
+Query plan:
+sscan
+    class: vu node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first, ? asc nulls first)
+           func[?]: lag partition by (? asc nulls first) order by (? asc nulls first)
+Query stmt:
+(select vu.cola, lag(vu.cold, ?, null) over (partition by ? order by ?), vu.colc from tble vu)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: vu node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select vu.cola, vu.lg from (select vu.cola, lag(vu.cold, ?, null) over (partition by ? order by ?), vu.colc from tble vu) vu (cola, lg) order by ?
+===================================================
+    
+Case 22: LEAD(cold) not referenced by the main query -- the whole select list, the analytic and its argument column cold included, must collapse to (1)     
+
+===================================================
+count(*)    
+5     
+
+Query plan:
+sscan
+    class: tble node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tble tble)
+Query plan:
+sscan
+    class: __t? node[?]
+    cost:  ? card ?
+Query stmt:
+select count(*) from (select ? from tble tble) [__t?] (?)
+===================================================
+0
+===================================================
+count(*)    
+5     
+
+Query plan:
+sscan
+    class: vv node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from tble vv)
+Query plan:
+sscan
+    class: vv node[?]
+    cost:  ? card ?
+Query stmt:
+select count(*) from (select ? from tble vv) vv (?)
+===================================================
+    
+Case 23: nested, the inner analytic is unreferenced at the top -- both levels must reduce (the top and the inner select list collapse to (1))     
+
+===================================================
+count(*)    
+5     
+
+Query plan:
+sscan
+    class: tble node[?]
+    cost:  ? card ?
+Query stmt:
+(select tble.cola from tble tble)
+Query plan:
+sscan
+    class: __t? node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from (select tble.cola from tble tble) [__t?] (cola))
+Query plan:
+sscan
+    class: __t? node[?]
+    cost:  ? card ?
+Query stmt:
+select count(*) from (select ? from (select tble.cola from tble tble) [__t?] (cola)) [__t?] (?)
+===================================================
+0
+===================================================
+0
+===================================================
+count(*)    
+5     
+
+Query plan:
+sscan
+    class: vw_in node[?]
+    cost:  ? card ?
+Query stmt:
+(select vw_in.cola from tble vw_in)
+Query plan:
+sscan
+    class: vw_out node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from (select vw_in.cola from tble vw_in) vw_out (cola))
+Query plan:
+sscan
+    class: vw_out node[?]
+    cost:  ? card ?
+Query stmt:
+select count(*) from (select ? from (select vw_in.cola from tble vw_in) vw_out (cola)) vw_out (?)
+===================================================
+    
+Case 24: regression -- the inner running SUM read through the outer view must match between the nested view and its equivalent nested inline view (a desync at depth would change the value)     
+
+===================================================
+cola    s_in    
+1     10     
+2     30     
+3     60     
+4     40     
+5     90     
+
+Query plan:
+sscan
+    class: tble node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first, ? asc nulls first)
+           func[?]: sum partition by (? asc nulls first) order by (? asc nulls first)
+Query stmt:
+(select tble.cola, sum(tble.cold) over (partition by ? order by ?), tble.colc from tble tble)
+Query plan:
+sscan
+    class: __t? node[?]
+    cost:  ? card ?
+Query stmt:
+(select [__t?].cola, [__t?].s_in from (select tble.cola, sum(tble.cold) over (partition by ? order by ?) as [s_in], tble.colc from tble tble) [__t?] (cola, s_in))
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].cola, [__t?].s_in from (select [__t?].cola, [__t?].s_in from (select tble.cola, sum(tble.cold) over (partition by ? order by ?) as [s_in], tble.colc from tble tble) [__t?] (cola, s_in)) [__t?] (cola, s_in) order by ?
+===================================================
+0
+===================================================
+0
+===================================================
+cola    s_in    
+1     10     
+2     30     
+3     60     
+4     40     
+5     90     
+
+Query plan:
+sscan
+    class: vx_in node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first, ? asc nulls first)
+           func[?]: sum partition by (? asc nulls first) order by (? asc nulls first)
+Query stmt:
+(select vx_in.cola, sum(vx_in.cold) over (partition by ? order by ?), vx_in.colc from tble vx_in)
+Query plan:
+sscan
+    class: vx_out node[?]
+    cost:  ? card ?
+Query stmt:
+(select vx_out.cola, vx_out.s_in from (select vx_in.cola, sum(vx_in.cold) over (partition by ? order by ?), vx_in.colc from tble vx_in) vx_out (cola, s_in))
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: vx_out node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select vx_out.cola, vx_out.s_in from (select vx_out.cola, vx_out.s_in from (select vx_in.cola, sum(vx_in.cold) over (partition by ? order by ?), vx_in.colc from tble vx_in) vx_out (cola, s_in)) vx_out (cola, s_in) order by ?
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0

--- a/sql/_13_issues/_26_2h/answers/cbrd_25531.answer
+++ b/sql/_13_issues/_26_2h/answers/cbrd_25531.answer
@@ -1,0 +1,1212 @@
+===================================================
+0
+===================================================
+0
+===================================================
+4
+===================================================
+0
+===================================================
+0
+===================================================
+4
+===================================================
+    
+Case 1: the analytic column is not referenced by the main query     
+
+===================================================
+count(*)    
+4     
+
+Query plan:
+sscan
+    class: t? node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from t? t?)
+Query plan:
+sscan
+    class: __t? node[?]
+    cost:  ? card ?
+Query stmt:
+select count(*) from (select ? from t? t?) [__t?] (?)
+===================================================
+0
+===================================================
+count(*)    
+4     
+
+Query plan:
+sscan
+    class: v? node[?]
+    cost:  ? card ?
+Query stmt:
+(select ? from t? v?)
+Query plan:
+sscan
+    class: v? node[?]
+    cost:  ? card ?
+Query stmt:
+select count(*) from (select ? from t? v?) v? (?)
+===================================================
+    
+Case 2: the analytic column is referenced by the main query     
+
+===================================================
+rn    
+1     
+2     
+3     
+4     
+
+Query plan:
+sscan
+    class: t? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key ()
+           func[?]: row_number partition by () order by ()
+Query stmt:
+(select row_number() over () from t? t?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].rn from (select row_number() over () as [rn] from t? t?) [__t?] (rn) order by ?
+===================================================
+0
+===================================================
+rn    
+1     
+2     
+3     
+4     
+
+Query plan:
+sscan
+    class: v? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key ()
+           func[?]: row_number partition by () order by ()
+Query stmt:
+(select row_number() over () from t? v?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select v?.rn from (select row_number() over () from t? v?) v? (rn) order by ?
+===================================================
+    
+Case 3: the OVER-clause column is also referenced by the main query     
+
+===================================================
+rn    c3    
+1     1     
+1     2     
+2     1     
+2     2     
+
+Query plan:
+sscan
+    class: t? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), t?.c? from t? t?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc, ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].rn, [__t?].c? from (select row_number() over (partition by ?) as [rn], t?.c? from t? t?) [__t?] (rn, c?) order by ?, ?
+===================================================
+0
+===================================================
+rn    c3    
+1     1     
+1     2     
+2     1     
+2     2     
+
+Query plan:
+sscan
+    class: v? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), v?.c? from t? v?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc, ? asc
+    cost:  ? card ?
+Query stmt:
+select v?.rn, v?.c? from (select row_number() over (partition by ?), v?.c? from t? v?) v? (rn, c?) order by ?, ?
+===================================================
+    
+Case 4: the OVER-clause column is referenced by ordinal, not by the main query     
+
+===================================================
+rn    
+1     
+1     
+2     
+2     
+
+Query plan:
+sscan
+    class: t? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), t?.c? from t? t?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].rn from (select row_number() over (partition by ?) as [rn], t?.c? from t? t?) [__t?] (rn) order by ?
+===================================================
+0
+===================================================
+rn    
+1     
+1     
+2     
+2     
+
+Query plan:
+sscan
+    class: v? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), v?.c? from t? v?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select v?.rn from (select row_number() over (partition by ?), v?.c? from t? v?) v? (rn) order by ?
+===================================================
+    
+Case 5: the OVER-clause column is missing from the view select list     
+
+===================================================
+rn    
+1     
+1     
+2     
+2     
+
+Query plan:
+sscan
+    class: t? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?) from t? t?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].rn from (select row_number() over (partition by ?) as [rn] from t? t?) [__t?] (rn) order by ?
+===================================================
+0
+===================================================
+rn    
+1     
+1     
+2     
+2     
+
+Query plan:
+sscan
+    class: v? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?) from t? v?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select v?.rn from (select row_number() over (partition by ?) from t? v?) v? (rn) order by ?
+===================================================
+    
+Case 6: the OVER-clause column is an expression over another column     
+
+===================================================
+rn    
+1     
+1     
+2     
+2     
+
+Query plan:
+sscan
+    class: t? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), nvl(t?.c?, ?) from t? t?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].rn from (select row_number() over (partition by ?) as [rn], nvl(t?.c?, ?) as [nvl_c?] from t? t?) [__t?] (rn) order by ?
+===================================================
+0
+===================================================
+rn    
+1     
+1     
+2     
+2     
+
+Query plan:
+sscan
+    class: v? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), (nvl(v?.c?, ?)) from t? v?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select v?.rn from (select row_number() over (partition by ?), (nvl(v?.c?, ?)) from t? v?) v? (rn) order by ?
+===================================================
+    
+Case 7: the OVER-clause column is a scalar subquery     
+
+===================================================
+rn    
+1     
+2     
+3     
+4     
+
+Query plan:
+sscan
+    class: t? node[?]
+    cost:  ? card ?
+Query stmt:
+(select max(t?.c?) from t? t?)
+Query plan:
+sscan
+    class: t? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), (select max(t?.c?) from t? t?) from t? t?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].rn from (select row_number() over (partition by ?) as [rn], (select max(t?.c?) from t? t?) as [max_c?] from t? t?) [__t?] (rn) order by ?
+===================================================
+0
+===================================================
+rn    
+1     
+2     
+3     
+4     
+
+Query plan:
+sscan
+    class: t? node[?]
+    cost:  ? card ?
+Query stmt:
+(select max(t?.c?) from t? t?)
+Query plan:
+sscan
+    class: v? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), (select max(t?.c?) from t? t?) from t? v?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select v?.rn from (select row_number() over (partition by ?), (select max(t?.c?) from t? t?) from t? v?) v? (rn) order by ?
+===================================================
+    
+Case 8: outer ORDER BY column is also referenced by the analytic function     
+
+===================================================
+rn    
+1     
+1     
+2     
+2     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), t?.c? from t? t? order by ?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].rn from (select row_number() over (partition by ?) as [rn], t?.c? from t? t? order by ?) [__t?] (rn, c?) order by ?
+===================================================
+0
+===================================================
+rn    
+1     
+1     
+2     
+2     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), v?.c? from t? v? order by ?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select v?.rn from (select row_number() over (partition by ?), v?.c? from t? v? order by ?) v? (rn) order by ?
+===================================================
+    
+Case 9: outer ORDER BY column is not referenced by the analytic function     
+
+===================================================
+rn    
+1     
+1     
+2     
+2     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), t?.c?, t?.c? from t? t? order by ?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].rn from (select row_number() over (partition by ?) as [rn], t?.c?, t?.c? from t? t? order by ?) [__t?] (rn, c?) order by ?
+===================================================
+0
+===================================================
+rn    
+1     
+1     
+2     
+2     
+
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), v?.c?, v?.c? from t? v? order by ?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select v?.rn from (select row_number() over (partition by ?), v?.c?, v?.c? from t? v? order by ?) v? (rn) order by ?
+===================================================
+    
+Case 10: outer GROUP BY column is also referenced by the analytic function     
+
+===================================================
+rn    
+1     
+1     
+
+Query plan:
+temp(group by)
+    subplan: sscan
+                 class: t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?)
+Query plan:
+sscan
+    class: t? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), a_? from (select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?) t? (a_?, a_?, a_?, a_?))
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].rn from (select row_number() over (partition by ?) as [rn], a_? from (select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?) t? (a_?, a_?, a_?, a_?)) [__t?] (rn) order by ?
+===================================================
+0
+===================================================
+rn    
+1     
+1     
+
+Query plan:
+temp(group by)
+    subplan: sscan
+                 class: t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?)
+Query plan:
+sscan
+    class: v? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), a_? from (select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?) v? (a_?, a_?, a_?, a_?))
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select v?.rn from (select row_number() over (partition by ?), a_? from (select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?) v? (a_?, a_?, a_?, a_?)) v? (rn) order by ?
+===================================================
+    
+Case 11: outer GROUP BY column is not referenced by the analytic function     
+
+===================================================
+rn    
+1     
+1     
+2     
+2     
+
+Query plan:
+temp(group by)
+    subplan: sscan
+                 class: t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?)
+Query plan:
+sscan
+    class: t? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), a_? from (select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?) t? (a_?, a_?, a_?, a_?))
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].rn from (select row_number() over (partition by ?) as [rn], a_? from (select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?) t? (a_?, a_?, a_?, a_?)) [__t?] (rn) order by ?
+===================================================
+0
+===================================================
+rn    
+1     
+1     
+2     
+2     
+
+Query plan:
+temp(group by)
+    subplan: sscan
+                 class: t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+(select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?)
+Query plan:
+sscan
+    class: v? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), a_? from (select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?) v? (a_?, a_?, a_?, a_?))
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select v?.rn from (select row_number() over (partition by ?), a_? from (select t?.c?, t?.c?, t?.c?, t?.c? from t? t? group by t?.c?) v? (a_?, a_?, a_?, a_?)) v? (rn) order by ?
+===================================================
+    
+Case 12: join query     
+
+===================================================
+rn    
+1     
+1     
+2     
+2     
+
+Query plan:
+nl-join (inner join)
+    edge:  term[?]
+    outer: sscan
+               class: t? node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: t? node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?) from t? t?, t? t? where t?.c?=t?.c?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].rn from (select row_number() over (partition by ?) as [rn] from t? t?, t? t? where t?.c?=t?.c?) [__t?] (rn) order by ?
+===================================================
+0
+===================================================
+rn    
+1     
+1     
+2     
+2     
+
+Query plan:
+nl-join (inner join)
+    edge:  term[?]
+    outer: sscan
+               class: v? node[?]
+               cost:  ? card ?
+    inner: sscan
+               class: t? node[?]
+               sargs: term[?]
+               cost:  ? card ?
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?) from t? v?, t? t? where (v?.c?=t?.c?))
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select v?.rn from (select row_number() over (partition by ?) from t? v?, t? t? where (v?.c?=t?.c?)) v? (rn) order by ?
+===================================================
+    
+Case 13: no_merge hint, view contains an analytic function     
+
+===================================================
+rn    c3    
+1     1     
+1     2     
+2     1     
+2     2     
+
+Query plan:
+sscan
+    class: t? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select /*+ NO_MERGE */ t?.c?, t?.c?, t?.c?, row_number() over (partition by ?), t?.c? from t? t?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc, ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].rn, [__t?].c? from (select /*+ NO_MERGE */ t?.c?, t?.c?, t?.c?, row_number() over (partition by ?) as [rn], t?.c? from t? t?) [__t?] (c?, c?, c?, rn, c?) order by ?, ?
+===================================================
+0
+===================================================
+rn    c3    
+1     1     
+1     2     
+2     1     
+2     2     
+
+Query plan:
+sscan
+    class: v? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select /*+ NO_MERGE */ row_number() over (partition by ?), v?.c?, v?.c?, v?.c?, v?.c? from t? v?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc, ? asc
+    cost:  ? card ?
+Query stmt:
+select v?.rn, v?.c? from (select /*+ NO_MERGE */ row_number() over (partition by ?), v?.c?, v?.c?, v?.c?, v?.c? from t? v?) v? (rn, c?, c?, c?, c?) order by ?, ?
+===================================================
+    
+Case 14: no_merge hint, view has no analytic function -- no_merge disables list pruning outright, with or without an analytic function     
+
+===================================================
+c1    
+1     
+2     
+3     
+4     
+
+Query plan:
+sscan
+    class: t? node[?]
+    cost:  ? card ?
+Query stmt:
+(select /*+ NO_MERGE */ t?.c?, t?.c?, t?.c?, t?.c? from t? t?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].c? from (select /*+ NO_MERGE */ t?.c?, t?.c?, t?.c?, t?.c? from t? t?) [__t?] (c?, c?, c?, c?) order by ?
+===================================================
+0
+===================================================
+c1    
+1     
+2     
+3     
+4     
+
+Query plan:
+sscan
+    class: v? node[?]
+    cost:  ? card ?
+Query stmt:
+(select /*+ NO_MERGE */ v?.c?, v?.c?, v?.c?, v?.c? from t? v?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select v?.c? from (select /*+ NO_MERGE */ v?.c?, v?.c?, v?.c?, v?.c? from t? v?) v? (c?, c?, c?, c?) order by ?
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+    
+Case 15: row_number() result must match between a named view and its equivalent inline view     
+
+===================================================
+0
+===================================================
+0
+===================================================
+9
+===================================================
+0
+===================================================
+rn    
+1     
+1     
+2     
+2     
+3     
+3     
+4     
+4     
+5     
+
+Query plan:
+sscan
+    class: v? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), v?.c? from t? v?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select v?.rn from (select row_number() over (partition by ?), v?.c? from t? v?) v? (rn) order by ?
+===================================================
+rn    
+1     
+1     
+2     
+2     
+3     
+3     
+4     
+4     
+5     
+
+Query plan:
+sscan
+    class: t? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), t?.c? from t? t?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].rn from (select row_number() over (partition by ?) as [rn], t?.c? from t? t?) [__t?] (rn) order by ?
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+5
+===================================================
+    
+Case 16: PREPARE/EXECUTE compiles and runs the pruned plan correctly     
+
+===================================================
+0
+===================================================
+rn    
+1     
+1     
+2     
+2     
+3     
+
+===================================================
+0
+===================================================
+    
+Case 17: two analytic functions in the view, only one referenced by the main query     
+
+===================================================
+rn1    
+1     
+1     
+2     
+2     
+3     
+
+Query plan:
+sscan
+    class: t? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), t?.c? from t? t?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].rn? from (select row_number() over (partition by ?) as [rn?], t?.c? from t? t?) [__t?] (rn?) order by ?
+===================================================
+0
+===================================================
+rn1    
+1     
+1     
+2     
+2     
+3     
+
+Query plan:
+sscan
+    class: v? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first)
+           func[?]: row_number partition by (? asc nulls first) order by ()
+Query stmt:
+(select row_number() over (partition by ?), v?.c? from t? v?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select v?.rn? from (select row_number() over (partition by ?), v?.c? from t? v?) v? (rn?) order by ?
+===================================================
+    
+Case 18: ORDER BY inside the OVER clause, referenced by ordinal -- ROW_NUMBER would not catch a wrong ordinal (its value set is order-invariant), so use a running SUM whose value depends on the actual row order     
+
+===================================================
+c1    s    
+1     1     
+2     3     
+3     6     
+4     1     
+5     3     
+
+Query plan:
+sscan
+    class: t? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first, ? asc nulls first)
+           func[?]: sum partition by (? asc nulls first) order by (? asc nulls first)
+Query stmt:
+(select t?.c?, sum(t?.c?) over (partition by ? order by ?), t?.c? from t? t?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].c?, [__t?].s from (select t?.c?, sum(t?.c?) over (partition by ? order by ?) as [s], t?.c? from t? t?) [__t?] (c?, s) order by ?
+===================================================
+0
+===================================================
+c1    s    
+1     1     
+2     3     
+3     6     
+4     1     
+5     3     
+
+Query plan:
+sscan
+    class: v? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first, ? asc nulls first)
+           func[?]: sum partition by (? asc nulls first) order by (? asc nulls first)
+Query stmt:
+(select v?.c?, sum(v?.c?) over (partition by ? order by ?), v?.c? from t? v?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select v?.c?, v?.s from (select v?.c?, sum(v?.c?) over (partition by ? order by ?), v?.c? from t? v?) v? (c?, s) order by ?
+===================================================
+    
+Case 19: regression -- the running SUM must match between a view and its equivalent inline view     
+
+===================================================
+0
+===================================================
+c1    s    
+1     6     
+2     5     
+3     3     
+4     3     
+5     2     
+
+Query plan:
+sscan
+    class: v? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first, ? desc nulls last)
+           func[?]: sum partition by (? asc nulls first) order by (? desc nulls last)
+Query stmt:
+(select v?.c?, sum(v?.c?) over (partition by ? order by ? desc ), v?.c? from t? v?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select v?.c?, v?.s from (select v?.c?, sum(v?.c?) over (partition by ? order by ? desc ), v?.c? from t? v?) v? (c?, s) order by ?
+===================================================
+c1    s    
+1     6     
+2     5     
+3     3     
+4     3     
+5     2     
+
+Query plan:
+sscan
+    class: t? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first, ? desc nulls last)
+           func[?]: sum partition by (? asc nulls first) order by (? desc nulls last)
+Query stmt:
+(select t?.c?, sum(t?.c?) over (partition by ? order by ? desc ), t?.c? from t? t?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].c?, [__t?].s from (select t?.c?, sum(t?.c?) over (partition by ? order by ? desc ) as [s], t?.c? from t? t?) [__t?] (c?, s) order by ?
+===================================================
+    
+Case 20: both the PARTITION BY and ORDER BY ordinals reference columns the main query does not select -- both must be re-added as hidden columns at once     
+
+===================================================
+s    
+1     
+1     
+3     
+3     
+6     
+
+Query plan:
+sscan
+    class: t? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first, ? asc nulls first)
+           func[?]: sum partition by (? asc nulls first) order by (? asc nulls first)
+Query stmt:
+(select sum(t?.c?) over (partition by ? order by ?), t?.c?, t?.c? from t? t?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: __t? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select [__t?].s from (select sum(t?.c?) over (partition by ? order by ?) as [s], t?.c?, t?.c? from t? t?) [__t?] (s) order by ?
+===================================================
+0
+===================================================
+s    
+1     
+1     
+3     
+3     
+6     
+
+Query plan:
+sscan
+    class: v? node[?]
+    cost:  ? card ?
+Analytic functions:
+    run[?]: sort with key (? asc nulls first, ? asc nulls first)
+           func[?]: sum partition by (? asc nulls first) order by (? asc nulls first)
+Query stmt:
+(select sum(v?.c?) over (partition by ? order by ?), v?.c?, v?.c? from t? v?)
+Query plan:
+temp(order by)
+    subplan: sscan
+                 class: v? node[?]
+                 cost:  ? card ?
+    sort:  ? asc
+    cost:  ? card ?
+Query stmt:
+select v?.s from (select sum(v?.c?) over (partition by ? order by ?), v?.c?, v?.c? from t? v?) v? (s) order by ?
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0
+===================================================
+0

--- a/sql/_13_issues/_26_2h/cases/cbrd_25531.sql
+++ b/sql/_13_issues/_26_2h/cases/cbrd_25531.sql
@@ -1,0 +1,198 @@
+/**
+ * This test case verifies CBRD-25531: unreferenced select-list items of a
+ * non-mergeable inline view are now pruned even when the view contains an
+ * analytic function, matching the pruning already done for a plain view.
+ * Each case runs as both an inline view and a named view (always
+ * non-mergeable, pinning the pre-fix baseline).
+ *
+ * Coverage:
+ * 1-2   analytic column referenced by main query or not
+ * 3-7   OVER-clause reference shapes (main query, ordinal, missing,
+ *       expression, scalar subquery)
+ * 8-11  outer ORDER BY / GROUP BY vs the OVER-clause column
+ * 12-14 join query, no_merge hint with/without an analytic function
+ * 15    regression: row_number() must match between a view and its
+ *       equivalent inline view (select-list reorder desyncing OVER)
+ * 16-17 PREPARE/EXECUTE path, two analytic functions with only one used
+ * 18-20 ORDER BY inside OVER: ordinal reference, regression vs a view,
+ *       both PARTITION BY and ORDER BY ordinals hidden-appended at once
+ */
+
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t1(c1 INT AUTO_INCREMENT, c2 INT, c3 INT, c4 INT);
+INSERT INTO t1(c2, c3, c4) VALUES
+(1,1,1),
+(1,1,2),
+(1,2,2),
+(1,2,3);
+
+DROP TABLE IF EXISTS t2;
+CREATE TABLE t2(c1 INT, c2 INT);
+INSERT INTO t2 VALUES (1,1),(2,1),(3,2),(4,2);
+
+evaluate 'Case 1: the analytic column is not referenced by the main query';
+SELECT /*+ recompile */ COUNT(*)
+FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1);
+CREATE OR REPLACE VIEW v1 AS SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1;
+SELECT /*+ recompile */ COUNT(*) FROM v1;
+
+evaluate 'Case 2: the analytic column is referenced by the main query';
+SELECT /*+ recompile */ rn
+FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER() AS rn, c4 FROM t1) ORDER BY 1;
+CREATE OR REPLACE VIEW v2 AS SELECT c1, c2, c3, ROW_NUMBER() OVER() AS rn, c4 FROM t1;
+SELECT /*+ recompile */ rn FROM v2 ORDER BY 1;
+
+evaluate 'Case 3: the OVER-clause column is also referenced by the main query';
+SELECT /*+ recompile */ rn, c3
+FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1) ORDER BY 1, 2;
+CREATE OR REPLACE VIEW v3 AS SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1;
+SELECT /*+ recompile */ rn, c3 FROM v3 ORDER BY 1, 2;
+
+evaluate 'Case 4: the OVER-clause column is referenced by ordinal, not by the main query';
+SELECT /*+ recompile */ rn
+FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY 3) AS rn, c4 FROM t1) ORDER BY 1;
+CREATE OR REPLACE VIEW v4 AS SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY 3) AS rn, c4 FROM t1;
+SELECT /*+ recompile */ rn FROM v4 ORDER BY 1;
+
+evaluate 'Case 5: the OVER-clause column is missing from the view select list';
+SELECT /*+ recompile */ rn
+FROM (SELECT c1, c2, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1) ORDER BY 1;
+CREATE OR REPLACE VIEW v5 AS SELECT c1, c2, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1;
+SELECT /*+ recompile */ rn FROM v5 ORDER BY 1;
+
+evaluate 'Case 6: the OVER-clause column is an expression over another column';
+SELECT /*+ recompile */ rn
+FROM (SELECT c1, c2, NVL(c3, 0) AS nvl_c3, ROW_NUMBER() OVER(PARTITION BY 3) AS rn, c4 FROM t1) ORDER BY 1;
+CREATE OR REPLACE VIEW v6 AS SELECT c1, c2, NVL(c3, 0) AS nvl_c3, ROW_NUMBER() OVER(PARTITION BY 3) AS rn, c4 FROM t1;
+SELECT /*+ recompile */ rn FROM v6 ORDER BY 1;
+
+evaluate 'Case 7: the OVER-clause column is a scalar subquery';
+SELECT /*+ recompile */ rn
+FROM (SELECT c1, c2, (SELECT MAX(c3) FROM t1) AS max_c3, ROW_NUMBER() OVER(PARTITION BY 3) AS rn FROM t1) ORDER BY 1;
+CREATE OR REPLACE VIEW v7 AS SELECT c1, c2, (SELECT MAX(c3) FROM t1) AS max_c3, ROW_NUMBER() OVER(PARTITION BY 3) AS rn FROM t1;
+SELECT /*+ recompile */ rn FROM v7 ORDER BY 1;
+
+evaluate 'Case 8: outer ORDER BY column is also referenced by the analytic function';
+SELECT /*+ recompile */ rn
+FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1 ORDER BY c3) ORDER BY 1;
+CREATE OR REPLACE VIEW v8 AS SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1 ORDER BY c3;
+SELECT /*+ recompile */ rn FROM v8 ORDER BY 1;
+
+evaluate 'Case 9: outer ORDER BY column is not referenced by the analytic function';
+SELECT /*+ recompile */ rn
+FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1 ORDER BY c1) ORDER BY 1;
+CREATE OR REPLACE VIEW v9 AS SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1 ORDER BY c1;
+SELECT /*+ recompile */ rn FROM v9 ORDER BY 1;
+
+evaluate 'Case 10: outer GROUP BY column is also referenced by the analytic function';
+SELECT /*+ recompile */ rn
+FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1 GROUP BY c3) ORDER BY 1;
+CREATE OR REPLACE VIEW v10 AS SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1 GROUP BY c3;
+SELECT /*+ recompile */ rn FROM v10 ORDER BY 1;
+
+evaluate 'Case 11: outer GROUP BY column is not referenced by the analytic function';
+SELECT /*+ recompile */ rn
+FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1 GROUP BY c1) ORDER BY 1;
+CREATE OR REPLACE VIEW v11 AS SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1 GROUP BY c1;
+SELECT /*+ recompile */ rn FROM v11 ORDER BY 1;
+
+evaluate 'Case 12: join query';
+SELECT /*+ recompile */ rn
+FROM (SELECT t1.c1 AS t1_c1, t2.c1 AS t2_c1, ROW_NUMBER() OVER(PARTITION BY t2.c2) AS rn FROM t1, t2 WHERE t1.c1 = t2.c1) ORDER BY 1;
+CREATE OR REPLACE VIEW v12 AS SELECT t1.c1 AS t1_c1, t2.c1 AS t2_c1, ROW_NUMBER() OVER(PARTITION BY t2.c2) AS rn FROM t1, t2 WHERE t1.c1 = t2.c1;
+SELECT /*+ recompile */ rn FROM v12 ORDER BY 1;
+
+evaluate 'Case 13: no_merge hint, view contains an analytic function';
+SELECT /*+ recompile */ rn, c3
+FROM (SELECT /*+ no_merge */ c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1) ORDER BY 1, 2;
+CREATE OR REPLACE VIEW v13 AS SELECT /*+ no_merge */ c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1;
+SELECT /*+ recompile */ rn, c3 FROM v13 ORDER BY 1, 2;
+
+evaluate 'Case 14: no_merge hint, view has no analytic function -- no_merge disables list pruning outright, with or without an analytic function';
+SELECT /*+ recompile */ c1
+FROM (SELECT /*+ no_merge */ c1, c2, c3, c4 FROM t1) ORDER BY 1;
+CREATE OR REPLACE VIEW v14 AS SELECT /*+ no_merge */ c1, c2, c3, c4 FROM t1;
+SELECT /*+ recompile */ c1 FROM v14 ORDER BY 1;
+
+DROP VIEW v1;
+DROP VIEW v2;
+DROP VIEW v3;
+DROP VIEW v4;
+DROP VIEW v5;
+DROP VIEW v6;
+DROP VIEW v7;
+DROP VIEW v8;
+DROP VIEW v9;
+DROP VIEW v10;
+DROP VIEW v11;
+DROP VIEW v12;
+DROP VIEW v13;
+DROP VIEW v14;
+DROP TABLE t1, t2;
+
+evaluate 'Case 15: row_number() result must match between a named view and its equivalent inline view';
+DROP TABLE IF EXISTS t3;
+CREATE TABLE t3(c1 INT AUTO_INCREMENT, c2 INT, c3 INT, c4 INT);
+INSERT INTO t3(c2, c3, c4) VALUES
+(1,1,1),
+(1,1,2),
+(1,1,3),
+(1,1,4),
+(1,1,5),
+(1,2,1),
+(1,2,2),
+(1,2,3),
+(1,2,4);
+
+CREATE OR REPLACE VIEW v15 AS SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t3;
+
+SELECT /*+ recompile */ rn FROM v15 ORDER BY 1;
+SELECT /*+ recompile */ rn
+FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t3) ORDER BY 1;
+
+DROP VIEW v15;
+DROP TABLE t3;
+
+DROP TABLE IF EXISTS t4;
+CREATE TABLE t4(c1 INT AUTO_INCREMENT, c2 INT, c3 INT, c4 INT);
+INSERT INTO t4(c2, c3, c4) VALUES
+(1,1,1),
+(1,1,2),
+(1,1,3),
+(1,2,1),
+(1,2,2);
+
+evaluate 'Case 16: PREPARE/EXECUTE compiles and runs the pruned plan correctly';
+PREPARE stmt1 FROM 'SELECT rn FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t4) WHERE rn > ? ORDER BY 1';
+EXECUTE stmt1 USING 0;
+DEALLOCATE PREPARE stmt1;
+
+evaluate 'Case 17: two analytic functions in the view, only one referenced by the main query';
+SELECT /*+ recompile */ rn1
+FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn1, RANK() OVER(ORDER BY c2) AS rn2, c4 FROM t4) ORDER BY 1;
+CREATE OR REPLACE VIEW v17 AS SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn1, RANK() OVER(ORDER BY c2) AS rn2, c4 FROM t4;
+SELECT /*+ recompile */ rn1 FROM v17 ORDER BY 1;
+
+evaluate 'Case 18: ORDER BY inside the OVER clause, referenced by ordinal -- ROW_NUMBER would not catch a wrong ordinal (its value set is order-invariant), so use a running SUM whose value depends on the actual row order';
+SELECT /*+ recompile */ c1, s
+FROM (SELECT c1, c2, c3, SUM(c4) OVER(PARTITION BY c3 ORDER BY 1) AS s, c4 FROM t4) ORDER BY 1;
+CREATE OR REPLACE VIEW v18 AS SELECT c1, c2, c3, SUM(c4) OVER(PARTITION BY c3 ORDER BY 1) AS s, c4 FROM t4;
+SELECT /*+ recompile */ c1, s FROM v18 ORDER BY 1;
+
+evaluate 'Case 19: regression -- the running SUM must match between a view and its equivalent inline view';
+CREATE OR REPLACE VIEW v19 AS SELECT c1, c2, c3, SUM(c4) OVER(PARTITION BY c3 ORDER BY c1 DESC) AS s, c4 FROM t4;
+SELECT /*+ recompile */ c1, s FROM v19 ORDER BY 1;
+SELECT /*+ recompile */ c1, s
+FROM (SELECT c1, c2, c3, SUM(c4) OVER(PARTITION BY c3 ORDER BY c1 DESC) AS s, c4 FROM t4) ORDER BY 1;
+
+evaluate 'Case 20: both the PARTITION BY and ORDER BY ordinals reference columns the main query does not select -- both must be re-added as hidden columns at once';
+SELECT /*+ recompile */ s
+FROM (SELECT c1, c2, c3, c4, SUM(c4) OVER(PARTITION BY 3 ORDER BY 1) AS s FROM t4) ORDER BY 1;
+CREATE OR REPLACE VIEW v20 AS SELECT c1, c2, c3, c4, SUM(c4) OVER(PARTITION BY 3 ORDER BY 1) AS s FROM t4;
+SELECT /*+ recompile */ s FROM v20 ORDER BY 1;
+
+DROP VIEW v17;
+DROP VIEW v18;
+DROP VIEW v19;
+DROP VIEW v20;
+DROP TABLE t4;

--- a/sql/_13_issues/_26_2h/cases/cbrd_25531.sql
+++ b/sql/_13_issues/_26_2h/cases/cbrd_25531.sql
@@ -2,20 +2,21 @@
  * This test case verifies CBRD-25531: unreferenced select-list items of a
  * non-mergeable inline view are now pruned even when the view contains an
  * analytic function, matching the pruning already done for a plain view.
- * Each case runs as both an inline view and a named view (always
- * non-mergeable, pinning the pre-fix baseline).
+ * Each case runs as both an inline view and a named view (non-mergeable).
  *
  * Coverage:
  * 1-2   analytic column referenced by main query or not
- * 3-7   OVER-clause reference shapes (main query, ordinal, missing,
- *       expression, scalar subquery)
+ * 3-7   OVER-clause reference shapes (direct, ordinal, missing, expression,
+ *       scalar subquery)
  * 8-11  outer ORDER BY / GROUP BY vs the OVER-clause column
  * 12-14 join query, no_merge hint with/without an analytic function
- * 15    regression: row_number() must match between a view and its
- *       equivalent inline view (select-list reorder desyncing OVER)
+ * 15    regression: view vs. inline view (select-list reorder desyncs OVER)
  * 16-17 PREPARE/EXECUTE path, two analytic functions with only one used
- * 18-20 ORDER BY inside OVER: ordinal reference, regression vs a view,
- *       both PARTITION BY and ORDER BY ordinals hidden-appended at once
+ * 18-20 ORDER BY-inside-OVER ordinal, its regression, both ordinals
+ *       hidden-appended at once
+ * 21-22 LAG/LEAD argument column kept alive/pruned by reference
+ * 23-24 nested non-mergeable views: pruning and the regression propagate
+ *       through two levels
  */
 
 DROP TABLE IF EXISTS tbla;
@@ -197,3 +198,48 @@ DROP VIEW vr;
 DROP VIEW vs;
 DROP VIEW vt;
 DROP TABLE tbld;
+
+DROP TABLE IF EXISTS tble;
+CREATE TABLE tble(cola INT AUTO_INCREMENT, colb INT, colc INT, cold INT);
+INSERT INTO tble(colb, colc, cold) VALUES
+(1,1,10),
+(1,1,20),
+(1,1,30),
+(1,2,40),
+(1,2,50);
+
+evaluate 'Case 21: LAG(cold) referenced -- the argument column cold and the OVER order column cola must be re-added as hidden columns; the LAG value is order-sensitive';
+SELECT /*+ recompile */ cola, lg
+FROM (SELECT cola, colb, colc, LAG(cold) OVER(PARTITION BY colc ORDER BY cola) AS lg, cold FROM tble) ORDER BY 1;
+CREATE OR REPLACE VIEW vu AS SELECT cola, colb, colc, LAG(cold) OVER(PARTITION BY colc ORDER BY cola) AS lg, cold FROM tble;
+SELECT /*+ recompile */ cola, lg FROM vu ORDER BY 1;
+
+evaluate 'Case 22: LEAD(cold) not referenced by the main query -- the whole select list, the analytic and its argument column cold included, must collapse to (1)';
+SELECT /*+ recompile */ COUNT(*)
+FROM (SELECT cola, colb, colc, LEAD(cold) OVER(PARTITION BY colc ORDER BY cola) AS ld, cold FROM tble);
+CREATE OR REPLACE VIEW vv AS SELECT cola, colb, colc, LEAD(cold) OVER(PARTITION BY colc ORDER BY cola) AS ld, cold FROM tble;
+SELECT /*+ recompile */ COUNT(*) FROM vv;
+
+evaluate 'Case 23: nested, the inner analytic is unreferenced at the top -- both levels must reduce (the top and the inner select list collapse to (1))';
+SELECT /*+ recompile */ COUNT(*)
+FROM (SELECT cola, ROW_NUMBER() OVER(PARTITION BY cola) AS rn_out
+      FROM (SELECT cola, colb, colc, SUM(cold) OVER(PARTITION BY colc ORDER BY cola) AS s_in, cold FROM tble));
+CREATE OR REPLACE VIEW vw_in AS SELECT cola, colb, colc, SUM(cold) OVER(PARTITION BY colc ORDER BY cola) AS s_in, cold FROM tble;
+CREATE OR REPLACE VIEW vw_out AS SELECT cola, ROW_NUMBER() OVER(PARTITION BY cola) AS rn_out FROM vw_in;
+SELECT /*+ recompile */ COUNT(*) FROM vw_out;
+
+evaluate 'Case 24: regression -- the inner running SUM read through the outer view must match between the nested view and its equivalent nested inline view (a desync at depth would change the value)';
+SELECT /*+ recompile */ cola, s_in
+FROM (SELECT cola, s_in, ROW_NUMBER() OVER(PARTITION BY cola) AS rn_out
+      FROM (SELECT cola, colb, colc, SUM(cold) OVER(PARTITION BY colc ORDER BY cola) AS s_in, cold FROM tble)) ORDER BY 1;
+CREATE OR REPLACE VIEW vx_in AS SELECT cola, colb, colc, SUM(cold) OVER(PARTITION BY colc ORDER BY cola) AS s_in, cold FROM tble;
+CREATE OR REPLACE VIEW vx_out AS SELECT cola, s_in, ROW_NUMBER() OVER(PARTITION BY cola) AS rn_out FROM vx_in;
+SELECT /*+ recompile */ cola, s_in FROM vx_out ORDER BY 1;
+
+DROP VIEW vu;
+DROP VIEW vv;
+DROP VIEW vw_in;
+DROP VIEW vw_out;
+DROP VIEW vx_in;
+DROP VIEW vx_out;
+DROP TABLE tble;

--- a/sql/_13_issues/_26_2h/cases/cbrd_25531.sql
+++ b/sql/_13_issues/_26_2h/cases/cbrd_25531.sql
@@ -18,122 +18,122 @@
  *       both PARTITION BY and ORDER BY ordinals hidden-appended at once
  */
 
-DROP TABLE IF EXISTS t1;
-CREATE TABLE t1(c1 INT AUTO_INCREMENT, c2 INT, c3 INT, c4 INT);
-INSERT INTO t1(c2, c3, c4) VALUES
+DROP TABLE IF EXISTS tbla;
+CREATE TABLE tbla(cola INT AUTO_INCREMENT, colb INT, colc INT, cold INT);
+INSERT INTO tbla(colb, colc, cold) VALUES
 (1,1,1),
 (1,1,2),
 (1,2,2),
 (1,2,3);
 
-DROP TABLE IF EXISTS t2;
-CREATE TABLE t2(c1 INT, c2 INT);
-INSERT INTO t2 VALUES (1,1),(2,1),(3,2),(4,2);
+DROP TABLE IF EXISTS tblb;
+CREATE TABLE tblb(cola INT, colb INT);
+INSERT INTO tblb VALUES (1,1),(2,1),(3,2),(4,2);
 
 evaluate 'Case 1: the analytic column is not referenced by the main query';
 SELECT /*+ recompile */ COUNT(*)
-FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1);
-CREATE OR REPLACE VIEW v1 AS SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1;
-SELECT /*+ recompile */ COUNT(*) FROM v1;
+FROM (SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tbla);
+CREATE OR REPLACE VIEW va AS SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tbla;
+SELECT /*+ recompile */ COUNT(*) FROM va;
 
 evaluate 'Case 2: the analytic column is referenced by the main query';
 SELECT /*+ recompile */ rn
-FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER() AS rn, c4 FROM t1) ORDER BY 1;
-CREATE OR REPLACE VIEW v2 AS SELECT c1, c2, c3, ROW_NUMBER() OVER() AS rn, c4 FROM t1;
-SELECT /*+ recompile */ rn FROM v2 ORDER BY 1;
+FROM (SELECT cola, colb, colc, ROW_NUMBER() OVER() AS rn, cold FROM tbla) ORDER BY 1;
+CREATE OR REPLACE VIEW vb AS SELECT cola, colb, colc, ROW_NUMBER() OVER() AS rn, cold FROM tbla;
+SELECT /*+ recompile */ rn FROM vb ORDER BY 1;
 
 evaluate 'Case 3: the OVER-clause column is also referenced by the main query';
-SELECT /*+ recompile */ rn, c3
-FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1) ORDER BY 1, 2;
-CREATE OR REPLACE VIEW v3 AS SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1;
-SELECT /*+ recompile */ rn, c3 FROM v3 ORDER BY 1, 2;
+SELECT /*+ recompile */ rn, colc
+FROM (SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tbla) ORDER BY 1, 2;
+CREATE OR REPLACE VIEW vc AS SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tbla;
+SELECT /*+ recompile */ rn, colc FROM vc ORDER BY 1, 2;
 
 evaluate 'Case 4: the OVER-clause column is referenced by ordinal, not by the main query';
 SELECT /*+ recompile */ rn
-FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY 3) AS rn, c4 FROM t1) ORDER BY 1;
-CREATE OR REPLACE VIEW v4 AS SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY 3) AS rn, c4 FROM t1;
-SELECT /*+ recompile */ rn FROM v4 ORDER BY 1;
+FROM (SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY 3) AS rn, cold FROM tbla) ORDER BY 1;
+CREATE OR REPLACE VIEW vd AS SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY 3) AS rn, cold FROM tbla;
+SELECT /*+ recompile */ rn FROM vd ORDER BY 1;
 
 evaluate 'Case 5: the OVER-clause column is missing from the view select list';
 SELECT /*+ recompile */ rn
-FROM (SELECT c1, c2, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1) ORDER BY 1;
-CREATE OR REPLACE VIEW v5 AS SELECT c1, c2, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1;
-SELECT /*+ recompile */ rn FROM v5 ORDER BY 1;
+FROM (SELECT cola, colb, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tbla) ORDER BY 1;
+CREATE OR REPLACE VIEW ve AS SELECT cola, colb, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tbla;
+SELECT /*+ recompile */ rn FROM ve ORDER BY 1;
 
 evaluate 'Case 6: the OVER-clause column is an expression over another column';
 SELECT /*+ recompile */ rn
-FROM (SELECT c1, c2, NVL(c3, 0) AS nvl_c3, ROW_NUMBER() OVER(PARTITION BY 3) AS rn, c4 FROM t1) ORDER BY 1;
-CREATE OR REPLACE VIEW v6 AS SELECT c1, c2, NVL(c3, 0) AS nvl_c3, ROW_NUMBER() OVER(PARTITION BY 3) AS rn, c4 FROM t1;
-SELECT /*+ recompile */ rn FROM v6 ORDER BY 1;
+FROM (SELECT cola, colb, NVL(colc, 0) AS nvl_colc, ROW_NUMBER() OVER(PARTITION BY 3) AS rn, cold FROM tbla) ORDER BY 1;
+CREATE OR REPLACE VIEW vf AS SELECT cola, colb, NVL(colc, 0) AS nvl_colc, ROW_NUMBER() OVER(PARTITION BY 3) AS rn, cold FROM tbla;
+SELECT /*+ recompile */ rn FROM vf ORDER BY 1;
 
 evaluate 'Case 7: the OVER-clause column is a scalar subquery';
 SELECT /*+ recompile */ rn
-FROM (SELECT c1, c2, (SELECT MAX(c3) FROM t1) AS max_c3, ROW_NUMBER() OVER(PARTITION BY 3) AS rn FROM t1) ORDER BY 1;
-CREATE OR REPLACE VIEW v7 AS SELECT c1, c2, (SELECT MAX(c3) FROM t1) AS max_c3, ROW_NUMBER() OVER(PARTITION BY 3) AS rn FROM t1;
-SELECT /*+ recompile */ rn FROM v7 ORDER BY 1;
+FROM (SELECT cola, colb, (SELECT MAX(colc) FROM tbla) AS max_colc, ROW_NUMBER() OVER(PARTITION BY 3) AS rn FROM tbla) ORDER BY 1;
+CREATE OR REPLACE VIEW vg AS SELECT cola, colb, (SELECT MAX(colc) FROM tbla) AS max_colc, ROW_NUMBER() OVER(PARTITION BY 3) AS rn FROM tbla;
+SELECT /*+ recompile */ rn FROM vg ORDER BY 1;
 
 evaluate 'Case 8: outer ORDER BY column is also referenced by the analytic function';
 SELECT /*+ recompile */ rn
-FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1 ORDER BY c3) ORDER BY 1;
-CREATE OR REPLACE VIEW v8 AS SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1 ORDER BY c3;
-SELECT /*+ recompile */ rn FROM v8 ORDER BY 1;
+FROM (SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tbla ORDER BY colc) ORDER BY 1;
+CREATE OR REPLACE VIEW vh AS SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tbla ORDER BY colc;
+SELECT /*+ recompile */ rn FROM vh ORDER BY 1;
 
 evaluate 'Case 9: outer ORDER BY column is not referenced by the analytic function';
 SELECT /*+ recompile */ rn
-FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1 ORDER BY c1) ORDER BY 1;
-CREATE OR REPLACE VIEW v9 AS SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1 ORDER BY c1;
-SELECT /*+ recompile */ rn FROM v9 ORDER BY 1;
+FROM (SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tbla ORDER BY cola) ORDER BY 1;
+CREATE OR REPLACE VIEW vi AS SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tbla ORDER BY cola;
+SELECT /*+ recompile */ rn FROM vi ORDER BY 1;
 
 evaluate 'Case 10: outer GROUP BY column is also referenced by the analytic function';
 SELECT /*+ recompile */ rn
-FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1 GROUP BY c3) ORDER BY 1;
-CREATE OR REPLACE VIEW v10 AS SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1 GROUP BY c3;
-SELECT /*+ recompile */ rn FROM v10 ORDER BY 1;
+FROM (SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tbla GROUP BY colc) ORDER BY 1;
+CREATE OR REPLACE VIEW vj AS SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tbla GROUP BY colc;
+SELECT /*+ recompile */ rn FROM vj ORDER BY 1;
 
 evaluate 'Case 11: outer GROUP BY column is not referenced by the analytic function';
 SELECT /*+ recompile */ rn
-FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1 GROUP BY c1) ORDER BY 1;
-CREATE OR REPLACE VIEW v11 AS SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1 GROUP BY c1;
-SELECT /*+ recompile */ rn FROM v11 ORDER BY 1;
+FROM (SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tbla GROUP BY cola) ORDER BY 1;
+CREATE OR REPLACE VIEW vk AS SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tbla GROUP BY cola;
+SELECT /*+ recompile */ rn FROM vk ORDER BY 1;
 
 evaluate 'Case 12: join query';
 SELECT /*+ recompile */ rn
-FROM (SELECT t1.c1 AS t1_c1, t2.c1 AS t2_c1, ROW_NUMBER() OVER(PARTITION BY t2.c2) AS rn FROM t1, t2 WHERE t1.c1 = t2.c1) ORDER BY 1;
-CREATE OR REPLACE VIEW v12 AS SELECT t1.c1 AS t1_c1, t2.c1 AS t2_c1, ROW_NUMBER() OVER(PARTITION BY t2.c2) AS rn FROM t1, t2 WHERE t1.c1 = t2.c1;
-SELECT /*+ recompile */ rn FROM v12 ORDER BY 1;
+FROM (SELECT tbla.cola AS tbla_cola, tblb.cola AS tblb_cola, ROW_NUMBER() OVER(PARTITION BY tblb.colb) AS rn FROM tbla, tblb WHERE tbla.cola = tblb.cola) ORDER BY 1;
+CREATE OR REPLACE VIEW vl AS SELECT tbla.cola AS tbla_cola, tblb.cola AS tblb_cola, ROW_NUMBER() OVER(PARTITION BY tblb.colb) AS rn FROM tbla, tblb WHERE tbla.cola = tblb.cola;
+SELECT /*+ recompile */ rn FROM vl ORDER BY 1;
 
 evaluate 'Case 13: no_merge hint, view contains an analytic function';
-SELECT /*+ recompile */ rn, c3
-FROM (SELECT /*+ no_merge */ c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1) ORDER BY 1, 2;
-CREATE OR REPLACE VIEW v13 AS SELECT /*+ no_merge */ c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t1;
-SELECT /*+ recompile */ rn, c3 FROM v13 ORDER BY 1, 2;
+SELECT /*+ recompile */ rn, colc
+FROM (SELECT /*+ no_merge */ cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tbla) ORDER BY 1, 2;
+CREATE OR REPLACE VIEW vm AS SELECT /*+ no_merge */ cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tbla;
+SELECT /*+ recompile */ rn, colc FROM vm ORDER BY 1, 2;
 
 evaluate 'Case 14: no_merge hint, view has no analytic function -- no_merge disables list pruning outright, with or without an analytic function';
-SELECT /*+ recompile */ c1
-FROM (SELECT /*+ no_merge */ c1, c2, c3, c4 FROM t1) ORDER BY 1;
-CREATE OR REPLACE VIEW v14 AS SELECT /*+ no_merge */ c1, c2, c3, c4 FROM t1;
-SELECT /*+ recompile */ c1 FROM v14 ORDER BY 1;
+SELECT /*+ recompile */ cola
+FROM (SELECT /*+ no_merge */ cola, colb, colc, cold FROM tbla) ORDER BY 1;
+CREATE OR REPLACE VIEW vn AS SELECT /*+ no_merge */ cola, colb, colc, cold FROM tbla;
+SELECT /*+ recompile */ cola FROM vn ORDER BY 1;
 
-DROP VIEW v1;
-DROP VIEW v2;
-DROP VIEW v3;
-DROP VIEW v4;
-DROP VIEW v5;
-DROP VIEW v6;
-DROP VIEW v7;
-DROP VIEW v8;
-DROP VIEW v9;
-DROP VIEW v10;
-DROP VIEW v11;
-DROP VIEW v12;
-DROP VIEW v13;
-DROP VIEW v14;
-DROP TABLE t1, t2;
+DROP VIEW va;
+DROP VIEW vb;
+DROP VIEW vc;
+DROP VIEW vd;
+DROP VIEW ve;
+DROP VIEW vf;
+DROP VIEW vg;
+DROP VIEW vh;
+DROP VIEW vi;
+DROP VIEW vj;
+DROP VIEW vk;
+DROP VIEW vl;
+DROP VIEW vm;
+DROP VIEW vn;
+DROP TABLE tbla, tblb;
 
 evaluate 'Case 15: row_number() result must match between a named view and its equivalent inline view';
-DROP TABLE IF EXISTS t3;
-CREATE TABLE t3(c1 INT AUTO_INCREMENT, c2 INT, c3 INT, c4 INT);
-INSERT INTO t3(c2, c3, c4) VALUES
+DROP TABLE IF EXISTS tblc;
+CREATE TABLE tblc(cola INT AUTO_INCREMENT, colb INT, colc INT, cold INT);
+INSERT INTO tblc(colb, colc, cold) VALUES
 (1,1,1),
 (1,1,2),
 (1,1,3),
@@ -144,18 +144,18 @@ INSERT INTO t3(c2, c3, c4) VALUES
 (1,2,3),
 (1,2,4);
 
-CREATE OR REPLACE VIEW v15 AS SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t3;
+CREATE OR REPLACE VIEW vo AS SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tblc;
 
-SELECT /*+ recompile */ rn FROM v15 ORDER BY 1;
+SELECT /*+ recompile */ rn FROM vo ORDER BY 1;
 SELECT /*+ recompile */ rn
-FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t3) ORDER BY 1;
+FROM (SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tblc) ORDER BY 1;
 
-DROP VIEW v15;
-DROP TABLE t3;
+DROP VIEW vo;
+DROP TABLE tblc;
 
-DROP TABLE IF EXISTS t4;
-CREATE TABLE t4(c1 INT AUTO_INCREMENT, c2 INT, c3 INT, c4 INT);
-INSERT INTO t4(c2, c3, c4) VALUES
+DROP TABLE IF EXISTS tbld;
+CREATE TABLE tbld(cola INT AUTO_INCREMENT, colb INT, colc INT, cold INT);
+INSERT INTO tbld(colb, colc, cold) VALUES
 (1,1,1),
 (1,1,2),
 (1,1,3),
@@ -163,36 +163,36 @@ INSERT INTO t4(c2, c3, c4) VALUES
 (1,2,2);
 
 evaluate 'Case 16: PREPARE/EXECUTE compiles and runs the pruned plan correctly';
-PREPARE stmt1 FROM 'SELECT rn FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn, c4 FROM t4) WHERE rn > ? ORDER BY 1';
+PREPARE stmt1 FROM 'SELECT rn FROM (SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tbld) WHERE rn > ? ORDER BY 1';
 EXECUTE stmt1 USING 0;
 DEALLOCATE PREPARE stmt1;
 
 evaluate 'Case 17: two analytic functions in the view, only one referenced by the main query';
-SELECT /*+ recompile */ rn1
-FROM (SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn1, RANK() OVER(ORDER BY c2) AS rn2, c4 FROM t4) ORDER BY 1;
-CREATE OR REPLACE VIEW v17 AS SELECT c1, c2, c3, ROW_NUMBER() OVER(PARTITION BY c3) AS rn1, RANK() OVER(ORDER BY c2) AS rn2, c4 FROM t4;
-SELECT /*+ recompile */ rn1 FROM v17 ORDER BY 1;
+SELECT /*+ recompile */ rna
+FROM (SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rna, RANK() OVER(ORDER BY colb) AS rnb, cold FROM tbld) ORDER BY 1;
+CREATE OR REPLACE VIEW vq AS SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rna, RANK() OVER(ORDER BY colb) AS rnb, cold FROM tbld;
+SELECT /*+ recompile */ rna FROM vq ORDER BY 1;
 
 evaluate 'Case 18: ORDER BY inside the OVER clause, referenced by ordinal -- ROW_NUMBER would not catch a wrong ordinal (its value set is order-invariant), so use a running SUM whose value depends on the actual row order';
-SELECT /*+ recompile */ c1, s
-FROM (SELECT c1, c2, c3, SUM(c4) OVER(PARTITION BY c3 ORDER BY 1) AS s, c4 FROM t4) ORDER BY 1;
-CREATE OR REPLACE VIEW v18 AS SELECT c1, c2, c3, SUM(c4) OVER(PARTITION BY c3 ORDER BY 1) AS s, c4 FROM t4;
-SELECT /*+ recompile */ c1, s FROM v18 ORDER BY 1;
+SELECT /*+ recompile */ cola, s
+FROM (SELECT cola, colb, colc, SUM(cold) OVER(PARTITION BY colc ORDER BY 1) AS s, cold FROM tbld) ORDER BY 1;
+CREATE OR REPLACE VIEW vr AS SELECT cola, colb, colc, SUM(cold) OVER(PARTITION BY colc ORDER BY 1) AS s, cold FROM tbld;
+SELECT /*+ recompile */ cola, s FROM vr ORDER BY 1;
 
 evaluate 'Case 19: regression -- the running SUM must match between a view and its equivalent inline view';
-CREATE OR REPLACE VIEW v19 AS SELECT c1, c2, c3, SUM(c4) OVER(PARTITION BY c3 ORDER BY c1 DESC) AS s, c4 FROM t4;
-SELECT /*+ recompile */ c1, s FROM v19 ORDER BY 1;
-SELECT /*+ recompile */ c1, s
-FROM (SELECT c1, c2, c3, SUM(c4) OVER(PARTITION BY c3 ORDER BY c1 DESC) AS s, c4 FROM t4) ORDER BY 1;
+CREATE OR REPLACE VIEW vs AS SELECT cola, colb, colc, SUM(cold) OVER(PARTITION BY colc ORDER BY cola DESC) AS s, cold FROM tbld;
+SELECT /*+ recompile */ cola, s FROM vs ORDER BY 1;
+SELECT /*+ recompile */ cola, s
+FROM (SELECT cola, colb, colc, SUM(cold) OVER(PARTITION BY colc ORDER BY cola DESC) AS s, cold FROM tbld) ORDER BY 1;
 
 evaluate 'Case 20: both the PARTITION BY and ORDER BY ordinals reference columns the main query does not select -- both must be re-added as hidden columns at once';
 SELECT /*+ recompile */ s
-FROM (SELECT c1, c2, c3, c4, SUM(c4) OVER(PARTITION BY 3 ORDER BY 1) AS s FROM t4) ORDER BY 1;
-CREATE OR REPLACE VIEW v20 AS SELECT c1, c2, c3, c4, SUM(c4) OVER(PARTITION BY 3 ORDER BY 1) AS s FROM t4;
-SELECT /*+ recompile */ s FROM v20 ORDER BY 1;
+FROM (SELECT cola, colb, colc, cold, SUM(cold) OVER(PARTITION BY 3 ORDER BY 1) AS s FROM tbld) ORDER BY 1;
+CREATE OR REPLACE VIEW vt AS SELECT cola, colb, colc, cold, SUM(cold) OVER(PARTITION BY 3 ORDER BY 1) AS s FROM tbld;
+SELECT /*+ recompile */ s FROM vt ORDER BY 1;
 
-DROP VIEW v17;
-DROP VIEW v18;
-DROP VIEW v19;
-DROP VIEW v20;
-DROP TABLE t4;
+DROP VIEW vq;
+DROP VIEW vr;
+DROP VIEW vs;
+DROP VIEW vt;
+DROP TABLE tbld;

--- a/sql/_13_issues/_26_2h/cases/cbrd_25531.sql
+++ b/sql/_13_issues/_26_2h/cases/cbrd_25531.sql
@@ -164,6 +164,7 @@ INSERT INTO tbld(colb, colc, cold) VALUES
 
 evaluate 'Case 16: PREPARE/EXECUTE compiles and runs the pruned plan correctly';
 PREPARE stmt1 FROM 'SELECT rn FROM (SELECT cola, colb, colc, ROW_NUMBER() OVER(PARTITION BY colc) AS rn, cold FROM tbld) WHERE rn > ? ORDER BY 1';
+--@queryplan
 EXECUTE stmt1 USING 0;
 DEALLOCATE PREPARE stmt1;
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25531>
위 이슈가 머지된 날짜는 작년입니다. (2025-06-27)
Resolved 된지는 2026-09-08일 기준, 5일 전으로 나옵니다.(jira 오류로 인해 status 반영이 안된것으로 추측됨) 
TC 위치가 25_1h로 수정이 필요하다면 리뷰로 의견 남겨주시면 감사하겠습니다.

### Purpose

분석 함수(ROW_NUMBER, RANK, SUM 등)가 포함된 인라인 뷰/뷰를 메인 쿼리와 merge할 수 없는 경우, 메인 쿼리에서 실제로 참조하지 않는 select list 항목(분석 함수 포함)이 지워지지 않아 불필요한 컬럼 조회·분석 함수 연산이 그대로 남아있던 문제를 고쳤습니다. 더 심각하게는, select list 순서가 재배치될 때 분석 함수의 OVER절이 컬럼 순서번호(ordinal)로 참조하던 컬럼을 놓쳐, 뷰로 조회한 결과와 동등한 인라인 뷰로 직접 조회한 결과가 서로 달라지는(조용히 틀린 결과) 버그도 함께 있었습니다.

### Implementation

이 TC는 분석 함수의 다양한 참조 형태(메인 쿼리 직접 참조/순서번호 참조/미참조/표현식/스칼라 서브쿼리)별로 select list가 올바르게 정리되는지, join·GROUP BY·no_merge 힌트·PREPARE/EXECUTE 등 여러 조합에서도 동일하게 동작하는지 검증합니다. 특히 뷰와 그와 동등한 인라인 뷰의 결과가 항상 일치하는지(정합성 회귀), 그리고 PARTITION BY/ORDER BY 순서번호가 가리키던 컬럼이 지워져도 값 계산에 필요하면 숨은 컬럼으로 다시 붙는지를 실제 값(누적합 등 순서에 민감한 값)으로 확인합니다.

### Remarks

11.5.0.1855-e5001e3 에서 fail, 11.5.0.2533-cd593bc 에서 pass 함을 확인했습니다.

### Coverage (케이스 20개 요약)

| # | 시나리오 | 확인하는 것 |
|---|---|---|
| 1 | 분석 함수 컬럼을 메인 쿼리가 아예 안 씀 | `COUNT(*)`만 쓰면 분석 함수와 나머지 컬럼 전부 pruning되어 `select 1 from ...`로 단순화되는지 (이슈의 핵심 Expected Result) |
| 2 | 분석 함수 컬럼을 메인 쿼리가 직접 씀 | 참조되는 컬럼은 pruning 안 되고 정상 조회되는지 |
| 3 | OVER절 컬럼을 메인 쿼리도 같이 씀 | OVER절이 참조하는 컬럼(`c3`)이 메인 쿼리에도 쓰이면 남는지 |
| 4 | OVER절이 컬럼을 순서번호(ordinal)로 참조 | `PARTITION BY 3`처럼 숫자로 참조해도 재배치 후 올바른 컬럼을 계속 가리키는지 |
| 5 | OVER절 참조 컬럼이 뷰 select-list에서 아예 빠짐 | 없는 컬럼을 숨은 컬럼으로 되살려 계산하는지 |
| 6 | OVER절 참조 컬럼이 표현식(`NVL(c3,0)`) | 단순 컬럼이 아니라 표현식이어도 동일하게 동작하는지 |
| 7 | OVER절 참조 컬럼이 스칼라 서브쿼리 | 서브쿼리 결과를 기준으로 partition해도 문제없는지 |
| 8 | 바깥쪽 ORDER BY가 분석함수 참조 컬럼과 겹침 | 외부 정렬과 내부 partition 컬럼이 같을 때 정상 동작 |
| 9 | 바깥쪽 ORDER BY가 다른 컬럼 | 외부 정렬 컬럼도 별도로 살아남는지 |
| 10 | 바깥쪽 GROUP BY가 분석함수 참조 컬럼과 겹침 | GROUP BY 결과 위에서 분석함수가 올바르게 재계산되는지 |
| 11 | 바깥쪽 GROUP BY가 다른 컬럼 | 위와 동일하되 겹치지 않는 경우 |
| 12 | JOIN 쿼리 안의 분석 함수 | 두 테이블 조인 결과에서도 pruning/ordinal이 안 깨지는지 |
| 13 | `no_merge` 힌트 + 분석 함수 있음 | 힌트가 있으면 pruning 자체가 아예 안 일어남(정상 동작)을 확인 |
| 14 | `no_merge` 힌트 + 분석 함수 없음 | 위와 대조군 — 힌트가 pruning을 막는 건 분석함수 유무와 무관함을 확인 |
| 15 | 뷰 vs 동등한 인라인뷰 결과 일치 (회귀) | 이슈 코멘트3의 실제 버그 — 컬럼 재배치로 값이 달라지던 문제가 재발 안 하는지 (9행 데이터로 검증) |
| 16 | `PREPARE`/`EXECUTE` 경로 | 즉시실행이 아니라 컴파일된 플랜 재사용 경로에서도 정상인지 |
| 17 | 분석 함수 2개 중 1개만 참조 | 안 쓰는 함수(`RANK`)와 그 의존 컬럼이 제대로 같이 지워지는지 |
| 18 | OVER절 안의 `ORDER BY`도 순서번호로 참조 | `PARTITION BY`뿐 아니라 `ORDER BY`도 ordinal 재계산이 되는지 (누적합으로 값 검증) |
| 19 | 위 18과 뷰-인라인뷰 일치 (회귀) | ORDER BY ordinal 버전의 15번과 동일한 정합성 확인 |
| 20 | `PARTITION BY`+`ORDER BY` 둘 다 pruning 대상 컬럼을 가리킴 | 두 ordinal이 동시에 숨은 컬럼으로 복원돼야 하는 가장 까다로운 경우 |
